### PR TITLE
fix: use env instead of secrets in nightly workflow if conditions

### DIFF
--- a/.github/workflows/nightly-mcp-test.yml
+++ b/.github/workflows/nightly-mcp-test.yml
@@ -16,6 +16,8 @@ jobs:
   mcp-integration-test:
     name: MCP integration test (${{ matrix.launcher.name }})
     runs-on: ubuntu-latest
+    env:
+      NIGHTLY_FAILURE_WEBHOOK_URL: ${{ secrets.NIGHTLY_FAILURE_WEBHOOK_URL }}
     strategy:
       fail-fast: false
       matrix:
@@ -92,9 +94,9 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Send failure webhook notification
-        if: failure() && secrets.NIGHTLY_FAILURE_WEBHOOK_URL != ''
+        if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL != ''
         env:
-          WEBHOOK_URL: ${{ secrets.NIGHTLY_FAILURE_WEBHOOK_URL }}
+          WEBHOOK_URL: ${{ env.NIGHTLY_FAILURE_WEBHOOK_URL }}
           MESSAGE: ${{ steps.failure_summary.outputs.message }}
         run: |
           payload="$(jq -cn --arg msg "$MESSAGE" '{text: $msg, content: $msg}')"
@@ -106,6 +108,6 @@ jobs:
             "$WEBHOOK_URL"
 
       - name: Warn when webhook secret is missing
-        if: failure() && secrets.NIGHTLY_FAILURE_WEBHOOK_URL == ''
+        if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL == ''
         run: |
           echo "::warning::Nightly MCP integration test failed, but NIGHTLY_FAILURE_WEBHOOK_URL is not set. Unable to send webhook notification."


### PR DESCRIPTION
## Problem

The nightly MCP integration test workflow fails with a "workflow file issue" validation error on every push to main.

## Root cause

The `secrets` context is **not available** in step `if:` conditionals in GitHub Actions. The workflow used:

```yaml
if: failure() && secrets.NIGHTLY_FAILURE_WEBHOOK_URL != ''
```

This causes a workflow validation error before any jobs can run.

## Fix

Move `NIGHTLY_FAILURE_WEBHOOK_URL` to job-level `env` and reference `env.NIGHTLY_FAILURE_WEBHOOK_URL` in the `if:` conditions instead:

```yaml
jobs:
  mcp-integration-test:
    env:
      NIGHTLY_FAILURE_WEBHOOK_URL: ${{ secrets.NIGHTLY_FAILURE_WEBHOOK_URL }}
    steps:
      - if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL != ''
      - if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL == ''
```

No changeset needed (CI-only fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly integration workflow to use a job-level environment setting for the failure webhook URL.
  * Failure notifications now send only when a webhook URL is provided, and a warning is shown when it is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Primary changes

- Adds `NIGHTLY_FAILURE_WEBHOOK_URL` at the job level and uses it in the failure-notification conditions.

## Reviewer walkthrough

- Review `.github/workflows/nightly-mcp-test.yml`: the failure webhook and missing-secret warning now check `env.NIGHTLY_FAILURE_WEBHOOK_URL`.

## Correctness and invariants

- The secret remains available only through the job environment, while the notification behavior remains unchanged when the webhook URL is present or absent.

## Testing and QA

- Not run (GitHub Actions workflow-only change).
