### PR TITLE
ci: raise auto-rebase threshold to 5 commits behind

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,7 +33,7 @@ pull_request_rules:
   - name: Keep PRs up to date
     conditions:
       - -draft
-      - "#commits-behind >= 1"
+      - "#commits-behind >= 5"
     actions:
       update: null
 priority_rules:


### PR DESCRIPTION
Follow-up to #465.

Changes the `Keep PRs up to date` threshold from `>= 1` to `>= 5`.

At `>= 1` every single commit to main would trigger a rebase of every open PR, causing a rebase storm and wasting CI minutes. At `>= 5` (~1–2 days of typical drift) conflicts still surface early without the noise.