### PR TITLE
Update priority rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,3 +30,9 @@ pull_request_rules:
     actions:
       queue:
         name: default
+priority_rules:
+  - name: dependabot
+    priority: low
+    conditions:
+      - author = dependabot[bot]
+    allow_checks_interruption: false


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Mergify priority rules to assign low priority queue level for dependabot pull requests.

Main changes:
- Added priority_rules configuration with named "dependabot" rule assigning low priority to dependabot[bot] authored PRs
- Configured allow_checks_interruption: false to prevent interrupting existing checks for low-priority dependabot PRs

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
## Primary changes
- Adds a `dependabot` priority rule that assigns low priority to pull requests authored by `dependabot[bot]`.
- Prevents the low-priority rule from interrupting existing checks.

## Reviewer walkthrough
- Review the `priority_rules` entry in `.mergify.yml`, including its Dependabot author condition, `low` priority, and `allow_checks_interruption: false` setting.

## Correctness and invariants
- The new rule applies only to pull requests authored by `dependabot[bot]`.
- Matching pull requests do not interrupt checks that are already running.

## Testing and QA
- Not run (configuration-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated dependency update pull requests now follow a lower-priority queue, helping other pull requests move ahead more smoothly.
  * Check runs are no longer interrupted for these queued updates, reducing unnecessary reruns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->