### PR TITLE
Update workflow automation rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,3 +30,9 @@ pull_request_rules:
     actions:
       queue:
         name: default
+  - name: Keep PRs up to date
+    conditions:
+      - -draft
+      - "#commits-behind >= 1"
+    actions:
+      update: null


### PR DESCRIPTION
## Primary changes

- Add a Mergify rule that updates non-draft pull requests when they are behind
  the base branch.

## Reviewer walkthrough

- In `.mergify.yml`, review the `Keep PRs up to date` rule and its `update`
  action.
- Confirm that it applies only when `#commits-behind >= 1` and the PR is not a
  draft.

## Correctness and invariants

- Draft pull requests remain excluded from automatic updates.
- Pull requests already current with the base branch do not match the rule.

## Testing and QA

- Not run (Mergify configuration-only change).

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Mergify automation rule to automatically rebase PRs when they fall behind the main branch.

Main changes:
- New rule "Keep PRs up to date" triggers rebase when PR has >= 1 commits behind main branch
- Rule excludes draft PRs from automatic rebase operations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated rule to keep open pull requests up to date when they fall behind the target branch, helping reduce merge conflicts and stale PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->