### PR TITLE
feat: add body measurements MCP tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ Sentry.init(sentryConfig);
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { registerBodyMeasurementTools } from "./tools/body-measurements.js";
 import { registerFolderTools } from "./tools/folders.js";
 import { registerRoutineTools } from "./tools/routines.js";
 import { registerTemplateTools } from "./tools/templates.js";
@@ -75,6 +76,7 @@ function buildServer(apiKey: string) {
 	registerRoutineTools(server, hevyClient);
 	registerTemplateTools(server, hevyClient);
 	registerFolderTools(server, hevyClient);
+	registerBodyMeasurementTools(server, hevyClient);
 	registerWebhookTools(server, hevyClient);
 
 	return server;

--- a/src/tools/body-measurements.test.ts
+++ b/src/tools/body-measurements.test.ts
@@ -1,0 +1,236 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+import type { BodyMeasurement } from "../generated/client/types/index.js";
+import { formatBodyMeasurement } from "../utils/formatters.js";
+import { registerBodyMeasurementTools } from "./body-measurements.js";
+
+type HevyClient = ReturnType<
+	typeof import("../utils/hevyClientKubb.js").createClient
+>;
+
+function createMockServer() {
+	const tool = vi.fn();
+	const server = { tool } as unknown as McpServer;
+	return { server, tool };
+}
+
+function getToolRegistration(toolSpy: ReturnType<typeof vi.fn>, name: string) {
+	const match = toolSpy.mock.calls.find(([toolName]) => toolName === name);
+	if (!match) {
+		throw new Error(`Tool ${name} was not registered`);
+	}
+	const [, , , handler] = match as [
+		string,
+		string,
+		Record<string, unknown>,
+		(args: Record<string, unknown>) => Promise<{
+			content: Array<{ type: string; text: string }>;
+			isError?: boolean;
+		}>,
+	];
+	return { handler };
+}
+
+const sampleMeasurement: BodyMeasurement = {
+	date: "2025-03-25",
+	weight_kg: 80.5,
+	lean_mass_kg: 65.0,
+	fat_percent: 19.3,
+	neck_cm: 38.0,
+	shoulder_cm: 120.0,
+	chest_cm: 100.0,
+	left_bicep_cm: 35.0,
+	right_bicep_cm: 35.5,
+	left_forearm_cm: 28.0,
+	right_forearm_cm: 28.5,
+	abdomen: 85.0,
+	waist: 82.0,
+	hips: 95.0,
+	left_thigh: 58.0,
+	right_thigh: 58.5,
+	left_calf: 38.0,
+	right_calf: 38.0,
+};
+
+describe("registerBodyMeasurementTools", () => {
+	it("returns error responses when Hevy client is not initialized", async () => {
+		const { server, tool } = createMockServer();
+		registerBodyMeasurementTools(server, null);
+
+		const toolNames = [
+			"get-body-measurements",
+			"get-body-measurement",
+			"create-body-measurement",
+			"update-body-measurement",
+		];
+
+		for (const name of toolNames) {
+			const { handler } = getToolRegistration(tool, name);
+			const response = await handler({});
+			expect(response).toMatchObject({
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: expect.stringContaining(
+							"API client not initialized. Please provide HEVY_API_KEY.",
+						),
+					},
+				],
+			});
+		}
+	});
+
+	it("get-body-measurements returns formatted measurements from the client", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			getBodyMeasurements: vi.fn().mockResolvedValue({
+				body_measurements: [sampleMeasurement],
+			}),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "get-body-measurements");
+
+		const response = await handler({ page: 1, pageSize: 10 });
+
+		expect(hevyClient.getBodyMeasurements).toHaveBeenCalledWith({
+			page: 1,
+			pageSize: 10,
+		});
+
+		const parsed = JSON.parse(response.content[0].text) as unknown[];
+		expect(parsed).toEqual([formatBodyMeasurement(sampleMeasurement)]);
+	});
+
+	it("get-body-measurements returns empty response when no measurements found", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			getBodyMeasurements: vi.fn().mockResolvedValue({ body_measurements: [] }),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "get-body-measurements");
+
+		const response = await handler({ page: 1, pageSize: 10 });
+		expect(response.content[0]?.text).toBe(
+			"No body measurements found for the specified parameters",
+		);
+	});
+
+	it("get-body-measurement returns a formatted measurement for a given date", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			getBodyMeasurement: vi.fn().mockResolvedValue(sampleMeasurement),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "get-body-measurement");
+
+		const response = await handler({ date: "2025-03-25" });
+
+		expect(hevyClient.getBodyMeasurement).toHaveBeenCalledWith("2025-03-25");
+
+		const parsed = JSON.parse(response.content[0].text) as unknown;
+		expect(parsed).toEqual(formatBodyMeasurement(sampleMeasurement));
+	});
+
+	it("get-body-measurement returns empty response when not found", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			getBodyMeasurement: vi.fn().mockResolvedValue(null),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "get-body-measurement");
+
+		const response = await handler({ date: "2099-01-01" });
+		expect(response.content[0]?.text).toBe(
+			"No body measurement found for date 2099-01-01",
+		);
+	});
+
+	it("create-body-measurement sends correct payload to the client", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			createBodyMeasurement: vi.fn().mockResolvedValue(undefined),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "create-body-measurement");
+
+		const response = await handler({
+			date: "2025-04-01",
+			weightKg: 81.0,
+			fatPercent: 18.5,
+		});
+
+		expect(hevyClient.createBodyMeasurement).toHaveBeenCalledWith({
+			date: "2025-04-01",
+			weight_kg: 81.0,
+			lean_mass_kg: null,
+			fat_percent: 18.5,
+			neck_cm: null,
+			shoulder_cm: null,
+			chest_cm: null,
+			left_bicep_cm: null,
+			right_bicep_cm: null,
+			left_forearm_cm: null,
+			right_forearm_cm: null,
+			abdomen: null,
+			waist: null,
+			hips: null,
+			left_thigh: null,
+			right_thigh: null,
+			left_calf: null,
+			right_calf: null,
+		});
+
+		expect(response.content[0]?.text).toBe(
+			"Body measurement for 2025-04-01 created successfully.",
+		);
+	});
+
+	it("update-body-measurement sends correct payload to the client", async () => {
+		const { server, tool } = createMockServer();
+		const hevyClient: HevyClient = {
+			updateBodyMeasurement: vi.fn().mockResolvedValue(undefined),
+		} as unknown as HevyClient;
+
+		registerBodyMeasurementTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-body-measurement");
+
+		const response = await handler({
+			date: "2025-03-25",
+			weightKg: 79.5,
+			chestCm: 101.0,
+		});
+
+		expect(hevyClient.updateBodyMeasurement).toHaveBeenCalledWith(
+			"2025-03-25",
+			{
+				weight_kg: 79.5,
+				lean_mass_kg: null,
+				fat_percent: null,
+				neck_cm: null,
+				shoulder_cm: null,
+				chest_cm: 101.0,
+				left_bicep_cm: null,
+				right_bicep_cm: null,
+				left_forearm_cm: null,
+				right_forearm_cm: null,
+				abdomen: null,
+				waist: null,
+				hips: null,
+				left_thigh: null,
+				right_thigh: null,
+				left_calf: null,
+				right_calf: null,
+			},
+		);
+
+		expect(response.content[0]?.text).toBe(
+			"Body measurement for 2025-03-25 updated successfully.",
+		);
+	});
+});

