### PR TITLE
Add integration tests for MCP server with real HevyAPI (get-workouts)

### DIFF
--- a/.cursor/rules/hevy_rules.mdc
+++ b/.cursor/rules/hevy_rules.mdc
@@ -1,0 +1,21 @@
+# Cursor Rule: hevy-mcp Integration Test Best Practices
+
+1. **Always re-run relevant tests after making any change to a test file.**
+   - This ensures that changes are immediately validated and no regressions are introduced.
+
+2. **When fixing or updating integration tests:**
+   - Use the correct method signatures and argument types for SDK/client calls.
+   - Add or update Zod schema validation for API responses to ensure type safety and contract adherence.
+   - Remove any debug or console.log statements before finalizing changes, unless explicitly requested otherwise.
+
+3. **When adding new tests or updating existing ones:**
+   - Prefer validating response data with Zod schemas that match the expected output structure.
+   - Ensure all test assertions are meaningful and reflect the actual API contract.
+
+4. **If a test fails:**
+   - Add temporary debug output (e.g., console.log) only as needed to diagnose the issue, and remove it once resolved.
+   - Investigate the actual response structure before updating assertions or schemas.
+
+5. **Keep integration tests clean and production-ready:**
+   - No unnecessary debug output.
+   - All code should be idiomatic, concise, and maintainable. 

--- a/.cursor/rules/rerun-tests-when-changes.mdc
+++ b/.cursor/rules/rerun-tests-when-changes.mdc
@@ -1,0 +1,6 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+Make sure to re-run tests whenever you make a change to the the source code and also ensure that the test cases are up to date

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,6 +60,16 @@ jobs:
     - name: Run build
       run: npm run build
 
+    - name: Check for HEVY_API_KEY
+      run: |
+        if [ -n "$HEVY_API_KEY" ]; then
+          echo "HEVY_API_KEY is set (value not shown for security)"
+        else
+          echo "HEVY_API_KEY is not set"
+        fi
+      env:
+        HEVY_API_KEY: ${{ secrets.HEVY_API_KEY }}
+
     - name: Run integration tests
       run: npx vitest run tests/integration
       env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,3 +40,27 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run build
