### PR TITLE
fix: move required constraint to parent schema level in CreateCustomExerciseRequestBody

### DIFF
--- a/openapi-spec.json
+++ b/openapi-spec.json
@@ -1637,7 +1637,6 @@
 				"type": "object",
 				"properties": {
 					"exercise": {
-						"required": true,
 						"type": "object",
 						"properties": {
 							"title": {
@@ -1668,7 +1667,8 @@
 							}
 						}
 					}
-				}
+				},
+				"required": ["exercise"]
 			},
 			"RoutineFolder": {
 				"type": "object",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix OpenAPI schema validation by moving 'required' constraint from property level to object level in CreateCustomExerciseRequestBody schema.

Main changes:
- Removed invalid 'required: true' from exercise property definition in CreateCustomExerciseRequestBody schema
- Added 'required' array at schema object level specifying 'exercise' as mandatory field
- Corrected JSON Schema structure to comply with OpenAPI/JSON Schema specification standards

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
