### PR TITLE
fix: workout count value not properly accessed

### DIFF
--- a/src/tools/workouts.ts
+++ b/src/tools/workouts.ts
@@ -117,7 +117,7 @@ export function registerWorkoutTools(
 					content: [
 						{
 							type: "text",
-							text: `Total workouts: ${data ? (data as { count?: number }).count || 0 : 0}`,
+							text: `Total workouts: ${data ? data.workoutCount || 0 : 0}`,
 						},
 					],
 				};

--- a/src/tools/workouts.ts
+++ b/src/tools/workouts.ts
@@ -117,7 +117,7 @@ export function registerWorkoutTools(
 					content: [
 						{
 							type: "text",
-							text: `Total workouts: ${data ? data.workoutCount || 0 : 0}`,
+text: `Total workouts: ${data ? (data as { workoutCount?: number }).workoutCount || 0 : 0}`,
 						},
 					],
 				};


### PR DESCRIPTION
Hi Chris, awesome work! 
I really appreciated someone building MCP servers for the Hevy App.

While testing the MCP I noticed that the workout count tool always returns 0, see image below
<img width="1561" alt="image" src="https://github.com/user-attachments/assets/dab5a959-a502-462b-b6ce-28c4039596f7" />


Turns out it stored in 
```tsx
data.workoutCount not in data.count
```
Here are the picture after testing it again with the changes
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/d62a47d0-6645-4752-8aa8-04fa9c0b6404" />
