### PR TITLE
Replace Kiota with direct axios implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@dotenvx/dotenvx": "^1.44.0",
-				"@microsoft/kiota-abstractions": "1.0.0-preview.94",
-				"@microsoft/kiota-authentication-azure": "1.0.0-preview.94",
-				"@microsoft/kiota-bundle": "1.0.0-preview.94",
-				"@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.94",
-				"@microsoft/kiota-serialization-json": "1.0.0-preview.94",
-				"@microsoft/kiota-serialization-text": "1.0.0-preview.94",
 				"@modelcontextprotocol/sdk": "^1.11.3",
+				"axios": "^1.9.0",
 				"uuid": "^11.1.0",
 				"zod": "^3.24.4"
 			},
@@ -56,45 +51,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@azure/abort-controller": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-			"integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@azure/core-auth": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-			"integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
-			"license": "MIT",
-			"dependencies": {
-				"@azure/abort-controller": "^2.0.0",
-				"@azure/core-util": "^1.11.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@azure/core-util": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
-			"integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
-			"license": "MIT",
-			"dependencies": {
-				"@azure/abort-controller": "^2.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1358,95 +1314,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@microsoft/kiota-abstractions": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.94.tgz",
-			"integrity": "sha512-DmkBCIvTc7Z9HRugx5humIKFmLADuZiPFqwujbTZN0u7ikzFCkJtjE+uwwtBaFyzNl5z69mAmKg84mmXiD4HHg==",
-			"license": "MIT",
-			"dependencies": {
-				"@opentelemetry/api": "^1.7.0",
-				"@std-uritemplate/std-uritemplate": "^2.0.0",
-				"tinyduration": "^3.3.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-authentication-azure": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.94.tgz",
-			"integrity": "sha512-pAB+cps5H+Y07qlbFgS/HxCt+xpv+pgp2tdOwIuWeGNQyfVJRXRBUWTMDBlGMwa5P8OO30x82/s9T9xfIS30JA==",
-			"license": "MIT",
-			"dependencies": {
-				"@azure/core-auth": "^1.5.0",
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"@opentelemetry/api": "^1.7.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-bundle": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.94.tgz",
-			"integrity": "sha512-zJbnnpmWU7PDY1fGiKrR/YGQh2XWrppx6D9g7suliVa7GTVCJCyD9mZ1fY6WA3fEnz5dFvNEudhu3WJb9aok2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.94",
-				"@microsoft/kiota-serialization-form": "^1.0.0-preview.94",
-				"@microsoft/kiota-serialization-json": "1.0.0-preview.94",
-				"@microsoft/kiota-serialization-multipart": "^1.0.0-preview.94",
-				"@microsoft/kiota-serialization-text": "1.0.0-preview.94"
-			}
-		},
-		"node_modules/@microsoft/kiota-http-fetchlibrary": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.94.tgz",
-			"integrity": "sha512-jDCv/4Qf6z7Tn3pZ3tuVjfvB0etgJ4EEgSTz0S4nGKfaCYG1rAjpIexFRu3vbhJSwaHW5BJHYCXFaKBE1OYVzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"@opentelemetry/api": "^1.7.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-serialization-form": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.94.tgz",
-			"integrity": "sha512-PlwJoIix80kKMHqSpeq739Peb5oie2o6+JdGRVNReqZYOqZ25iTrPvaveWVG4WD5OQve2RVzLZ16znzhSH+nGg==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-serialization-json": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.94.tgz",
-			"integrity": "sha512-5JUnVbQ2Ko4SdeHmPaIxhIehkuJzTFD4uoY6N061XSxFhtkaXLB7HVryhk4utLc4/p/DBODTDDRRheRK8stinQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-serialization-multipart": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.94.tgz",
-			"integrity": "sha512-qMQ8/rsTdYpnijW0U6va1R9UAE71MTC6v/X8NUXkWuj2L5U0LJY2PhxZZiD2iTymZuroJuo0kVhwkulPFaOGcA==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@microsoft/kiota-serialization-text": {
-			"version": "1.0.0-preview.94",
-			"resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.94.tgz",
-			"integrity": "sha512-7jPBBO3Hy2cHMRgBMDW05Av+GPyGA1cCXqVPeUc+fTtrY26zJv9oeEZNdvgj+xlqm+b/zQ4v+UAuUODTyiwRow==",
-			"license": "MIT",
-			"dependencies": {
-				"@microsoft/kiota-abstractions": "^1.0.0-preview.94",
-				"tslib": "^2.6.2"
-			}
-		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.12.1",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
@@ -1722,15 +1589,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -2522,12 +2380,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@std-uritemplate/std-uritemplate": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.3.tgz",
-			"integrity": "sha512-oN5BHB81TMdasLZLkcdmVDFajo3CxrdeYWFKbeVw1MVZcd4jWZX6cbxm0Iq91wt/o2zsJjmefUaYrLInvZ3/DQ==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/@types/chai": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -2967,6 +2819,23 @@
 			"license": "MIT",
 			"bin": {
 				"astring": "bin/astring"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -3681,6 +3550,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -4044,6 +3925,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4401,6 +4291,21 @@
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4869,6 +4774,26 @@
 				"rollup": "^4.34.8"
 			}
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4897,6 +4822,42 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -5278,6 +5239,21 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -10231,6 +10207,12 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10893,9 +10875,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11736,12 +11718,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/tinyduration": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.4.1.tgz",
-			"integrity": "sha512-NemFoamVYn7TmtwZKZ3OiliM9fZkr6EWiTM+wKknco6POSy2gS689xx/pXip0JYp40HXpUw6k65CUYHWYUXdaA==",
-			"license": "MIT"
-		},
 		"node_modules/tinyexec": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -11875,6 +11851,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsup": {
@@ -11989,9 +11966,9 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-			"integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
@@ -12601,6 +12578,21 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist", "README.md"],
+	"files": [
+		"dist",
+		"README.md"
+	],
 	"access": "public",
 	"bugs": {
 		"url": "https://github.com/chrisdoc/hevy-mcp/issues"
@@ -18,7 +21,6 @@
 		"test": "vitest",
 		"export-specs": "node ./scripts/export-openapi-spec.js",
 		"build": "tsup",
-		"build:client": "kiota generate -l typescript -d openapi-spec.json -c HevyClient -o ./src/generated/client --log-level error --clean-output --clear-cache",
 		"start": "node dist/index.js",
 		"dev": "tsx watch --clear-screen=false src/index.ts",
 		"check": "biome check --fix",
@@ -29,19 +31,20 @@
 		"commit": "commit"
 	},
 	"type": "module",
-	"keywords": ["mcp", "hevy", "fitness", "api", "model context protocol"],
+	"keywords": [
+		"mcp",
+		"hevy",
+		"fitness",
+		"api",
+		"model context protocol"
+	],
 	"author": "Christoph Kieslich",
 	"license": "MIT",
 	"description": "A Model Context Protocol (MCP) server implementation that interfaces with the Hevy fitness tracking app and its API.",
 	"dependencies": {
 		"@dotenvx/dotenvx": "^1.44.0",
-		"@microsoft/kiota-abstractions": "1.0.0-preview.94",
-		"@microsoft/kiota-authentication-azure": "1.0.0-preview.94",
-		"@microsoft/kiota-bundle": "1.0.0-preview.94",
-		"@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.94",
-		"@microsoft/kiota-serialization-json": "1.0.0-preview.94",
-		"@microsoft/kiota-serialization-text": "1.0.0-preview.94",
 		"@modelcontextprotocol/sdk": "^1.11.3",
+		"axios": "^1.9.0",
 		"uuid": "^11.1.0",
 		"zod": "^3.24.4"
 	},

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { HevyClient } from "../generated/client/hevyClient.js";
-import type { RoutineFolder } from "../generated/client/models/index.js";
+import type { HevyClient } from "../utils/hevyClient.js";
 import { formatRoutineFolder } from "../utils/formatters.js";
 
 /**

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { HevyClient } from "../generated/client/hevyClient.js";
-import type { Routine } from "../generated/client/models/index.js";
+import type { HevyClient } from "../utils/hevyClient.js";
 import { formatRoutine } from "../utils/formatters.js";
 
 /**

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { HevyClient } from "../generated/client/hevyClient.js";
-import type { ExerciseTemplate } from "../generated/client/models/index.js";
+import type { HevyClient } from "../utils/hevyClient.js";
 import { formatExerciseTemplate } from "../utils/formatters.js";
 
 /**

--- a/src/tools/workouts.ts
+++ b/src/tools/workouts.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { HevyClient } from "../generated/client/hevyClient.js";
-import type { PostWorkoutsRequestBody } from "../generated/client/models/index.js";
+import type { HevyClient } from "../utils/hevyClient.js";
 import { withErrorHandling } from "../utils/error-handler.js";
 import { formatWorkout } from "../utils/formatters.js";
 import {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -5,7 +5,7 @@ import type {
 	Routine,
 	RoutineFolder,
 	Workout,
-} from "../generated/client/models/index.js";
+} from "./models.js";
 
 /**
  * Formatted workout set interface

--- a/src/utils/hevyClient.ts
+++ b/src/utils/hevyClient.ts
@@ -1,18 +1,105 @@
-import {
-	ApiKeyAuthenticationProvider,
-	ApiKeyLocation,
-} from "@microsoft/kiota-abstractions";
-import { FetchRequestAdapter } from "@microsoft/kiota-http-fetchlibrary";
-import { createHevyClient } from "../generated/client/hevyClient.js";
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 
-export function createClient(apiKey: string, baseUrl: string) {
-	const authProvider = new ApiKeyAuthenticationProvider(
-		apiKey,
-		"api-key",
-		ApiKeyLocation.Header,
-	);
-	const adapter = new FetchRequestAdapter(authProvider);
-	adapter.baseUrl = baseUrl;
+export interface HevyClient {
+  v1: {
+    workouts: {
+      get: (params?: any) => Promise<any>;
+      post: (data: any) => Promise<any>;
+      count: {
+        get: (params?: any) => Promise<any>;
+      };
+      events: {
+        get: (params?: any) => Promise<any>;
+      };
+      byId: (id: string) => {
+        get: () => Promise<any>;
+        patch: (data: any) => Promise<any>;
+        delete: () => Promise<any>;
+      };
+    };
+    routines: {
+      get: (params?: any) => Promise<any>;
+      post: (data: any) => Promise<any>;
+      byId: (id: string) => {
+        get: () => Promise<any>;
+        patch: (data: any) => Promise<any>;
+        delete: () => Promise<any>;
+      };
+    };
+    routine_folders: {
+      get: (params?: any) => Promise<any>;
+      post: (data: any) => Promise<any>;
+      byId: (id: string) => {
+        get: () => Promise<any>;
+        patch: (data: any) => Promise<any>;
+        delete: () => Promise<any>;
+      };
+    };
+    exercise_templates: {
+      get: (params?: any) => Promise<any>;
+      post: (data: any) => Promise<any>;
+      byId: (id: string) => {
+        get: () => Promise<any>;
+        patch: (data: any) => Promise<any>;
+        delete: () => Promise<any>;
+      };
+    };
+  };
+}
 
-	return createHevyClient(adapter);
+export function createClient(apiKey: string, baseUrl: string): HevyClient {
+  const axiosInstance = axios.create({
+    baseURL: baseUrl,
+    headers: {
+      "api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+  });
+
+  return {
+    v1: {
+      workouts: {
+        get: (params) => axiosInstance.get("/v1/workouts", { params }).then(res => res.data),
+        post: (data) => axiosInstance.post("/v1/workouts", data).then(res => res.data),
+        count: {
+          get: (params) => axiosInstance.get("/v1/workouts/count", { params }).then(res => res.data),
+        },
+        events: {
+          get: (params) => axiosInstance.get("/v1/workouts/events", { params }).then(res => res.data),
+        },
+        byId: (id) => ({
+          get: () => axiosInstance.get(`/v1/workouts/${id}`).then(res => res.data),
+          patch: (data) => axiosInstance.patch(`/v1/workouts/${id}`, data).then(res => res.data),
+          delete: () => axiosInstance.delete(`/v1/workouts/${id}`).then(res => res.data),
+        }),
+      },
+      routines: {
+        get: (params) => axiosInstance.get("/v1/routines", { params }).then(res => res.data),
+        post: (data) => axiosInstance.post("/v1/routines", data).then(res => res.data),
+        byId: (id) => ({
+          get: () => axiosInstance.get(`/v1/routines/${id}`).then(res => res.data),
+          patch: (data) => axiosInstance.patch(`/v1/routines/${id}`, data).then(res => res.data),
+          delete: () => axiosInstance.delete(`/v1/routines/${id}`).then(res => res.data),
+        }),
+      },
+      routine_folders: {
+        get: (params) => axiosInstance.get("/v1/routine_folders", { params }).then(res => res.data),
+        post: (data) => axiosInstance.post("/v1/routine_folders", data).then(res => res.data),
+        byId: (id) => ({
+          get: () => axiosInstance.get(`/v1/routine_folders/${id}`).then(res => res.data),
+          patch: (data) => axiosInstance.patch(`/v1/routine_folders/${id}`, data).then(res => res.data),
+          delete: () => axiosInstance.delete(`/v1/routine_folders/${id}`).then(res => res.data),
+        }),
+      },
+      exercise_templates: {
+        get: (params) => axiosInstance.get("/v1/exercise_templates", { params }).then(res => res.data),
+        post: (data) => axiosInstance.post("/v1/exercise_templates", data).then(res => res.data),
+        byId: (id) => ({
+          get: () => axiosInstance.get(`/v1/exercise_templates/${id}`).then(res => res.data),
+          patch: (data) => axiosInstance.patch(`/v1/exercise_templates/${id}`, data).then(res => res.data),
+          delete: () => axiosInstance.delete(`/v1/exercise_templates/${id}`).then(res => res.data),
+        }),
+      },
+    },
+  };
 }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -1,0 +1,65 @@
+// Define the models used in the application
+
+export interface ExerciseSet {
+  id: string;
+  weight?: number;
+  reps?: number;
+  distance?: number;
+  duration?: number;
+  set_type?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface Exercise {
+  id: string;
+  exercise_template_id: string;
+  name: string;
+  notes?: string;
+  sets: ExerciseSet[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface Workout {
+  id: string;
+  user_id: string;
+  name: string;
+  description?: string;
+  start_time: string;
+  end_time?: string;
+  exercises: Exercise[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface Routine {
+  id: string;
+  user_id: string;
+  name: string;
+  description?: string;
+  exercises: Exercise[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface RoutineFolder {
+  id: string;
+  user_id: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ExerciseTemplate {
+  id: string;
+  name: string;
+  category?: string;
+  primary_muscle_group?: string;
+  secondary_muscle_groups?: string[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export type Routine_exercises = Exercise;
+export type Routine_exercises_sets = ExerciseSet;


### PR DESCRIPTION
This PR addresses issue #48 by replacing Kiota with a direct axios implementation for API calls.

## Changes
- Removed all Kiota dependencies from package.json
- Added axios for HTTP requests
- Created a new HevyClient interface and implementation in src/utils/hevyClient.ts
- Created a models.ts file to define the types used in the application
- Updated all import paths in the tools files

This approach simplifies the codebase by removing the complexity of code generation and using a direct axios implementation instead.

Closes #48

@chrisdoc can click here to [continue refining the PR](https://app.all-hands.dev/conversations/64946aabd342417e8280f4b41ecfc9f1)