### PR TITLE
chore: add Mergify merge queue configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,29 @@
+queue_rules:
+  - name: default
+    merge_method: squash
+    # Batch several PRs into a single speculative CI run to clear the backlog faster.
+    batch_size: 3
+    batch_max_wait_time: 5 min
+    # Conditions to enter the queue.
+    queue_conditions:
+      - base = main
+      - check-success = build
+    # Conditions re-checked at the front of the queue before merging.
+    merge_conditions:
+      - check-success = build
+
+pull_request_rules:
+  - name: Queue pull requests labeled 'queue'
+    conditions:
+      - base = main
+      - label = queue
+    actions:
+      queue:
+
+  - name: Automatically queue Dependabot pull requests
+    conditions:
+      - base = main
+      - author = dependabot[bot]
+      - check-success = build
+    actions:
+      queue:


### PR DESCRIPTION
## Primary changes

Adds `.mergify.yml` to enable a [Mergify merge queue](https://docs.mergify.com/merge-queue/) for the repo, to help work through the current backlog of open PRs (~20).

## Reviewer walkthrough

**Queue (`queue_rules.default`)**
- `merge_method: squash` — matches the changesets + commitlint workflow.
- `batch_size: 3` with `batch_max_wait_time: 5 min` — batches up to 3 queued PRs into a single speculative CI run so the backlog clears faster.
- Gate: `check-success = build` for both entering the queue and merging at the front.

**Triggers (`pull_request_rules`)**
- **`queue` label** — add the `queue` label to any PR targeting `main` to enqueue it (opt-in, controlled rollout).
- **Dependabot** — PRs from `dependabot[bot]` are queued automatically once `build` passes.

## Correctness and invariants

- Requires the **Mergify GitHub App** installed on the repo (confirmed installed via API).
- Only `build` is required by design; CodeQL/GitGuardian/Codecov and `gitstream/*` checks are informational and some report "skipping", which would otherwise stall the queue.
- The queue configuration only targets PRs against `main`; non-Dependabot PRs remain opt-in via the `queue` label.

## Testing and QA

- QA target: verify Mergify accepts `.mergify.yml` and enforces the configured `build` gate for queue entry and merge.
- QA target: verify a `queue`-labeled PR and a passing Dependabot PR both enter the queue as configured.

## Notes / follow-ups

- Optionally add a GitHub ruleset on `main` requiring `build` + the Mergify check so the queue can't be bypassed by manual merges.