+      run: npm run build
+
+    - name: Run integration tests
+      run: npx vitest run tests/integration
+      env:
+        HEVY_API_KEY: ${{ secrets.HEVY_API_KEY }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Run build
       run: npm run build
 
-    - name: Run tests
-      run: npx vitest run --coverage
+    - name: Run unit tests
+      run: npx vitest run --coverage --exclude tests/integration/**
 
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v5
@@ -61,16 +61,24 @@ jobs:
       run: npm run build
 
     - name: Check for HEVY_API_KEY
+      id: check_key
       run: |
         if [ -n "$HEVY_API_KEY" ]; then
           echo "HEVY_API_KEY is set (value not shown for security)"
+          echo "has_key=true" >> $GITHUB_OUTPUT
         else
-          echo "HEVY_API_KEY is not set"
+          echo "HEVY_API_KEY is not set - integration tests will be skipped"
+          echo "has_key=false" >> $GITHUB_OUTPUT
         fi
       env:
         HEVY_API_KEY: ${{ secrets.HEVY_API_KEY }}
 
     - name: Run integration tests
+      if: steps.check_key.outputs.has_key == 'true'
       run: npx vitest run tests/integration
       env:
         HEVY_API_KEY: ${{ secrets.HEVY_API_KEY }}
+        
+    - name: Skip integration tests
+      if: steps.check_key.outputs.has_key != 'true'
+      run: echo "Skipping integration tests because HEVY_API_KEY is not set. Please add the HEVY_API_KEY secret to run integration tests."

--- a/README.md
+++ b/README.md
@@ -160,9 +160,25 @@ Run the unit tests with:
 npm test
 ```
 
-#### Integration Tests
+#### Tests
 
-The project includes integration tests that validate the MCP server's functionality with the real Hevy API. To run these tests locally:
+The project includes both unit tests and integration tests:
+
+##### Unit Tests
+
+Unit tests validate the functionality of individual components without external dependencies:
+
+```bash
+# Run all unit tests
+npx vitest run --exclude tests/integration/**
+
+# Run unit tests with coverage
+npx vitest run --coverage --exclude tests/integration/**
+```
+
+##### Integration Tests
+
+Integration tests validate the MCP server's functionality with the real Hevy API. To run these tests:
 
 1. Make sure you have a valid Hevy API key in your `.env` file
 2. Run the integration tests:
@@ -173,7 +189,14 @@ npx vitest run tests/integration
 
 **Note:** The integration tests will fail if the `HEVY_API_KEY` environment variable is not set. This is by design to ensure that the tests are always run with a valid API key.
 
-For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to be set in the repository settings:
+##### GitHub Actions Configuration
+
+For GitHub Actions:
+
+1. Unit tests will always run on every push and pull request
+2. Integration tests will only run if the `HEVY_API_KEY` secret is set in the repository settings
+
+To set up the `HEVY_API_KEY` secret:
 
 1. Go to your GitHub repository
 2. Click on "Settings" > "Secrets and variables" > "Actions"
@@ -181,7 +204,7 @@ For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to b
 4. Set the name to `HEVY_API_KEY` and the value to your Hevy API key
 5. Click "Add secret"
 
-The GitHub Actions workflow will use this secret to authenticate with the Hevy API during integration tests.
+If the secret is not set, the integration tests step will be skipped with a message indicating that the API key is missing.
 
 ### Generating API Client
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The project includes integration tests that validate the MCP server's functional
 npx vitest run tests/integration
 ```
 
+**Note:** The integration tests will fail if the `HEVY_API_KEY` environment variable is not set. This is by design to ensure that the tests are always run with a valid API key.
+
 For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to be set in the repository settings.
 
 ### Generating API Client

--- a/README.md
+++ b/README.md
@@ -173,7 +173,15 @@ npx vitest run tests/integration
 
 **Note:** The integration tests will fail if the `HEVY_API_KEY` environment variable is not set. This is by design to ensure that the tests are always run with a valid API key.
 
-For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to be set in the repository settings.
+For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to be set in the repository settings:
+
+1. Go to your GitHub repository
+2. Click on "Settings" > "Secrets and variables" > "Actions"
+3. Click on "New repository secret"
+4. Set the name to `HEVY_API_KEY` and the value to your Hevy API key
+5. Click "Add secret"
+
+The GitHub Actions workflow will use this secret to authenticate with the Hevy API during integration tests.
 
 ### Generating API Client
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ hevy-mcp/
 │       └── validators.ts  # Input validation helpers
 ├── scripts/               # Build and utility scripts
 └── tests/                 # Test suite
+    ├── integration/       # Integration tests with real API
+    │   └── hevy-mcp.integration.test.ts  # MCP server integration tests
 ```
 
 ## Development Guide
@@ -147,6 +149,29 @@ This project uses Biome for code formatting and linting:
 ```bash
 npm run check
 ```
+
+### Testing
+
+#### Unit Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+
+#### Integration Tests
+
+The project includes integration tests that validate the MCP server's functionality with the real Hevy API. To run these tests locally:
+
+1. Make sure you have a valid Hevy API key in your `.env` file
+2. Run the integration tests:
+
+```bash
+npx vitest run tests/integration
+```
+
+For GitHub Actions, the integration tests require the `HEVY_API_KEY` secret to be set in the repository settings.
 
 ### Generating API Client
 

--- a/README.md
+++ b/README.md
@@ -152,36 +152,33 @@ npm run check
 
 ### Testing
 
-#### Unit Tests
+#### Run All Tests
 
-Run the unit tests with:
+To run all tests (unit and integration), use:
 
 ```bash
 npm test
 ```
 
-#### Tests
+> **Note:** If the `HEVY_API_KEY` environment variable is set, integration tests will also run. If not, only unit tests will run.
 
-The project includes both unit tests and integration tests:
+#### Run Only Unit Tests
 
-##### Unit Tests
-
-Unit tests validate the functionality of individual components without external dependencies:
+To run only unit tests (excluding integration tests):
 
 ```bash
-# Run all unit tests
 npx vitest run --exclude tests/integration/**
+```
 
-# Run unit tests with coverage
+Or with coverage:
+
+```bash
 npx vitest run --coverage --exclude tests/integration/**
 ```
 
-##### Integration Tests
+#### Run Only Integration Tests
 
-Integration tests validate the MCP server's functionality with the real Hevy API. To run these tests:
-
-1. Make sure you have a valid Hevy API key in your `.env` file
-2. Run the integration tests:
+To run only the integration tests (requires a valid `HEVY_API_KEY`):
 
 ```bash
 npx vitest run tests/integration

--- a/tests/integration/hevy-mcp.integration.test.ts
+++ b/tests/integration/hevy-mcp.integration.test.ts
@@ -98,12 +98,16 @@ describe("Hevy MCP Server Integration Tests", () => {
 
 			expect(result).toBeDefined();
 			expect(result.result).toBeDefined();
-			expect(result.result.workouts).toBeDefined();
-			expect(Array.isArray(result.result.workouts)).toBe(true);
-			expect(result.result.workouts.length).toBeGreaterThan(0);
-			expect(result.result.workouts[0].id).toBeDefined();
-			expect(result.result.workouts[0].title).toBeDefined();
-			expect(result.result.workouts[0].start_time).toBeDefined();
+
+			// Parse the JSON string in the result
+			const responseData = JSON.parse(result.result.content[0].text);
+
+			expect(responseData).toBeDefined();
+			expect(Array.isArray(responseData)).toBe(true);
+			expect(responseData.length).toBeGreaterThan(0);
+			expect(responseData[0].id).toBeDefined();
+			expect(responseData[0].name).toBeDefined(); // title is formatted as name
+			expect(responseData[0].date).toBeDefined(); // start_time is formatted as date
 		});
 	});
 });

--- a/tests/integration/hevy-mcp.integration.test.ts
+++ b/tests/integration/hevy-mcp.integration.test.ts
@@ -20,17 +20,13 @@ describe("Hevy MCP Server Integration Tests", () => {
 		hasApiKey = !!hevyApiKey;
 
 		if (!hasApiKey) {
-			console.warn(
-				"HEVY_API_KEY is not set in environment variables. Integration tests will be skipped.",
+			throw new Error(
+				"HEVY_API_KEY is not set in environment variables. Integration tests cannot run without a valid API key.",
 			);
 		}
 	});
 
 	beforeEach(async () => {
-		if (!hasApiKey) {
-			return;
-		}
-
 		// Create server instance
 		server = new McpServer({
 			name: "hevy-mcp-test",
@@ -73,11 +69,6 @@ describe("Hevy MCP Server Integration Tests", () => {
 
 	describe("Get Workouts", () => {
 		it("should be able to get workouts", async () => {
-			if (!hasApiKey) {
-				// Skip test if no API key is available
-				return;
-			}
-
 			const args = {
 				page: 1,
 				pageSize: 5,

--- a/tests/integration/hevy-mcp.integration.test.ts
+++ b/tests/integration/hevy-mcp.integration.test.ts
@@ -1,5 +1,6 @@
-import { Client } from "@microsoft/mcp";
-import { InMemoryTransport } from "@microsoft/mcp/lib/transports/in-memory";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
 	afterAll,
 	afterEach,
@@ -9,10 +10,8 @@ import {
 	expect,
 	it,
 } from "vitest";
-import { GetWorkoutsHandler } from "../../src/handlers/get-workouts";
-import { HevyApiClient } from "../../src/hevy-api-client";
-import { HevyApiClientFactory } from "../../src/hevy-api-client-factory";
-import { McpServer } from "../../src/server";
+import { registerWorkoutTools } from "../../src/tools/workouts.js";
+import { createClient } from "../../src/utils/hevyClient.js";
 
 const HEVY_API_BASEURL = "https://api.hevyapp.com";
 
@@ -49,17 +48,11 @@ describe("Hevy MCP Server Integration Tests", () => {
 			version: "1.0.0",
 		});
 
-		// Create Hevy API client
-		const hevyApiClient = new HevyApiClient(HEVY_API_BASEURL, hevyApiKey);
+		// Create Hevy client
+		const hevyClient = createClient(hevyApiKey, HEVY_API_BASEURL);
 
-		// Create Hevy API client factory
-		const hevyApiClientFactory = new HevyApiClientFactory(
-			HEVY_API_BASEURL,
-			hevyApiKey,
-		);
-
-		// Register handlers
-		server.registerHandler(new GetWorkoutsHandler(hevyApiClientFactory));
+		// Register tools
+		registerWorkoutTools(server, hevyClient);
 
 		// Create client
 		client = new Client({

--- a/tests/integration/hevy-mcp.integration.test.ts
+++ b/tests/integration/hevy-mcp.integration.test.ts
@@ -1,0 +1,121 @@
+import { config } from "@dotenvx/dotenvx/config";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { registerWorkoutTools } from "../../src/tools/workouts.js";
+import { createClient } from "../../src/utils/hevyClient.js";
+
+const HEVY_API_BASEURL = "https://api.hevyapp.com";
+
+describe("Hevy MCP Server Integration Tests", () => {
+	let server: McpServer | null = null;
+	let client: Client | null = null;
+	let hevyApiKey: string;
+	let hasApiKey = false;
+
+	beforeAll(() => {
+		hevyApiKey = process.env.HEVY_API_KEY || "";
+		hasApiKey = !!hevyApiKey;
+
+		if (!hasApiKey) {
+			console.warn(
+				"HEVY_API_KEY is not set in environment variables. Integration tests will be skipped.",
+			);
+		}
+	});
+
+	beforeEach(async () => {
+		if (!hasApiKey) {
+			return;
+		}
+
+		// Create server instance
+		server = new McpServer({
+			name: "hevy-mcp-test",
+			version: "1.0.0",
+		});
+
+		// Configure client
+		const hevyClient = createClient(hevyApiKey, HEVY_API_BASEURL);
+
+		// Register workout tools
+		registerWorkoutTools(server, hevyClient);
+
+		// Create client
+		client = new Client(
+			{
+				name: "hevy-test-client",
+				version: "1.0.0",
+			},
+			{
+				capabilities: {
+					tools: {},
+				},
+			},
+		);
+
+		// Connect client and server
+		const [clientTransport, serverTransport] =
+			InMemoryTransport.createLinkedPair();
+		await Promise.all([
+			client?.connect(clientTransport),
+			server.connect(serverTransport),
+		]);
+	});
+
+	afterAll(async () => {
+		if (client) {
+			await client.close();
+		}
+	});
+
+	describe("Get Workouts", () => {
+		it("should be able to get workouts", async () => {
+			if (!hasApiKey) {
+				// Skip test if no API key is available
+				return;
+			}
+
+			const args = {
+				page: 1,
+				pageSize: 5,
+			};
+
+			const result = await client?.request(
+				{
+					method: "tools/call",
+					params: {
+						name: "get-workouts",
+						arguments: args,
+					},
+				},
+				CallToolResultSchema,
+			);
+
+			// Check that we got a result
+			expect(result).toBeDefined();
+			expect(result.content).toBeDefined();
+			expect(result.content.length).toBeGreaterThan(0);
+
+			// Parse the JSON content
+			const content = result.content[0].text as string;
+			const workouts = JSON.parse(content);
+
+			// Validate the structure of the response
+			expect(Array.isArray(workouts)).toBe(true);
+
+			// If there are workouts, validate the structure of the first workout
+			if (workouts.length > 0) {
+				const workout = workouts[0];
+				expect(workout).toHaveProperty("id");
+				expect(workout).toHaveProperty("title");
+				expect(workout).toHaveProperty("startTime");
+				expect(workout).toHaveProperty("endTime");
+				expect(workout).toHaveProperty("exercises");
+				expect(Array.isArray(workout.exercises)).toBe(true);
+			}
+		}, 30000); // Increase timeout to 30 seconds for API calls
+	});
+});


### PR DESCRIPTION
This PR adds integration tests for the MCP server with the real HevyAPI, specifically for the `get-workouts` endpoint. The tests validate that the MCP server is working as expected and returns a list of workouts.

Changes include:
- Added integration tests in `tests/integration/hevy-mcp.integration.test.ts`
- Updated GitHub Actions workflow to run integration tests using the `HEVY_API_KEY` secret
- Updated README.md to document the integration tests and required secret

The integration tests are designed to be skipped if the `HEVY_API_KEY` environment variable is not set, making them suitable for both local development and CI environments.

Fixes #51

@chrisdoc can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})