### PR TITLE
fix: correct snake_case property for get-workout-events mocked test

### DIFF
--- a/.changeset/fix-mocked-events-test-workout-id.md
+++ b/.changeset/fix-mocked-events-test-workout-id.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal test fix: corrected a property name in the new mocked integration test for `get-workout-events` so it matches the raw snake_case API response (`workout_id` rather than `workoutId`).

--- a/tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts
+++ b/tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts
@@ -147,7 +147,7 @@ describe("Hevy MCP workout detail endpoints mocked tests", () => {
 			const payload = JSON.parse(result.text) as Array<{
 				id?: string;
 				type?: string;
-				workoutId?: string;
+				workout_id?: string;
 			}>;
 
 			expect(result.isError).toBeFalsy();
@@ -156,7 +156,7 @@ describe("Hevy MCP workout detail endpoints mocked tests", () => {
 			expect(payload[0]).toMatchObject({
 				id: "event-1",
 				type: "updated",
-				workoutId: "workout-1",
+				workout_id: "workout-1",
 			});
 		} finally {
 			consoleErrorSpy.mockRestore();


### PR DESCRIPTION
## Primary changes

Corrects the mocked `get-workout-events` integration test to expect the raw API property `workout_id` instead of `workoutId`.

## Reviewer walkthrough

Review the updated payload type and assertion in `tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts`.

## Correctness and invariants

`get-workout-events` returns the raw API object without the workout formatter, so the test must preserve the snake_case `workout_id` property expectation.

## Testing and QA

The mocked MCP transport test for `get-workout-events` passes with the corrected assertion; the related mocked `get-workout-count` and `get-workout` tests also pass.

Internal test fix only; uses an empty changeset per `AGENTS.md`.

Refs #488