### PR TITLE
fix: correct live Worker test assertions for numeric routine folder IDs

### DIFF
--- a/.changeset/worker-test-folder-id-types.md
+++ b/.changeset/worker-test-folder-id-types.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Fix live Wrangler Worker integration test assertions for routine folder IDs, which are numeric in the Hevy API but were asserted as strings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hevy-mcp",
-	"version": "2.0.0",
+	"version": "3.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hevy-mcp",
-			"version": "2.0.0",
+			"version": "3.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.29.0",

--- a/tests/integration/worker-http.live.integration.test.ts
+++ b/tests/integration/worker-http.live.integration.test.ts
@@ -268,9 +268,13 @@ function optionalStringId(
 	schemaPath: string,
 ): string | undefined {
 	if (!value?.[0]) return undefined;
-	assertCondition(typeof value[0].id === "string", `${schemaPath}/0/id`);
-	assertCondition(value[0].id.length > 0, `${schemaPath}/0/id`);
-	return value[0].id;
+	const id = value[0].id;
+	assertCondition(
+		typeof id === "string" || typeof id === "number",
+		`${schemaPath}/0/id`,
+	);
+	assertCondition(String(id).length > 0, `${schemaPath}/0/id`);
+	return String(id);
 }
 
 describeLive("live Wrangler Worker HTTP integration", () => {
@@ -460,7 +464,7 @@ describeLive("live Wrangler Worker HTTP integration", () => {
 						"tools/get-routine-folder/routineFolder",
 					);
 					assertCondition(
-						folder.routineFolder.id === folderId,
+						String(folder.routineFolder.id) === folderId,
 						"tools/get-routine-folder/routineFolder/id",
 					);
 				}

--- a/tests/unit/performance-harness.test.ts
+++ b/tests/unit/performance-harness.test.ts
@@ -109,9 +109,18 @@ describe("server RSS observations", () => {
 	});
 
 	it("reads the current process and handles inaccessible process status files", () => {
-		expect(
-			observeServerRss(process.pid, 1, "scenario-complete").rssBytes,
-		).toBeTypeOf("number");
+		if (process.platform === "linux") {
+			expect(
+				observeServerRss(process.pid, 1, "scenario-complete").rssBytes,
+			).toBeTypeOf("number");
+		} else {
+			expect(
+				observeServerRss(process.pid, 1, "scenario-complete"),
+			).toMatchObject({
+				rssBytes: null,
+				unavailableReason: expect.any(String),
+			});
+		}
 		expect(observeServerRss(-1, 2, "initialized")).toMatchObject({
 			rssBytes: null,
 			unavailableReason: expect.any(String),


### PR DESCRIPTION
## Primary changes

- The Hevy API returns `RoutineFolder.id` as a **number** (per `openapi-spec.json`: `RoutineFolder.id.type == "number"`), but the live Wrangler Worker integration test asserted it as a string, causing `get-routine-folders` to fail.
- `optionalStringId` now accepts numeric or string IDs and coerces to string (needed by the string-typed `get-routine-folder` `folderId` parameter).
- Fixed the subsequent `folder.routineFolder.id === folderId` strict comparison, which compared a number to a string, by coercing the numeric ID to string.
- Made the pre-existing `performance-harness` test platform-aware so it passes on non-Linux (macOS) where `/proc` is unavailable; the test is designed for Linux CI.

## Reviewer walkthrough

- `tests/integration/worker-http.live.integration.test.ts` accepts numeric or string routine-folder IDs and compares their normalized string forms.
- `tests/unit/performance-harness.test.ts` verifies the expected unavailable RSS result on platforms without `/proc`.
- `.changeset/worker-test-folder-id-types.md` documents the patch release impact.

## Correctness and invariants

- The live Worker test accepts the API's numeric routine-folder IDs while continuing to pass the string-typed `folderId` parameter to `get-routine-folder`.
- The retrieved routine folder ID and the requested ID are compared in the same string representation.
- RSS observation remains numeric on Linux and reports an unavailable result when process status files are unsupported.

## Testing and QA

- `npx vitest run --exclude tests/integration/**` passes
- `npm run check` passes

🤖 Generated with [opencode](https://opencode.ai)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when routine folder IDs are returned as numbers or strings.
  * Updated performance monitoring behavior to correctly handle platforms where server memory usage is unavailable.

* **Tests**
  * Expanded integration and performance test coverage for ID type variations and platform-specific memory metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix live Worker integration test assertions to handle numeric routine folder IDs from the Hevy API instead of assuming string types.

Main changes:
- Updated `optionalStringId()` helper to accept both string and numeric ID types, converting to string with validation
- Modified routine folder ID assertion to convert numeric ID to string before comparing with folderId parameter
- Added platform-specific conditional in performance harness test to handle Linux process RSS observation differences

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
