### PR TITLE
chore: remove non-functional nightly webhook notification #477

### DIFF
--- a/.github/workflows/nightly-mcp-test.yml
+++ b/.github/workflows/nightly-mcp-test.yml
@@ -16,8 +16,6 @@ jobs:
   mcp-integration-test:
     name: MCP integration test (${{ matrix.launcher.name }})
     runs-on: ubuntu-latest
-    env:
-      NIGHTLY_FAILURE_WEBHOOK_URL: ${{ secrets.NIGHTLY_FAILURE_WEBHOOK_URL }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,52 +60,3 @@ jobs:
           HEVY_API_KEY: ${{ secrets.HEVY_API_KEY }}
           HEVY_MCP_COMMAND: ${{ matrix.launcher.command }}
           HEVY_MCP_ARGS_JSON: ${{ matrix.launcher.args_json }}
-
-      - name: Build failure summary
-        id: failure_summary
-        if: failure()
-        run: |
-          failed_step="Unknown step"
-
-          if [[ "${{ steps.checkout.outcome }}" == "failure" ]]; then
-            failed_step="Checkout repository"
-          elif [[ "${{ steps.setup_node.outcome }}" == "failure" ]]; then
-            failed_step="Set up Node.js"
-          elif [[ "${{ steps.setup_python.outcome }}" == "failure" ]]; then
-            failed_step="Set up Python"
-          elif [[ "${{ steps.install_mcp_use.outcome }}" == "failure" ]]; then
-            failed_step="Install mcp-use"
-          elif [[ "${{ steps.run_mcp_integration_test.outcome }}" == "failure" ]]; then
-            failed_step="Run MCP integration test"
-          fi
-
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          message="Nightly MCP integration test failed for"
-          message="${message} ${{ github.repository }}@${{ github.ref_name }}."
-          message="${message} Failed step: ${failed_step}."
-          message="${message} Run: ${run_url}"
-
-          {
-            echo "message<<EOF"
-            echo "$message"
-            echo "EOF"
-          } >>"$GITHUB_OUTPUT"
-
-      - name: Send failure webhook notification
-        if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL != ''
-        env:
-          WEBHOOK_URL: ${{ env.NIGHTLY_FAILURE_WEBHOOK_URL }}
-          MESSAGE: ${{ steps.failure_summary.outputs.message }}
-        run: |
-          payload="$(jq -cn --arg msg "$MESSAGE" '{text: $msg, content: $msg}')"
-
-          curl --fail --show-error --silent \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "$WEBHOOK_URL"
-
-      - name: Warn when webhook secret is missing
-        if: failure() && env.NIGHTLY_FAILURE_WEBHOOK_URL == ''
-        run: |
-          echo "::warning::Nightly MCP integration test failed, but NIGHTLY_FAILURE_WEBHOOK_URL is not set. Unable to send webhook notification."


### PR DESCRIPTION
Removes the nightly failure webhook from `.github/workflows/nightly-mcp-test.yml`. The webhook step never worked correctly (the workflow file failed validation at the conditional expressions on the failure-summary, send-webhook, and warn-missing-secret steps), and we no longer need it.

Changes:
- Drop the `NIGHTLY_FAILURE_WEBHOOK_URL` job env var.
- Remove the `Build failure summary`, `Send failure webhook notification`, and `Warn when webhook secret is missing` steps.

## Primary changes

- Removes the nightly failure-webhook configuration and its supporting failure-summary, notification, and missing-secret steps.

## Reviewer walkthrough

- Review `.github/workflows/nightly-mcp-test.yml`; the workflow now ends after the MCP integration-test step.

## Correctness and invariants

- The nightly MCP integration test and its required `HEVY_API_KEY` configuration are unchanged; only the non-functional failure-notification path is removed.

## Testing and QA

- Not run (GitHub Actions workflow-only change).

Refs #477
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove non-functional webhook notification logic from nightly MCP integration test workflow due to missing secret configuration.

Main changes:
- Removed `NIGHTLY_FAILURE_WEBHOOK_URL` environment variable from job configuration
- Deleted failure detection, webhook payload construction, and notification delivery steps
- Removed warning message step for missing webhook secret

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
