### PR TITLE
fix: bake OTEL_COLLECTOR_TOKEN into Release workflow build

### DIFF
--- a/.changeset/release-otel-token.md
+++ b/.changeset/release-otel-token.md
@@ -1,0 +1,11 @@
+---
+"hevy-mcp": patch
+---
+
+Fix missing OTEL_COLLECTOR_TOKEN in the Release workflow build step.
+
+The Release workflow built the npm package without passing the
+OTEL_COLLECTOR_TOKEN secret, so the published package had an empty
+collector token. This caused the OTLP exporter to be skipped at
+runtime (the `if (collectorToken)` guard in telemetry.ts), meaning
+no traces or metrics were sent to the OTel Collector.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          OTEL_COLLECTOR_TOKEN: ${{ secrets.OTEL_COLLECTOR_TOKEN }}
       - name: Run unit tests
         run: npx vitest run --exclude tests/integration/**
       - name: Run integration tests


### PR DESCRIPTION
## Problem

The published npm package had an empty OTel collector token baked in, so no traces or metrics were being sent to `otel.chrisdoc.dev`.

## Root cause

The **Release workflow** (`release.yml`) builds the package without passing `OTEL_COLLECTOR_TOKEN`:

```yaml
# release.yml — MISSING the token
- run: npm run build
  env:
    SENTRY_ORG: ...
    SENTRY_PROJECT: ...
    SENTRY_AUTH_TOKEN: ...
```

The **Build and Test workflow** (`build-and-test.yml`) does pass it, so CI passes but the npm package ships with an empty token. At runtime, `collectorToken` is `""`, the `if (collectorToken)` guard in `telemetry.ts` skips the OTLP exporter, and nothing reaches the collector.

## Fix

Add `OTEL_COLLECTOR_TOKEN: ${{ secrets.OTEL_COLLECTOR_TOKEN }}` to the `npm run build` env in `release.yml`. Includes a patch changeset to trigger a republish.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Inject OTEL_COLLECTOR_TOKEN secret into Release workflow build to enable telemetry data export in published packages.

Main changes:
- Add OTEL_COLLECTOR_TOKEN environment variable to npm build step in release.yml
- Create changeset documenting fix for missing collector token causing disabled OTLP exporter

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
