### PR TITLE
fix: ignore Mergify batch merge commits in commitlint

### DIFF
--- a/.changeset/fix-commitlint-mergify.md
+++ b/.changeset/fix-commitlint-mergify.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Fix commitlint failing on Mergify batch merge commits in the merge queue.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,7 @@
-export default { extends: ["@commitlint/config-conventional"] };
+export default {
+	extends: ["@commitlint/config-conventional"],
+	// Ignore merge commits created by Mergify when batching PRs in the queue
+	// (e.g. "Merge of #431", "Merge of #425"). These are internal bookkeeping
+	// commits and are not authored by contributors.
+	ignores: [(msg) => /^Merge of #\d+/.test(msg)],
+};


### PR DESCRIPTION
## Problem

The commitlint check was failing on every Mergify merge queue run. When Mergify batches multiple PRs together (e.g. `batch_size: 3`), it creates internal merge commits with messages like:

```
Merge of #431
Merge of #425
Merge of #437
```

These don't follow conventional commits format, so commitlint rejects them and the entire batch fails CI.

Observed in: https://github.com/chrisdoc/hevy-mcp/actions/runs/29041087529/job/86198135882

## Fix

Add an `ignores` predicate to `commitlint.config.js` that skips messages matching `/^Merge of #\d+/`. This is the standard approach for filtering out tooling-generated merge commits.

The ignore is deliberately narrow — it only matches Mergify's exact pattern and still rejects any non-conventional commit from contributors.

## Verification

```
echo 'Merge of #431' | npx commitlint  # ✔ 0 problems (ignored)
echo 'Update priority rules' | npx commitlint  # ✖ still rejected
echo 'fix: something valid' | npx commitlint  # ✔ 0 problems
```

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Configure commitlint to ignore Mergify batch merge commits that don't represent actual contributor contributions.

Main changes:
- Added regex-based commit message filter to ignore Mergify "Merge of #X" commits in ignores configuration
- Documented the rationale for ignoring internal bookkeeping commits created during PR batching

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