--- a/src/tools/body-measurements.ts
+++ b/src/tools/body-measurements.ts
@@ -18,7 +18,7 @@ type HevyClient = ReturnType<
 	typeof import("../utils/hevyClientKubb.js").createClient
 >;
 
-const zNullableNumber = z.coerce.number().nullable().optional();
+const zNullableNumber = z.number().nullable().optional();
 
 const bodyMeasurementFieldsSchema = {
 	weightKg: zNullableNumber.describe("Body weight in kilograms"),

--- a/src/tools/body-measurements.ts
+++ b/src/tools/body-measurements.ts
@@ -1,0 +1,248 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type {
+	BodyMeasurement,
+	GetV1BodyMeasurements200,
+	GetV1BodyMeasurementsDate200,
+} from "../generated/client/types/index.js";
+import { withErrorHandling } from "../utils/error-handler.js";
+import { formatBodyMeasurement } from "../utils/formatters.js";
+import {
+	createEmptyResponse,
+	createJsonResponse,
+	createTextResponse,
+} from "../utils/response-formatter.js";
+import type { InferToolParams } from "../utils/tool-helpers.js";
+
+type HevyClient = ReturnType<
+	typeof import("../utils/hevyClientKubb.js").createClient
+>;
+
+const zNullableNumber = z.coerce.number().nullable().optional();
+
+const bodyMeasurementFieldsSchema = {
+	weightKg: zNullableNumber.describe("Body weight in kilograms"),
+	leanMassKg: zNullableNumber.describe("Lean body mass in kilograms"),
+	fatPercent: zNullableNumber.describe("Body fat percentage"),
+	neckCm: zNullableNumber.describe("Neck circumference in centimeters"),
+	shoulderCm: zNullableNumber.describe("Shoulder circumference in centimeters"),
+	chestCm: zNullableNumber.describe("Chest circumference in centimeters"),
+	leftBicepCm: zNullableNumber.describe(
+		"Left bicep circumference in centimeters",
+	),
+	rightBicepCm: zNullableNumber.describe(
+		"Right bicep circumference in centimeters",
+	),
+	leftForearmCm: zNullableNumber.describe(
+		"Left forearm circumference in centimeters",
+	),
+	rightForearmCm: zNullableNumber.describe(
+		"Right forearm circumference in centimeters",
+	),
+	abdomen: zNullableNumber.describe("Abdomen circumference in centimeters"),
+	waist: zNullableNumber.describe("Waist circumference in centimeters"),
+	hips: zNullableNumber.describe("Hips circumference in centimeters"),
+	leftThigh: zNullableNumber.describe(
+		"Left thigh circumference in centimeters",
+	),
+	rightThigh: zNullableNumber.describe(
+		"Right thigh circumference in centimeters",
+	),
+	leftCalf: zNullableNumber.describe("Left calf circumference in centimeters"),
+	rightCalf: zNullableNumber.describe(
+		"Right calf circumference in centimeters",
+	),
+} as const;
+
+function buildMeasurementPayload(args: {
+	weightKg?: number | null;
+	leanMassKg?: number | null;
+	fatPercent?: number | null;
+	neckCm?: number | null;
+	shoulderCm?: number | null;
+	chestCm?: number | null;
+	leftBicepCm?: number | null;
+	rightBicepCm?: number | null;
+	leftForearmCm?: number | null;
+	rightForearmCm?: number | null;
+	abdomen?: number | null;
+	waist?: number | null;
+	hips?: number | null;
+	leftThigh?: number | null;
+	rightThigh?: number | null;
+	leftCalf?: number | null;
+	rightCalf?: number | null;
+}) {
+	return {
+		weight_kg: args.weightKg ?? null,
+		lean_mass_kg: args.leanMassKg ?? null,
+		fat_percent: args.fatPercent ?? null,
+		neck_cm: args.neckCm ?? null,
+		shoulder_cm: args.shoulderCm ?? null,
+		chest_cm: args.chestCm ?? null,
+		left_bicep_cm: args.leftBicepCm ?? null,
+		right_bicep_cm: args.rightBicepCm ?? null,
+		left_forearm_cm: args.leftForearmCm ?? null,
+		right_forearm_cm: args.rightForearmCm ?? null,
+		abdomen: args.abdomen ?? null,
+		waist: args.waist ?? null,
+		hips: args.hips ?? null,
+		left_thigh: args.leftThigh ?? null,
+		right_thigh: args.rightThigh ?? null,
+		left_calf: args.leftCalf ?? null,
+		right_calf: args.rightCalf ?? null,
+	};
+}
+
+export function registerBodyMeasurementTools(
+	server: McpServer,
+	hevyClient: HevyClient | null,
+) {
+	// Get body measurements (paginated list)
+	const getBodyMeasurementsSchema = {
+		page: z.coerce.number().int().gte(1).default(1),
+		pageSize: z.coerce.number().int().gte(1).lte(10).default(10),
+	} as const;
+	type GetBodyMeasurementsParams = InferToolParams<
+		typeof getBodyMeasurementsSchema
+	>;
+
+	server.tool(
+		"get-body-measurements",
+		"Get a paginated list of body measurements for the authenticated user. Returns measurements including weight, body fat, and various circumference measurements.",
+		getBodyMeasurementsSchema,
+		withErrorHandling(async (args: GetBodyMeasurementsParams) => {
+			if (!hevyClient) {
+				throw new Error(
+					"API client not initialized. Please provide HEVY_API_KEY.",
+				);
+			}
+			const { page, pageSize } = args;
+			const data: GetV1BodyMeasurements200 =
+				await hevyClient.getBodyMeasurements({
+					page,
+					pageSize,
+				});
+
+			const measurements =
+				data?.body_measurements?.map((measurement: BodyMeasurement) =>
+					formatBodyMeasurement(measurement),
+				) || [];
+
+			if (measurements.length === 0) {
+				return createEmptyResponse(
+					"No body measurements found for the specified parameters",
+				);
+			}
+
+			return createJsonResponse(measurements);
+		}, "get-body-measurements"),
+	);
+
+	// Get single body measurement by date
+	const getBodyMeasurementSchema = {
+		date: z
+			.string()
+			.regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
+			.describe("The date of the body measurement (YYYY-MM-DD)"),
+	} as const;
+	type GetBodyMeasurementParams = InferToolParams<
+		typeof getBodyMeasurementSchema
+	>;
+
+	server.tool(
+		"get-body-measurement",
+		"Get a single body measurement by date. Returns all measurement fields for the specified date.",
+		getBodyMeasurementSchema,
+		withErrorHandling(async (args: GetBodyMeasurementParams) => {
+			if (!hevyClient) {
+				throw new Error(
+					"API client not initialized. Please provide HEVY_API_KEY.",
+				);
+			}
+			const { date } = args;
+			const data: GetV1BodyMeasurementsDate200 =
+				await hevyClient.getBodyMeasurement(date);
+
+			if (!data) {
+				return createEmptyResponse(
+					`No body measurement found for date ${date}`,
+				);
+			}
+
+			return createJsonResponse(formatBodyMeasurement(data));
+		}, "get-body-measurement"),
+	);
+
+	// Create body measurement
+	const createBodyMeasurementSchema = {
+		date: z
+			.string()
+			.regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
+			.describe(
+				"The date of the body measurement (YYYY-MM-DD). Must be unique — returns 409 if an entry already exists for this date.",
+			),
+		...bodyMeasurementFieldsSchema,
+	} as const;
+	type CreateBodyMeasurementParams = InferToolParams<
+		typeof createBodyMeasurementSchema
+	>;
+
+	server.tool(
+		"create-body-measurement",
+		"Create a body measurement entry for a given date. All measurement fields are optional. Returns 409 if an entry already exists for that date — use update-body-measurement instead.",
+		createBodyMeasurementSchema,
+		withErrorHandling(async (args: CreateBodyMeasurementParams) => {
+			if (!hevyClient) {
+				throw new Error(
+					"API client not initialized. Please provide HEVY_API_KEY.",
+				);
+			}
+			const { date, ...fields } = args;
+			await hevyClient.createBodyMeasurement({
+				date,
+				...buildMeasurementPayload(fields),
+			});
+
+			return createTextResponse(
+				`Body measurement for ${date} created successfully.`,
+			);
+		}, "create-body-measurement"),
+	);
+
+	// Update body measurement
+	const updateBodyMeasurementSchema = {
+		date: z
+			.string()
+			.regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format")
+			.describe(
+				"The date of the body measurement to update (YYYY-MM-DD). Must already exist — returns 404 otherwise.",
+			),
+		...bodyMeasurementFieldsSchema,
+	} as const;
+	type UpdateBodyMeasurementParams = InferToolParams<
+		typeof updateBodyMeasurementSchema
+	>;
+
+	server.tool(
+		"update-body-measurement",
+		"Update an existing body measurement entry for a given date. All fields are overwritten — omitted fields are set to null. Returns 404 if no entry exists for the date.",
+		updateBodyMeasurementSchema,
+		withErrorHandling(async (args: UpdateBodyMeasurementParams) => {
+			if (!hevyClient) {
+				throw new Error(
+					"API client not initialized. Please provide HEVY_API_KEY.",
+				);
+			}
+			const { date, ...fields } = args;
+			await hevyClient.updateBodyMeasurement(
+				date,
+				buildMeasurementPayload(fields),
+			);
+
+			return createTextResponse(
+				`Body measurement for ${date} updated successfully.`,
+			);
+		}, "update-body-measurement"),
+	);
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -297,23 +297,23 @@ export function formatExerciseHistoryEntry(
 
 export interface FormattedBodyMeasurement {
 	date: string;
-	weightKg: number | undefined | null;
-	leanMassKg: number | undefined | null;
-	fatPercent: number | undefined | null;
-	neckCm: number | undefined | null;
-	shoulderCm: number | undefined | null;
-	chestCm: number | undefined | null;
-	leftBicepCm: number | undefined | null;
-	rightBicepCm: number | undefined | null;
-	leftForearmCm: number | undefined | null;
-	rightForearmCm: number | undefined | null;
-	abdomen: number | undefined | null;
-	waist: number | undefined | null;
-	hips: number | undefined | null;
-	leftThigh: number | undefined | null;
-	rightThigh: number | undefined | null;
-	leftCalf: number | undefined | null;
-	rightCalf: number | undefined | null;
+	weightKg: number | null;
+	leanMassKg: number | null;
+	fatPercent: number | null;
+	neckCm: number | null;
+	shoulderCm: number | null;
+	chestCm: number | null;
+	leftBicepCm: number | null;
+	rightBicepCm: number | null;
+	leftForearmCm: number | null;
+	rightForearmCm: number | null;
+	abdomen: number | null;
+	waist: number | null;
+	hips: number | null;
+	leftThigh: number | null;
+	rightThigh: number | null;
+	leftCalf: number | null;
+	rightCalf: number | null;
 }
 
 export function formatBodyMeasurement(
@@ -321,22 +321,22 @@ export function formatBodyMeasurement(
 ): FormattedBodyMeasurement {
 	return {
 		date: measurement.date,
-		weightKg: measurement.weight_kg,
-		leanMassKg: measurement.lean_mass_kg,
-		fatPercent: measurement.fat_percent,
-		neckCm: measurement.neck_cm,
-		shoulderCm: measurement.shoulder_cm,
-		chestCm: measurement.chest_cm,
-		leftBicepCm: measurement.left_bicep_cm,
-		rightBicepCm: measurement.right_bicep_cm,
-		leftForearmCm: measurement.left_forearm_cm,
-		rightForearmCm: measurement.right_forearm_cm,
-		abdomen: measurement.abdomen,
-		waist: measurement.waist,
-		hips: measurement.hips,
-		leftThigh: measurement.left_thigh,
-		rightThigh: measurement.right_thigh,
-		leftCalf: measurement.left_calf,
-		rightCalf: measurement.right_calf,
+		weightKg: measurement.weight_kg ?? null,
+		leanMassKg: measurement.lean_mass_kg ?? null,
+		fatPercent: measurement.fat_percent ?? null,
+		neckCm: measurement.neck_cm ?? null,
+		shoulderCm: measurement.shoulder_cm ?? null,
+		chestCm: measurement.chest_cm ?? null,
+		leftBicepCm: measurement.left_bicep_cm ?? null,
+		rightBicepCm: measurement.right_bicep_cm ?? null,
+		leftForearmCm: measurement.left_forearm_cm ?? null,
+		rightForearmCm: measurement.right_forearm_cm ?? null,
+		abdomen: measurement.abdomen ?? null,
+		waist: measurement.waist ?? null,
+		hips: measurement.hips ?? null,
+		leftThigh: measurement.left_thigh ?? null,
+		rightThigh: measurement.right_thigh ?? null,
+		leftCalf: measurement.left_calf ?? null,
+		rightCalf: measurement.right_calf ?? null,
 	};
 }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,4 +1,5 @@
 import type {
+	BodyMeasurement,
 	ExerciseHistoryEntry,
 	ExerciseTemplate,
 	Routine,
@@ -291,5 +292,51 @@ export function formatExerciseHistoryEntry(
 		rpe: entry.rpe,
 		customMetric: entry.custom_metric,
 		setType: entry.set_type,
+	};
+}
+
+export interface FormattedBodyMeasurement {
+	date: string;
+	weightKg: number | undefined | null;
+	leanMassKg: number | undefined | null;
+	fatPercent: number | undefined | null;
+	neckCm: number | undefined | null;
+	shoulderCm: number | undefined | null;
+	chestCm: number | undefined | null;
+	leftBicepCm: number | undefined | null;
+	rightBicepCm: number | undefined | null;
+	leftForearmCm: number | undefined | null;
+	rightForearmCm: number | undefined | null;
+	abdomen: number | undefined | null;
+	waist: number | undefined | null;
+	hips: number | undefined | null;
+	leftThigh: number | undefined | null;
+	rightThigh: number | undefined | null;
+	leftCalf: number | undefined | null;
+	rightCalf: number | undefined | null;
+}
+
+export function formatBodyMeasurement(
+	measurement: BodyMeasurement,
+): FormattedBodyMeasurement {
+	return {
+		date: measurement.date,
+		weightKg: measurement.weight_kg,
+		leanMassKg: measurement.lean_mass_kg,
+		fatPercent: measurement.fat_percent,
+		neckCm: measurement.neck_cm,
+		shoulderCm: measurement.shoulder_cm,
+		chestCm: measurement.chest_cm,
+		leftBicepCm: measurement.left_bicep_cm,
+		rightBicepCm: measurement.right_bicep_cm,
+		leftForearmCm: measurement.left_forearm_cm,
+		rightForearmCm: measurement.right_forearm_cm,
+		abdomen: measurement.abdomen,
+		waist: measurement.waist,
+		hips: measurement.hips,
+		leftThigh: measurement.left_thigh,
+		rightThigh: measurement.right_thigh,
+		leftCalf: measurement.left_calf,
+		rightCalf: measurement.right_calf,
 	};
 }

--- a/src/utils/hevyClientKubb.ts
+++ b/src/utils/hevyClientKubb.ts
@@ -5,16 +5,19 @@ import type {
 import axios from "axios";
 import * as api from "../generated/client/api";
 import type {
+	GetV1BodyMeasurementsQueryParams,
 	GetV1ExerciseHistoryExercisetemplateidQueryParams,
 	GetV1ExerciseTemplatesQueryParams,
 	GetV1RoutineFoldersQueryParams,
 	GetV1RoutinesQueryParams,
 	GetV1WorkoutsEventsQueryParams,
 	GetV1WorkoutsQueryParams,
+	PostV1BodyMeasurementsMutationRequest,
 	PostV1ExerciseTemplatesMutationRequest,
 	PostV1RoutineFoldersMutationRequest,
 	PostV1RoutinesMutationRequest,
 	PostV1WorkoutsMutationRequest,
+	PutV1BodyMeasurementsDateMutationRequest,
 	PutV1RoutinesRoutineidMutationRequest,
 	PutV1WorkoutsWorkoutidMutationRequest,
 } from "../generated/client/types";
@@ -162,6 +165,27 @@ export function createClient(
 			folderId: string,
 		): ReturnType<typeof api.getV1RoutineFoldersFolderid> =>
 			wrapApi(api.getV1RoutineFoldersFolderid)(folderId, headers, {
+				client,
+			}),
+
+		// Body Measurements
+		getBodyMeasurements: (
+			params?: GetV1BodyMeasurementsQueryParams,
+		): ReturnType<typeof api.getV1BodyMeasurements> =>
+			wrapApi(api.getV1BodyMeasurements)(headers, params, { client }),
+		getBodyMeasurement: (
+			date: string,
+		): ReturnType<typeof api.getV1BodyMeasurementsDate> =>
+			wrapApi(api.getV1BodyMeasurementsDate)(date, headers, { client }),
+		createBodyMeasurement: (
+			data: PostV1BodyMeasurementsMutationRequest,
+		): ReturnType<typeof api.postV1BodyMeasurements> =>
+			wrapApi(api.postV1BodyMeasurements)(data, headers, { client }),
+		updateBodyMeasurement: (
+			date: string,
+			data: PutV1BodyMeasurementsDateMutationRequest,
+		): ReturnType<typeof api.putV1BodyMeasurementsDate> =>
+			wrapApi(api.putV1BodyMeasurementsDate)(date, data, headers, {
 				client,
 			}),
 


### PR DESCRIPTION
Add four new MCP tools for managing body measurements via the Hevy API.

### New Tools

- **get-body-measurements** — Paginated list of body measurements
- **get-body-measurement** — Single measurement by date (YYYY-MM-DD)
- **create-body-measurement** — Create entry for a date (409 if already exists)
- **update-body-measurement** — Overwrite entry for a date (404 if not found)

### Changes

- `src/tools/body-measurements.ts` — Tool implementations with Zod schemas and type-safe handlers
- `src/tools/body-measurements.test.ts` — 7 unit tests covering all tools
- `src/utils/hevyClientKubb.ts` — Added body measurement client methods
- `src/utils/formatters.ts` — Added `formatBodyMeasurement` formatter
- `src/index.ts` — Registered `registerBodyMeasurementTools`
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement body measurements MCP tools to enable creating, updating, and retrieving user body measurements via the Hevy API.

Main changes:
- Added `registerBodyMeasurementTools` with four tools: get-body-measurements, get-body-measurement, create-body-measurement, update-body-measurement
- Implemented `formatBodyMeasurement` formatter converting snake_case API fields to camelCase representation
- Extended HevyClient with body measurement methods wrapping API endpoints and query parameter types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
