### PR TITLE
fix(routines): omit null rep_range and unwrap mutation response

### DIFF
--- a/src/tools/routines.test.ts
+++ b/src/tools/routines.test.ts
@@ -151,7 +151,6 @@ describe("registerRoutineTools", () => {
 								distance_meters: null,
 								duration_seconds: null,
 								custom_metric: null,
-								rep_range: null,
 							},
 						],
 					},
@@ -444,6 +443,137 @@ describe("registerRoutineTools", () => {
 		expect(response.content[1]?.text).toContain("issues/261");
 	});
 
+	it("create-routine omits rep_range from reps-only sets", async () => {
+		// Regression test: the Hevy API rejects PUT payloads containing
+		// `rep_range: null` with "rep_range must be of type object", and the
+		// mobile app stores a null range object instead of treating the set
+		// as reps-only. When no rep range is provided, the field must be
+		// omitted from the outgoing payload.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "created-routine",
+			title: "Reps Only",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:00:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			createRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "create-routine");
+
+		await handler({
+			title: "Reps Only",
+			folderId: null,
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.createRoutine).mock.calls[0]?.[0] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const set = call.routine.exercises[0]?.sets[0] as Record<string, unknown>;
+		expect(set).not.toHaveProperty("rep_range");
+		expect(set.reps).toBe(10);
+	});
+
+	it("update-routine omits rep_range from reps-only sets", async () => {
+		// Regression test: `update-routine` previously always sent
+		// `rep_range: repRange`, producing `rep_range: null` for reps-only
+		// sets. The Hevy API rejects that payload ("rep_range must be of
+		// type object"), so every update with at least one reps-only set
+		// failed. The field must be omitted when no range exists.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "Reps Only",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		await handler({
+			routineId: "routine-123",
+			title: "Reps Only",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [
+						{ type: "warmup", weightKg: 40, reps: 6 },
+						{ type: "normal", weightKg: 60, reps: 10 },
+					],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.updateRoutine).mock.calls[0]?.[1] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const sets = call.routine.exercises[0]?.sets ?? [];
+		for (const set of sets) {
+			expect(set).not.toHaveProperty("rep_range");
+		}
+	});
+
+	it("update-routine preserves rep_range when a real range is provided", async () => {
+		// Counterpart to the omit regression: when the caller supplies a
+		// real rep range, it must round-trip into the payload as an object
+		// so the Hevy API stores it.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "With Range",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		await handler({
+			routineId: "routine-123",
+			title: "With Range",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [
+						{
+							type: "normal",
+							weightKg: 80,
+							reps: null,
+							repRange: { start: 8, end: 12 },
+						},
+					],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.updateRoutine).mock.calls[0]?.[1] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const set = call.routine.exercises[0]?.sets[0] as Record<string, unknown>;
+		expect(set.rep_range).toEqual({ start: 8, end: 12 });
+	});
+
 	it("create-routine schema keeps reps null (does not coerce to 0)", () => {
 		const { server, tool } = createMockServer();
 		registerRoutineTools(server, null);
@@ -685,7 +815,6 @@ describe("registerRoutineTools", () => {
 								distance_meters: null,
 								duration_seconds: null,
 								custom_metric: null,
-								rep_range: null,
 							},
 						],
 					},

--- a/src/tools/routines.test.ts
+++ b/src/tools/routines.test.ts
@@ -443,6 +443,81 @@ describe("registerRoutineTools", () => {
 		expect(response.content[1]?.text).toContain("issues/261");
 	});
 
+	it("create-routine unwraps {routine: [...]} mutation response", async () => {
+		// Regression test: the Hevy API returns POST /v1/routines as
+		// `{ routine: [Routine] }` (a one-element array nested under a
+		// `routine` key), but the generated OpenAPI types claim the response
+		// IS a Routine. The handler must defensively unwrap so the tool
+		// returns the actual routine object, not "{}".
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "created-routine",
+			title: "Wrapped Response",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:00:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			createRoutine: vi
+				.fn()
+				.mockResolvedValue({ routine: [routine] } as unknown as Routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "create-routine");
+
+		const response = await handler({
+			title: "Wrapped Response",
+			folderId: null,
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const parsed = JSON.parse(response.content[0].text) as unknown;
+		expect(parsed).toEqual(formatRoutine(routine));
+	});
+
+	it("update-routine unwraps {routine: [...]} mutation response", async () => {
+		// Regression test: PUT /v1/routines/:id has the same wrapping
+		// behaviour as POST; unwrap so the response isn't "{}".
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "Wrapped Response",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi
+				.fn()
+				.mockResolvedValue({ routine: [routine] } as unknown as Routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		const response = await handler({
+			routineId: "routine-123",
+			title: "Wrapped Response",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const parsed = JSON.parse(response.content[0].text) as unknown;
+		expect(parsed).toEqual(formatRoutine(routine));
+	});
+
 	it("create-routine omits rep_range from reps-only sets", async () => {
 		// Regression test: the Hevy API rejects PUT payloads containing
 		// `rep_range: null` with "rep_range must be of type object", and the

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -119,6 +119,31 @@ function getFixedRepsFromRepRange(
 	return start;
 }
 
+/**
+ * Unwraps the mutation (POST/PUT) response from the Hevy API.
+ *
+ * The API wraps the created/updated routine in `{ routine: [routineObj] }`
+ * — a single-element array inside a `routine` key — even though the
+ * generated OpenAPI types claim the response body IS a Routine. Until the
+ * spec is corrected, unwrap defensively: accept either the wrapped shape,
+ * `{ routine: routineObj }`, or a bare Routine, so callers always receive
+ * a single Routine (or null).
+ */
+function unwrapMutationResponse(data: unknown): Routine | null {
+	if (!data || typeof data !== "object") {
+		return null;
+	}
+	const maybeWrapped = data as { routine?: Routine | Routine[] };
+	if (maybeWrapped.routine !== undefined) {
+		const r = maybeWrapped.routine;
+		if (Array.isArray(r)) {
+			return r[0] ?? null;
+		}
+		return r;
+	}
+	return data as Routine;
+}
+
 const repRangeDisplayWarningText =
 	"Note: Hevy's public API stores rep ranges (rep_range), but the Hevy apps may " +
 	"not display them because they rely on an internal-only exercise field " +
@@ -291,13 +316,18 @@ export function registerRoutineTools(
 				},
 			});
 
-			if (!data) {
+			// The Hevy API returns { routine: [Routine] } on POST — a wrapper
+			// around an array with a single element — even though the
+			// generated OpenAPI type claims the response IS a Routine. Unwrap
+			// it so `formatRoutine` receives the actual routine object.
+			const created = unwrapMutationResponse(data);
+			if (!created) {
 				return createEmptyResponse(
 					"Failed to create routine: Server returned no data",
 				);
 			}
 
-			const routine = formatRoutine(data);
+			const routine = formatRoutine(created);
 			const response = createJsonResponse(routine, {
 				pretty: true,
 				indent: 2,
@@ -410,13 +440,15 @@ export function registerRoutineTools(
 				},
 			);
 
-			if (!data) {
+			// The Hevy API returns { routine: [Routine] } on PUT as well.
+			const updated = unwrapMutationResponse(data);
+			if (!updated) {
 				return createEmptyResponse(
 					`Failed to update routine with ID ${routineId}`,
 				);
 			}
 
-			const routine = formatRoutine(data);
+			const routine = formatRoutine(updated);
 			const response = createJsonResponse(routine, {
 				pretty: true,
 				indent: 2,

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -261,7 +261,12 @@ export function registerRoutineTools(
 								distance_meters: set.distance ?? set.distanceMeters ?? null,
 								duration_seconds: set.duration ?? set.durationSeconds ?? null,
 								custom_metric: set.customMetric ?? null,
-								rep_range: repRange,
+								// Omit rep_range when null. The Hevy API rejects PUT
+								// payloads with `rep_range: null` ("rep_range must be of
+								// type object"), and on POST we prefer omitting so the
+								// app treats the set as reps-only rather than storing a
+								// null range object.
+								...(repRange !== null && { rep_range: repRange }),
 							};
 						});
 
@@ -375,7 +380,11 @@ export function registerRoutineTools(
 									distance_meters: set.distance ?? set.distanceMeters ?? null,
 									duration_seconds: set.duration ?? set.durationSeconds ?? null,
 									custom_metric: set.customMetric ?? null,
-									rep_range: repRange,
+									// Omit rep_range when null. The Hevy API rejects PUT
+									// payloads with `rep_range: null` ("rep_range must be
+									// of type object"), which breaks every reps-only set
+									// (warmups and sets without a prescribed range).
+									...(repRange !== null && { rep_range: repRange }),
 								};
 							});
 


### PR DESCRIPTION
Two bugs in `create-routine` / `update-routine` surfaced while building a routine-sync tool against a real Hevy account (Filip-style trainer-programmed routines with warmups and reps-only working sets).

## Bug 1 — `update-routine` rejects every routine with a reps-only set

### Repro

Any call to `update-routine` where **at least one** set has `reps` but no `repRange` fails with:

```
Error: \"rep_range must be of type object\"
```

That description matches almost every real-world routine: warmups, reps-only working sets, accessory sets without a prescribed range.

### Root cause

`src/tools/routines.ts:264,378` always spreads `rep_range: repRange` into the outgoing payload. When the caller omits `repRange` (or sends `{start: null, end: null}`), `buildRepRange()` returns `null`, and the MCP posts `rep_range: null`. The Hevy API rejects the null value.

The generated OpenAPI type already declares it as optional (`rep_range?: ... | null`), so omission is the correct shape.

### Fix

Build `rep_range` into the outgoing set payload **only when `buildRepRange()` returns a real range object**. When there is no range, the field is omitted entirely. Matches the GET response contract: the API returns sets without the field for reps-only sets.

```diff
 custom_metric: set.customMetric ?? null,
-rep_range: repRange,
+...(repRange !== null && { rep_range: repRange }),
```

## Bug 2 — `create-routine` and `update-routine` return an empty `{}` instead of the routine

### Repro

Call `create-routine` → routine is successfully created server-side, but the MCP response to the caller is literally `{}`, so the agent has no ID and believes the call failed silently. `update-routine` exhibits the same empty-response shape.

### Root cause

The Hevy API returns POST /v1/routines and PUT /v1/routines/:id as

```json
{ \"routine\": [ { \"id\": \"...\", \"title\": \"...\", ... } ] }
```

— a one-element array nested under a `routine` key — but the generated OpenAPI types declare the response body **is** a `Routine`. As a result, `routines.ts:300,419` pass the wrapper object into `formatRoutine`, which returns an empty-looking object.

### Fix

Added a small defensive `unwrapMutationResponse` helper that accepts the wrapped array shape, a singular `{ routine: Routine }` shape, or a bare `Routine` (preserving the existing test-mock contract). Both mutation handlers now route the client response through it before formatting.

This also makes the MCP consistent with `get-routine`, which already unwraps `data.routine`.

## Verification

- `npm run check:types` ✅
- `npm run check` (oxlint + oxfmt) ✅
- `npm test` (excluding integration) ✅  — 152 → **157** unit tests, +5 regression tests:
  - `create-routine omits rep_range from reps-only sets`
  - `update-routine omits rep_range from reps-only sets`
  - `update-routine preserves rep_range when a real range is provided`
  - `create-routine unwraps {routine: [...]} mutation response`
  - `update-routine unwraps {routine: [...]} mutation response`
- **End-to-end against the live Hevy API**: built the patched `dist/cli.mjs` and exercised it over stdio JSON-RPC against a real Hevy account:
  - `create-routine` now returns full routine JSON with the new id, not \`{}\`
  - `update-routine` with a mix of warmup (reps-only), a working set with `repRange {8,12}`, and a reps-only working set round-trips correctly:
    - warmup: `rep_range` omitted ✅
    - working set with range: `rep_range: {start: 8, end: 12}` preserved ✅
    - reps-only working set: `rep_range` omitted ✅
    - notes updated ✅
  - Fixes #261 for the \"invisible `{reps, reps}` workaround\" class of issues — callers no longer need to inject fake rep ranges to satisfy the API.

## Follow-ups (out of scope here)

- The OpenAPI spec is wrong about the POST/PUT mutation response shape (`{routine: [Routine]}`, not `Routine`). Regenerating the client with a corrected spec would remove the need for the `unwrapMutationResponse` helper, but I didn't want to touch generated code in this PR.
- #261 (app doesn't render `rep_range`) remains a Hevy-app-side issue around `input_modifier`; intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routine creation and update operations to properly handle API responses and correctly format requests for reps-only sets.
  * Eliminated unnecessary null values in routine request payloads, ensuring cleaner data transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix routine creation and updates by handling Hevy API's wrapped mutation responses and preventing null rep_range rejection errors.

Main changes:
- Added unwrapMutationResponse() to handle API returning {routine: [Routine]} instead of bare Routine object
- Changed rep_range field to be conditionally omitted when null to prevent API validation error
- Added comprehensive test coverage for mutation response unwrapping and rep_range omission behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
