### PR TITLE
ci: auto-rebase open PRs when they fall behind main #458

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,6 +30,12 @@ pull_request_rules:
     actions:
       queue:
         name: default
+  - name: Keep PRs up to date
+    conditions:
+      - -draft
+      - "#commits-behind >= 1"
+    actions:
+      update: null
 priority_rules:
   - name: dependabot
     priority: low


### PR DESCRIPTION
Supersedes #458.

## Primary changes

Adds a Mergify `pull_request_rules` entry that automatically rebases any non-draft PR that is one or more commits behind the base branch.

## Why

Without this rule, PRs accumulate rebase debt as main advances. Contributors have to manually rebase before the merge queue accepts them, creating friction.

## Reviewer walkthrough

`.mergify.yml` — new `Keep PRs up to date` rule:
```yaml
- name: Keep PRs up to date
  conditions:
    - -draft
    - "#commits-behind >= 1"
  actions:
    update: null
```

## Correctness and invariants

- Draft pull requests remain excluded from automatic updates.
- Only pull requests at least one commit behind their base branch match the rule.

## Testing and QA

- Not run (Mergify configuration-only change).

## Note

PR #458 had the same change but its commit message (`Update workflow automation rules`) did not follow conventional commits format, causing the commitlint CI check to fail.

Refs #458

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement automatic rebasing of open PRs when they fall behind the main branch using Mergify configuration.

Main changes:
- Added Mergify rule to automatically update non-draft PRs that are 1+ commits behind main branch
- Configured update action to trigger rebasing without blocking other operations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
