### PR TITLE
feat: add optional OAuth 2.1 layer to the Cloudflare Worker for remote MCP clients

### DIFF
--- a/.changeset/oauth-worker-support.md
+++ b/.changeset/oauth-worker-support.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": minor
+---
+
+Add an optional OAuth 2.1 layer to the Cloudflare Worker so remote MCP clients such as Claude.ai custom connectors can connect without a fixed Authorization header. When an `OAUTH_KV` namespace is bound, the Worker serves RFC 8414 / RFC 9728 discovery metadata, dynamic client registration, and PKCE token exchange, plus an `/authorize` page that validates the submitted Hevy API key against Hevy and stores it encrypted inside the OAuth grant. Without the binding, Worker behavior is unchanged, and direct Hevy-API-key bearer requests keep working in both modes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ src/
 ├── cli.ts             # Node.js stdio executable entrypoint
 ├── index.ts           # Node-only stdio server, telemetry, and observability
 ├── worker.ts          # Cloudflare Worker Streamable HTTP entrypoint
+├── worker-oauth.ts    # Optional Worker OAuth 2.1 layer (Claude.ai remote MCP)
 ├── shared-server.ts   # Runtime-neutral shared MCP server construction
 ├── tools/             # MCP tool implementations (+ co-located *.test.ts)
 │   ├── annotations.ts       # Workout annotation tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,9 +251,9 @@ With the binding present, `src/worker-oauth.ts` (backed by
 - `/authorize` (a form that validates the submitted Hevy API key against Hevy
   and stores it encrypted inside the OAuth grant)
 
-Bearer values containing a colon are treated as OAuth access tokens
-(`userId:grantId:secret`); Hevy API keys never contain a colon, so they keep
-using the direct path. With OAuth enabled, unauthenticated `POST /mcp`
+Bearer values matching the OAuth access-token shape (`userId:grantId:secret`)
+are routed to the OAuth layer; Hevy API keys never contain a colon, so they
+keep using the direct path. With OAuth enabled, unauthenticated `POST /mcp`
 requests receive the RFC 9728 challenge (`WWW-Authenticate` with
 `resource_metadata`) instead of the bare `Bearer` challenge so OAuth clients
 can discover the flow. Without the `OAUTH_KV` binding, Worker behavior is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,39 @@ Wildcards are unsupported. Browser requests with an unmatched `Origin` receive
 `403`; non-browser requests without `Origin` remain accepted. Test both origin
 and bearer-auth behavior when changing Worker request handling.
 
+### Optional OAuth layer for remote MCP clients
+
+Clients that cannot send a fixed `Authorization` header (for example Claude.ai
+custom connectors) can use OAuth 2.1 instead. The layer is opt-in per
+deployment: create a KV namespace and bind it as `OAUTH_KV` in
+`wrangler.jsonc`:
+
+```bash
+npx wrangler kv namespace create OAUTH_KV
+```
+
+```jsonc
+"kv_namespaces": [{ "binding": "OAUTH_KV", "id": "<namespace-id>" }]
+```
+
+With the binding present, `src/worker-oauth.ts` (backed by
+`@cloudflare/workers-oauth-provider`) additionally serves:
+
+- `/.well-known/oauth-authorization-server` and
+  `/.well-known/oauth-protected-resource` discovery metadata
+- `/register` (RFC 7591 dynamic client registration)
+- `/token` (authorization code + PKCE and refresh-token grants)
+- `/authorize` (a form that validates the submitted Hevy API key against Hevy
+  and stores it encrypted inside the OAuth grant)
+
+Bearer values containing a colon are treated as OAuth access tokens
+(`userId:grantId:secret`); Hevy API keys never contain a colon, so they keep
+using the direct path. With OAuth enabled, unauthenticated `POST /mcp`
+requests receive the RFC 9728 challenge (`WWW-Authenticate` with
+`resource_metadata`) instead of the bare `Bearer` challenge so OAuth clients
+can discover the flow. Without the `OAUTH_KV` binding, Worker behavior is
+unchanged.
+
 Internal pull requests receive preview Worker deployments through
 `.github/workflows/deploy-worker.yml`. Fork pull requests do not receive
 deployment credentials. Production deployment remains gated by the repository's

--- a/README.md
+++ b/README.md
@@ -367,9 +367,28 @@ The bearer value is your Hevy API key, not an OAuth token. The Worker validates
 the key with Hevy on each request, does not store it, and forwards it upstream
 only as Hevy's required `api-key` header.
 
-The endpoint does not expose legacy SSE or a `GET` event stream. Clients that
-require OAuth discovery, dynamic registration, token refresh, or legacy SSE are
-not compatible unless they can send the fixed custom header above.
+### OAuth for Claude.ai and other remote MCP clients
+
+Workers deployed with an `OAUTH_KV` namespace binding (see
+[CONTRIBUTING.md](./CONTRIBUTING.md)) additionally expose a full OAuth 2.1
+layer for clients that cannot send a fixed header, such as Claude.ai custom
+connectors:
+
+- RFC 8414 / RFC 9728 discovery metadata under `/.well-known/`
+- Dynamic client registration (`/register`) and PKCE token exchange (`/token`)
+- An `/authorize` page where you paste your Hevy API key once; the key is
+  validated with Hevy and stored encrypted inside the OAuth grant
+
+Add the Worker URL ending in `/mcp` as a Claude.ai custom connector and
+complete the authorization flow in the browser. Direct
+`Authorization: Bearer <hevy-api-key>` requests keep working unchanged — the
+OAuth layer is purely additive — and rotating your Hevy API key invalidates
+every OAuth grant created with it.
+
+The endpoint does not expose legacy SSE or a `GET` event stream. Without the
+opt-in OAuth layer, clients that require OAuth discovery, dynamic
+registration, or token refresh are not compatible unless they can send the
+fixed custom header above.
 
 ### Self-host the Worker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "hevy-mcp",
-	"version": "3.1.1",
+	"version": "3.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hevy-mcp",
-			"version": "3.1.1",
+			"version": "3.2.1",
 			"license": "MIT",
 			"dependencies": {
+				"@cloudflare/workers-oauth-provider": "^0.8.2",
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
@@ -171,6 +172,7 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -836,6 +838,12 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/@cloudflare/workers-oauth-provider": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.8.2.tgz",
+			"integrity": "sha512-Pho5qWDl4qj1STI5QYMQfPmJBBkxyrFpXyDl9BrtYOfWHxThabEzdi9p3ezS2cUkbjA0E6L5ki/kq2pcbRUtlg==",
+			"license": "MIT"
+		},
 		"node_modules/@commitlint/cli": {
 			"version": "21.2.1",
 			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
@@ -1296,29 +1304,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -1908,9 +1893,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1928,9 +1910,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1948,9 +1927,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1968,9 +1944,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1988,9 +1961,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2008,9 +1978,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2028,9 +1995,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2048,9 +2012,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2068,9 +2029,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2094,9 +2052,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2120,9 +2075,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2146,9 +2098,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2172,9 +2121,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2198,9 +2144,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2224,9 +2167,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2250,9 +2190,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2977,6 +2914,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
 			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -3010,6 +2948,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
 			"integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -3044,6 +2983,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
 			"integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.9.0",
 				"@opentelemetry/otlp-exporter-base": "0.220.0",
@@ -3063,6 +3003,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
 			"integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.220.0",
 				"import-in-the-middle": "^3.0.0",
@@ -3183,6 +3124,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
 			"integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.9.0",
 				"@opentelemetry/resources": "2.9.0",
@@ -3359,9 +3301,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3379,9 +3318,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3399,9 +3335,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3419,9 +3352,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3439,9 +3369,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3459,9 +3386,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3479,9 +3403,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3499,9 +3420,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3790,9 +3708,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3810,9 +3725,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3830,9 +3742,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3850,9 +3759,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3870,9 +3776,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3890,9 +3793,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3910,9 +3810,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3930,9 +3827,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4303,9 +4197,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4323,9 +4214,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4343,9 +4231,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4363,9 +4248,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4383,9 +4265,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4403,9 +4282,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4999,7 +4875,8 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/node": {
 			"version": "26.1.1",
@@ -5007,6 +4884,7 @@
 			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
@@ -5364,6 +5242,7 @@
 			"integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.10",
@@ -5522,9 +5401,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5538,9 +5414,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5554,9 +5427,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5570,9 +5440,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5586,9 +5453,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5602,9 +5466,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5683,9 +5544,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5699,9 +5557,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5715,9 +5570,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5731,9 +5583,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5747,9 +5596,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5763,9 +5609,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"optional": true,
 			"os": [
 				"linux"
@@ -5853,6 +5696,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -6175,6 +6019,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.42",
 				"caniuse-lite": "^1.0.30001803",
@@ -6565,6 +6410,7 @@
 			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -7162,6 +7008,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -7663,6 +7510,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
 			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -8139,6 +7987,7 @@
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -9407,7 +9256,8 @@
 			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
 			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/ora": {
 			"version": "5.4.1",
@@ -9554,6 +9404,7 @@
 			"integrity": "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"tsgolint": "bin/tsgolint.js"
 			},
@@ -10237,6 +10088,7 @@
 			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@oxc-project/types": "=0.139.0",
 				"@rolldown/pluginutils": "^1.0.0"
@@ -11111,6 +10963,7 @@
 			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -11164,6 +11017,7 @@
 			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc"
 			},
@@ -11230,6 +11084,7 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -11354,6 +11209,7 @@
 			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.10",
 				"@vitest/mocker": "4.1.10",
@@ -11471,6 +11327,7 @@
 			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -11610,6 +11467,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -11920,6 +11778,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,6 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -1304,6 +1303,30 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -2914,7 +2937,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
 			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2948,7 +2970,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
 			"integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -2983,7 +3004,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
 			"integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.9.0",
 				"@opentelemetry/otlp-exporter-base": "0.220.0",
@@ -3003,7 +3023,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
 			"integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.220.0",
 				"import-in-the-middle": "^3.0.0",
@@ -3124,7 +3143,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
 			"integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.9.0",
 				"@opentelemetry/resources": "2.9.0",
@@ -4327,6 +4345,29 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -4875,8 +4916,7 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "26.1.1",
@@ -4884,7 +4924,6 @@
 			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
@@ -5242,7 +5281,6 @@
 			"integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.10",
@@ -5696,7 +5734,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -6019,7 +6056,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.42",
 				"caniuse-lite": "^1.0.30001803",
@@ -6410,7 +6446,6 @@
 			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -7008,7 +7043,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -7510,7 +7544,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
 			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -7987,7 +8020,6 @@
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -9256,8 +9288,7 @@
 			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
 			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/ora": {
 			"version": "5.4.1",
@@ -9404,7 +9435,6 @@
 			"integrity": "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"tsgolint": "bin/tsgolint.js"
 			},
@@ -10088,7 +10118,6 @@
 			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@oxc-project/types": "=0.139.0",
 				"@rolldown/pluginutils": "^1.0.0"
@@ -10963,7 +10992,6 @@
 			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.28.0"
 			},
@@ -11017,7 +11045,6 @@
 			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc"
 			},
@@ -11084,7 +11111,6 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -11209,7 +11235,6 @@
 			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.10",
 				"@vitest/mocker": "4.1.10",
@@ -11327,7 +11352,6 @@
 			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -11467,7 +11491,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -11778,7 +11801,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"worker:dry-run": "wrangler deploy --dry-run --outdir .wrangler/dry-run"
 	},
 	"dependencies": {
+		"@cloudflare/workers-oauth-provider": "^0.8.2",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",

--- a/src/worker-oauth.test.ts
+++ b/src/worker-oauth.test.ts
@@ -1,0 +1,686 @@
+import type {
+	AuthRequest,
+	OAuthHelpers,
+} from "@cloudflare/workers-oauth-provider";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HevyHttpError } from "./utils/hevy-http-error.js";
+import type { HevyClient } from "./utils/hevyClient.js";
+import {
+	decodeAuthRequest,
+	encodeAuthRequest,
+	handleAuthorizeGet,
+	handleAuthorizePost,
+	hasOAuthAccessTokenShape,
+	renderAuthorizePage,
+	type HevyOAuthDependencies,
+} from "./worker-oauth.js";
+import { createWorkerFetchHandler } from "./worker.js";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function createMockClient(overrides: Partial<HevyClient> = {}): HevyClient {
+	return {
+		getUserInfo: vi.fn().mockResolvedValue({ data: { id: "user" } }),
+		...overrides,
+	} as HevyClient;
+}
+
+const sampleAuthRequest: AuthRequest = {
+	responseType: "code",
+	clientId: "client-123",
+	redirectUri: "https://claude.ai/api/mcp/auth_callback",
+	scope: [],
+	state: "state-xyz",
+	codeChallenge: "challenge",
+	codeChallengeMethod: "S256",
+};
+
+type FakeHelpers = Pick<
+	OAuthHelpers,
+	"parseAuthRequest" | "lookupClient" | "completeAuthorization"
+>;
+
+function createFakeHelpers(overrides: Partial<FakeHelpers> = {}): OAuthHelpers {
+	const helpers: FakeHelpers = {
+		parseAuthRequest: vi.fn().mockResolvedValue(sampleAuthRequest),
+		lookupClient: vi.fn().mockResolvedValue({
+			clientId: "client-123",
+			clientName: "Claude",
+			redirectUris: [sampleAuthRequest.redirectUri],
+			tokenEndpointAuthMethod: "none",
+		}),
+		completeAuthorization: vi.fn().mockResolvedValue({
+			redirectTo: `${sampleAuthRequest.redirectUri}?code=abc&state=state-xyz`,
+		}),
+		...overrides,
+	};
+	return helpers as OAuthHelpers;
+}
+
+function createDependencies(
+	overrides: Partial<HevyOAuthDependencies<object>> = {},
+): HevyOAuthDependencies<object> {
+	return {
+		validateApiKey: vi.fn().mockResolvedValue("valid"),
+		serveMcp: vi.fn().mockResolvedValue(new Response("ok")),
+		...overrides,
+	};
+}
+
+function authorizePostRequest(fields: Record<string, string>): Request {
+	return new Request("https://worker.example/authorize", {
+		method: "POST",
+		body: new URLSearchParams(fields),
+	});
+}
+
+describe("OAuth helpers", () => {
+	it.each([
+		["3f2c8a9e-1b7d-4c6a-9e2f-abc123def456", false],
+		["plain-api-key", false],
+		["user:grant:secret", true],
+		["a:b", true],
+	])("classifies bearer value %j as OAuth token: %j", (token, expected) => {
+		expect(hasOAuthAccessTokenShape(token)).toBe(expected);
+	});
+
+	it("round-trips an auth request through encode/decode", () => {
+		const encoded = encodeAuthRequest(sampleAuthRequest);
+		expect(decodeAuthRequest(encoded)).toEqual(sampleAuthRequest);
+	});
+
+	it.each([
+		["not base64 json", "%%%"],
+		["non-object payload", btoa(JSON.stringify("nope"))],
+		["missing clientId", btoa(JSON.stringify({ responseType: "code" }))],
+		[
+			"non-string scope entries",
+			btoa(
+				JSON.stringify({
+					...sampleAuthRequest,
+					scope: [42],
+				}),
+			),
+		],
+	])("rejects tampered auth request payloads: %s", (_label, encoded) => {
+		expect(decodeAuthRequest(encoded)).toBeNull();
+	});
+
+	it("escapes HTML in the authorization page", () => {
+		const page = renderAuthorizePage({
+			clientName: '<script>alert("x")</script>',
+			encodedRequest: 'abc" onmouseover="evil',
+		});
+		expect(page).not.toContain("<script>alert");
+		expect(page).toContain("&lt;script&gt;");
+		expect(page).toContain("abc&quot; onmouseover=&quot;evil");
+	});
+});
+
+describe("authorize endpoint", () => {
+	it("renders the consent form with the client name", async () => {
+		const result = await handleAuthorizeGet(
+			new Request(
+				"https://worker.example/authorize?response_type=code&client_id=client-123",
+			),
+			createFakeHelpers(),
+		);
+		expect(result.status).toBe(200);
+		expect(result.headers.get("content-type")).toContain("text/html");
+		expect(result.headers.get("cache-control")).toBe("no-store");
+		expect(result.headers.get("x-frame-options")).toBe("DENY");
+		const body = await result.text();
+		expect(body).toContain("Claude");
+		expect(body).toContain('name="oauth_request"');
+		expect(body).toContain('name="hevy_api_key"');
+	});
+
+	it("rejects unknown clients", async () => {
+		const result = await handleAuthorizeGet(
+			new Request("https://worker.example/authorize?client_id=nope"),
+			createFakeHelpers({
+				lookupClient: vi.fn().mockResolvedValue(null),
+			}),
+		);
+		expect(result.status).toBe(400);
+	});
+
+	it("completes authorization with encrypted-at-rest props", async () => {
+		const completeAuthorization = vi.fn().mockResolvedValue({
+			redirectTo: `${sampleAuthRequest.redirectUri}?code=abc&state=state-xyz`,
+		});
+		const validateApiKey = vi.fn().mockResolvedValue("valid");
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: " secret-key ",
+			}),
+			{},
+			createFakeHelpers({ completeAuthorization }),
+			createDependencies({ validateApiKey }),
+		);
+
+		expect(result.status).toBe(302);
+		expect(result.headers.get("location")).toContain("code=abc");
+		expect(validateApiKey).toHaveBeenCalledWith("secret-key", {});
+		expect(completeAuthorization).toHaveBeenCalledTimes(1);
+		const options = completeAuthorization.mock.calls[0]?.[0];
+		expect(options?.request).toEqual(sampleAuthRequest);
+		expect(options?.props).toEqual({ hevyApiKey: "secret-key" });
+		// SHA-256 of the API key, never the key itself.
+		expect(options?.userId).toMatch(/^[0-9a-f]{64}$/);
+		expect(options?.userId).not.toContain("secret-key");
+	});
+
+	it("re-renders the form when Hevy rejects the API key", async () => {
+		const completeAuthorization = vi.fn();
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "bad-key",
+			}),
+			{},
+			createFakeHelpers({ completeAuthorization }),
+			createDependencies({
+				validateApiKey: vi.fn().mockResolvedValue("invalid"),
+			}),
+		);
+		expect(result.status).toBe(401);
+		expect(await result.text()).toContain("rejected this API key");
+		expect(completeAuthorization).not.toHaveBeenCalled();
+	});
+
+	it("re-renders with 502 when Hevy is unavailable", async () => {
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "some-key",
+			}),
+			{},
+			createFakeHelpers(),
+			createDependencies({
+				validateApiKey: vi.fn().mockResolvedValue("unavailable"),
+			}),
+		);
+		expect(result.status).toBe(502);
+		expect(await result.text()).toContain("temporarily unavailable");
+	});
+
+	it("rejects submissions without a usable auth request", async () => {
+		const completeAuthorization = vi.fn();
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: "tampered",
+				hevy_api_key: "some-key",
+			}),
+			{},
+			createFakeHelpers({ completeAuthorization }),
+			createDependencies(),
+		);
+		expect(result.status).toBe(400);
+		expect(completeAuthorization).not.toHaveBeenCalled();
+	});
+
+	it("requires an API key before contacting Hevy", async () => {
+		const validateApiKey = vi.fn().mockResolvedValue("valid");
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "   ",
+			}),
+			{},
+			createFakeHelpers(),
+			createDependencies({ validateApiKey }),
+		);
+		expect(result.status).toBe(400);
+		expect(validateApiKey).not.toHaveBeenCalled();
+	});
+});
+
+interface MemoryKVEntry {
+	value: string;
+}
+
+function createMemoryKV() {
+	const store = new Map<string, MemoryKVEntry>();
+	return {
+		store,
+		async get(key: string, options?: { type?: string } | string) {
+			const entry = store.get(key);
+			if (!entry) return null;
+			const type = typeof options === "string" ? options : options?.type;
+			return type === "json" ? JSON.parse(entry.value) : entry.value;
+		},
+		async put(key: string, value: string) {
+			store.set(key, { value });
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+		async list(options?: { prefix?: string }) {
+			const prefix = options?.prefix ?? "";
+			return {
+				keys: [...store.keys()]
+					.filter((name) => name.startsWith(prefix))
+					.map((name) => ({ name })),
+				list_complete: true,
+			};
+		},
+	};
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/, "");
+}
+
+const initializeBody = {
+	jsonrpc: "2.0",
+	id: 1,
+	method: "initialize",
+	params: {
+		protocolVersion: "2025-11-25",
+		capabilities: {},
+		clientInfo: { name: "oauth-test", version: "1" },
+	},
+};
+
+async function parseMcpResponse(response: Response) {
+	const text = await response.text();
+	if (response.headers.get("content-type")?.includes("text/event-stream")) {
+		const data = text
+			.split("\n")
+			.find((line) => line.startsWith("data: "))
+			?.slice(6);
+		if (!data) throw new Error(`Missing SSE data: ${text}`);
+		return JSON.parse(data) as Record<string, unknown>;
+	}
+	return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("OAuth-enabled Worker fetch handler", () => {
+	const redirectUri = "https://claude.ai/api/mcp/auth_callback";
+
+	function createHandlerWithEnv(
+		dependencies: Parameters<typeof createWorkerFetchHandler>[0] = {},
+	) {
+		const handler = createWorkerFetchHandler({
+			createValidationClient: () => createMockClient(),
+			createRequestClient: () => createMockClient(),
+			...dependencies,
+		});
+		const env = { OAUTH_KV: createMemoryKV() };
+		return { handler, env };
+	}
+
+	it("serves OAuth discovery metadata when OAUTH_KV is bound", async () => {
+		const { handler, env } = createHandlerWithEnv();
+		const authServer = await handler(
+			new Request(
+				"https://worker.example/.well-known/oauth-authorization-server",
+			),
+			env,
+			{},
+		);
+		expect(authServer.status).toBe(200);
+		const metadata = (await authServer.json()) as Record<string, unknown>;
+		expect(metadata.authorization_endpoint).toBe(
+			"https://worker.example/authorize",
+		);
+		expect(metadata.token_endpoint).toBe("https://worker.example/token");
+		expect(metadata.registration_endpoint).toBe(
+			"https://worker.example/register",
+		);
+		expect(metadata.code_challenge_methods_supported).toEqual(["S256"]);
+
+		const resource = await handler(
+			new Request(
+				"https://worker.example/.well-known/oauth-protected-resource/mcp",
+			),
+			env,
+			{},
+		);
+		expect(resource.status).toBe(200);
+		const resourceMetadata = (await resource.json()) as Record<string, unknown>;
+		expect(resourceMetadata.resource).toBe("https://worker.example/mcp");
+	});
+
+	it("keeps discovery paths returning 404 without OAUTH_KV", async () => {
+		const { handler } = createHandlerWithEnv();
+		const result = await handler(
+			new Request(
+				"https://worker.example/.well-known/oauth-authorization-server",
+			),
+			{},
+			{},
+		);
+		expect(result.status).toBe(404);
+	});
+
+	it("challenges unauthenticated /mcp requests with resource metadata", async () => {
+		const { handler, env } = createHandlerWithEnv();
+		const result = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: "{}",
+			}),
+			env,
+			{},
+		);
+		expect(result.status).toBe(401);
+		expect(result.headers.get("www-authenticate")).toContain(
+			'resource_metadata="https://worker.example/.well-known/oauth-protected-resource/mcp"',
+		);
+	});
+
+	it("keeps serving raw Hevy API keys on the legacy path", async () => {
+		const createValidationClient = vi.fn(() => createMockClient());
+		const { handler, env } = createHandlerWithEnv({
+			createValidationClient,
+		});
+		const result = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					accept: "application/json, text/event-stream",
+					"content-type": "application/json",
+					authorization: "Bearer raw-hevy-api-key",
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(result.status).toBe(200);
+		expect(createValidationClient).toHaveBeenCalledTimes(1);
+		expect(await parseMcpResponse(result)).toMatchObject({ id: 1 });
+	});
+
+	it("keeps preflight and 405 handling for /mcp unchanged", async () => {
+		const { handler, env } = createHandlerWithEnv();
+		const preflight = await handler(
+			new Request("https://worker.example/mcp", { method: "OPTIONS" }),
+			env,
+			{},
+		);
+		expect(preflight.status).toBe(204);
+		expect(preflight.headers.get("access-control-allow-methods")).toBe(
+			"POST, OPTIONS",
+		);
+
+		const get = await handler(
+			new Request("https://worker.example/mcp", { method: "GET" }),
+			env,
+			{},
+		);
+		expect(get.status).toBe(405);
+	});
+
+	it("rejects disallowed browser origins before the OAuth provider", async () => {
+		const { handler, env } = createHandlerWithEnv();
+		const result = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					origin: "https://browser.example",
+					authorization: "Bearer user:grant:secret",
+				},
+				body: "{}",
+			}),
+			env,
+			{},
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it("completes the full OAuth flow and serves MCP requests", async () => {
+		const { handler, env } = createHandlerWithEnv();
+
+		// 1. Dynamic client registration (RFC 7591), as Claude.ai performs it.
+		const registration = await handler(
+			new Request("https://worker.example/register", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					client_name: "Claude",
+					redirect_uris: [redirectUri],
+					token_endpoint_auth_method: "none",
+				}),
+			}),
+			env,
+			{},
+		);
+		expect(registration.status).toBe(201);
+		const client = (await registration.json()) as { client_id: string };
+		expect(client.client_id).toBeTruthy();
+
+		// 2. Authorization request renders the consent form.
+		const verifier = base64UrlEncode(
+			crypto.getRandomValues(new Uint8Array(32)),
+		);
+		const challenge = base64UrlEncode(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
+		const authorizeUrl = new URL("https://worker.example/authorize");
+		authorizeUrl.searchParams.set("response_type", "code");
+		authorizeUrl.searchParams.set("client_id", client.client_id);
+		authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+		authorizeUrl.searchParams.set("state", "state-123");
+		authorizeUrl.searchParams.set("code_challenge", challenge);
+		authorizeUrl.searchParams.set("code_challenge_method", "S256");
+		const consent = await handler(new Request(authorizeUrl), env, {});
+		expect(consent.status).toBe(200);
+		const consentHtml = await consent.text();
+		const encodedRequest = /name="oauth_request" value="([^"]+)"/.exec(
+			consentHtml,
+		)?.[1];
+		expect(encodedRequest).toBeTruthy();
+
+		// 3. The user submits their Hevy API key.
+		const approval = await handler(
+			new Request("https://worker.example/authorize", {
+				method: "POST",
+				body: new URLSearchParams({
+					oauth_request: encodedRequest as string,
+					hevy_api_key: "users-hevy-api-key",
+				}),
+			}),
+			env,
+			{},
+		);
+		expect(approval.status).toBe(302);
+		const redirect = new URL(approval.headers.get("location") as string);
+		expect(redirect.origin + redirect.pathname).toBe(redirectUri);
+		expect(redirect.searchParams.get("state")).toBe("state-123");
+		const code = redirect.searchParams.get("code");
+		expect(code).toBeTruthy();
+
+		// 4. Authorization code + PKCE verifier exchange for tokens.
+		const tokenResult = await handler(
+			new Request("https://worker.example/token", {
+				method: "POST",
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					code: code as string,
+					redirect_uri: redirectUri,
+					client_id: client.client_id,
+					code_verifier: verifier,
+				}),
+			}),
+			env,
+			{},
+		);
+		expect(tokenResult.status).toBe(200);
+		const tokens = (await tokenResult.json()) as {
+			access_token: string;
+			refresh_token?: string;
+			token_type: string;
+		};
+		expect(tokens.token_type.toLowerCase()).toBe("bearer");
+		expect(hasOAuthAccessTokenShape(tokens.access_token)).toBe(true);
+		expect(tokens.access_token).not.toContain("users-hevy-api-key");
+
+		// The Hevy API key is never stored in plaintext in KV.
+		const kvDump = JSON.stringify([...env.OAUTH_KV.store.entries()]);
+		expect(kvDump).not.toContain("users-hevy-api-key");
+
+		// 5. The access token authorizes MCP requests.
+		const requestClients: string[] = [];
+		const { handler: mcpHandler } = createHandlerWithEnv({
+			createRequestClient: (apiKey: string) => {
+				requestClients.push(apiKey);
+				return createMockClient();
+			},
+		});
+		const mcpResult = await mcpHandler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					accept: "application/json, text/event-stream",
+					"content-type": "application/json",
+					authorization: `Bearer ${tokens.access_token}`,
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(mcpResult.status).toBe(200);
+		expect(await parseMcpResponse(mcpResult)).toMatchObject({ id: 1 });
+		// The decrypted grant props resupply the original Hevy API key.
+		expect(requestClients).toEqual(["users-hevy-api-key"]);
+
+		// 6. A bogus OAuth-shaped token is rejected with a challenge.
+		const rejected = await mcpHandler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					authorization: "Bearer forged:token:value",
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(rejected.status).toBe(401);
+	});
+
+	it("returns 401 when the stored Hevy API key was revoked upstream", async () => {
+		const revokedValidation = vi.fn(() =>
+			createMockClient({
+				getUserInfo: vi.fn().mockRejectedValue(
+					new HevyHttpError("HTTP 401", {
+						status: 401,
+						method: "GET",
+						endpoint: "/v1/user/info",
+					}),
+				),
+			}),
+		);
+		const validValidation = vi.fn(() => createMockClient());
+		let validationFactory = validValidation;
+		const { handler, env } = createHandlerWithEnv({
+			createValidationClient: () => validationFactory(),
+		});
+
+		const registration = await handler(
+			new Request("https://worker.example/register", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					redirect_uris: [redirectUri],
+					token_endpoint_auth_method: "none",
+				}),
+			}),
+			env,
+			{},
+		);
+		const client = (await registration.json()) as { client_id: string };
+		const verifier = base64UrlEncode(
+			crypto.getRandomValues(new Uint8Array(32)),
+		);
+		const challenge = base64UrlEncode(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
+		const authorizeUrl = new URL("https://worker.example/authorize");
+		authorizeUrl.searchParams.set("response_type", "code");
+		authorizeUrl.searchParams.set("client_id", client.client_id);
+		authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+		authorizeUrl.searchParams.set("state", "s");
+		authorizeUrl.searchParams.set("code_challenge", challenge);
+		authorizeUrl.searchParams.set("code_challenge_method", "S256");
+		const consentHtml = await (
+			await handler(new Request(authorizeUrl), env, {})
+		).text();
+		const encodedRequest = /name="oauth_request" value="([^"]+)"/.exec(
+			consentHtml,
+		)?.[1] as string;
+		const approval = await handler(
+			new Request("https://worker.example/authorize", {
+				method: "POST",
+				body: new URLSearchParams({
+					oauth_request: encodedRequest,
+					hevy_api_key: "soon-revoked-key",
+				}),
+			}),
+			env,
+			{},
+		);
+		const code = new URL(
+			approval.headers.get("location") as string,
+		).searchParams.get("code") as string;
+		const tokens = (await (
+			await handler(
+				new Request("https://worker.example/token", {
+					method: "POST",
+					body: new URLSearchParams({
+						grant_type: "authorization_code",
+						code,
+						redirect_uri: redirectUri,
+						client_id: client.client_id,
+						code_verifier: verifier,
+					}),
+				}),
+				env,
+				{},
+			)
+		).json()) as { access_token: string };
+
+		// The key gets revoked in Hevy after the grant was issued.
+		validationFactory = revokedValidation;
+		const result = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${tokens.access_token}`,
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(result.status).toBe(401);
+		expect(result.headers.get("www-authenticate")).toContain(
+			'error="invalid_token"',
+		);
+	});
+});

--- a/src/worker-oauth.test.ts
+++ b/src/worker-oauth.test.ts
@@ -81,7 +81,9 @@ describe("OAuth helpers", () => {
 		["3f2c8a9e-1b7d-4c6a-9e2f-abc123def456", false],
 		["plain-api-key", false],
 		["user:grant:secret", true],
-		["a:b", true],
+		["a:b", false],
+		["a:b:c:d", false],
+		["::secret", false],
 	])("classifies bearer value %j as OAuth token: %j", (token, expected) => {
 		expect(hasOAuthAccessTokenShape(token)).toBe(expected);
 	});
@@ -101,6 +103,33 @@ describe("OAuth helpers", () => {
 				JSON.stringify({
 					...sampleAuthRequest,
 					scope: [42],
+				}),
+			),
+		],
+		[
+			"missing PKCE code challenge",
+			btoa(
+				JSON.stringify({
+					...sampleAuthRequest,
+					codeChallenge: undefined,
+				}),
+			),
+		],
+		[
+			"plain PKCE method",
+			btoa(
+				JSON.stringify({
+					...sampleAuthRequest,
+					codeChallengeMethod: "plain",
+				}),
+			),
+		],
+		[
+			"implicit flow response type",
+			btoa(
+				JSON.stringify({
+					...sampleAuthRequest,
+					responseType: "token",
 				}),
 			),
 		],
@@ -135,6 +164,45 @@ describe("authorize endpoint", () => {
 		expect(body).toContain("Claude");
 		expect(body).toContain('name="oauth_request"');
 		expect(body).toContain('name="hevy_api_key"');
+	});
+
+	it("rejects authorization requests without a PKCE challenge", async () => {
+		const result = await handleAuthorizeGet(
+			new Request(
+				"https://worker.example/authorize?response_type=code&client_id=client-123",
+			),
+			createFakeHelpers({
+				parseAuthRequest: vi.fn().mockResolvedValue({
+					...sampleAuthRequest,
+					codeChallenge: undefined,
+				}),
+			}),
+		);
+		expect(result.status).toBe(400);
+		expect(await result.text()).toContain("PKCE");
+	});
+
+	it("returns a safe 502 when completing authorization fails", async () => {
+		const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "some-key",
+			}),
+			{},
+			createFakeHelpers({
+				completeAuthorization: vi
+					.fn()
+					.mockRejectedValue(new Error("kv exploded")),
+			}),
+			createDependencies(),
+		);
+		expect(result.status).toBe(502);
+		expect(await result.text()).toContain("could not be completed");
+		const diagnostic = JSON.stringify(stderrSpy.mock.calls);
+		expect(diagnostic).toContain("oauth-complete-authorization");
+		expect(diagnostic).not.toContain("kv exploded");
+		stderrSpy.mockRestore();
 	});
 
 	it("rejects unknown clients", async () => {
@@ -363,6 +431,40 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		expect(result.status).toBe(404);
 	});
 
+	it("falls back to legacy behavior when OAUTH_KV is not a KV namespace", async () => {
+		const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { handler } = createHandlerWithEnv();
+		const env = { OAUTH_KV: "not-a-kv-namespace" };
+
+		const discovery = await handler(
+			new Request(
+				"https://worker.example/.well-known/oauth-authorization-server",
+			),
+			env,
+			{},
+		);
+		expect(discovery.status).toBe(404);
+
+		const legacy = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					accept: "application/json, text/event-stream",
+					"content-type": "application/json",
+					authorization: "Bearer raw-hevy-api-key",
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(legacy.status).toBe(200);
+		expect(JSON.stringify(stderrSpy.mock.calls)).toContain(
+			"oauth-kv-misconfigured",
+		);
+		stderrSpy.mockRestore();
+	});
+
 	it("challenges unauthenticated /mcp requests with resource metadata", async () => {
 		const { handler, env } = createHandlerWithEnv();
 		const result = await handler(
@@ -531,6 +633,7 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		expect(tokens.token_type.toLowerCase()).toBe("bearer");
 		expect(hasOAuthAccessTokenShape(tokens.access_token)).toBe(true);
 		expect(tokens.access_token).not.toContain("users-hevy-api-key");
+		expect(tokens.refresh_token).toBeTruthy();
 
 		// The Hevy API key is never stored in plaintext in KV.
 		const kvDump = JSON.stringify([...env.OAUTH_KV.store.entries()]);
@@ -562,7 +665,43 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		// The decrypted grant props resupply the original Hevy API key.
 		expect(requestClients).toEqual(["users-hevy-api-key"]);
 
-		// 6. A bogus OAuth-shaped token is rejected with a challenge.
+		// 6. The refresh-token grant issues a new working access token.
+		const refreshResult = await handler(
+			new Request("https://worker.example/token", {
+				method: "POST",
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: tokens.refresh_token as string,
+					client_id: client.client_id,
+				}),
+			}),
+			env,
+			{},
+		);
+		expect(refreshResult.status).toBe(200);
+		const refreshed = (await refreshResult.json()) as {
+			access_token: string;
+		};
+		const refreshedMcpResult = await mcpHandler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					accept: "application/json, text/event-stream",
+					"content-type": "application/json",
+					authorization: `Bearer ${refreshed.access_token}`,
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			{},
+		);
+		expect(refreshedMcpResult.status).toBe(200);
+		expect(requestClients).toEqual([
+			"users-hevy-api-key",
+			"users-hevy-api-key",
+		]);
+
+		// 7. A bogus OAuth-shaped token is rejected with a challenge.
 		const rejected = await mcpHandler(
 			new Request("https://worker.example/mcp", {
 				method: "POST",

--- a/src/worker-oauth.ts
+++ b/src/worker-oauth.ts
@@ -113,8 +113,11 @@ const HTML_RESPONSE_HEADERS: Record<string, string> = {
 	"Cache-Control": "no-store",
 	"X-Frame-Options": "DENY",
 	"Referrer-Policy": "no-referrer",
+	// No form-action directive: Chrome applies it to the redirect that
+	// follows the form submission, which would block the 302 back to the
+	// OAuth client's redirect_uri (e.g. claude.ai) after approval.
 	"Content-Security-Policy":
-		"default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; " +
+		"default-src 'none'; style-src 'unsafe-inline'; " +
 		"frame-ancestors 'none'; base-uri 'none'",
 };
 

--- a/src/worker-oauth.ts
+++ b/src/worker-oauth.ts
@@ -1,0 +1,400 @@
+import {
+	type AuthRequest,
+	OAuthProvider,
+	type OAuthHelpers,
+} from "@cloudflare/workers-oauth-provider";
+
+const MCP_PATH = "/mcp";
+const AUTHORIZE_PATH = "/authorize";
+const TOKEN_PATH = "/token";
+const REGISTER_PATH = "/register";
+
+/** Outcome of checking a Hevy API key against the upstream Hevy API. */
+export type HevyApiKeyValidation =
+	| "valid"
+	| "invalid"
+	| "unavailable"
+	| "config-error";
+
+/**
+ * Hevy-specific behavior injected by the Worker entrypoint so this module
+ * stays focused on the OAuth flow itself.
+ */
+export interface HevyOAuthDependencies<Env> {
+	validateApiKey(apiKey: string, env: Env): Promise<HevyApiKeyValidation>;
+	serveMcp(request: Request, env: Env, apiKey: string): Promise<Response>;
+}
+
+/** Grant props stored (encrypted) by the OAuth provider for each grant. */
+export interface HevyGrantProps {
+	hevyApiKey: string;
+	[key: string]: unknown;
+}
+
+interface OAuthProviderEnv {
+	OAUTH_PROVIDER: OAuthHelpers;
+}
+
+export interface HevyOAuthWorker<Env> {
+	fetch(request: Request, env: Env, ctx: object): Promise<Response>;
+}
+
+/**
+ * Access tokens minted by the OAuth provider always have the shape
+ * `userId:grantId:secret`. Hevy API keys never contain a colon, so the
+ * presence of one is what routes a bearer value to the OAuth layer instead
+ * of the legacy direct-API-key path.
+ */
+export function hasOAuthAccessTokenShape(token: string): boolean {
+	return token.includes(":");
+}
+
+export function isOAuthEnabled(env: { OAUTH_KV?: unknown }): boolean {
+	return env.OAUTH_KV != null;
+}
+
+async function deriveUserId(apiKey: string): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(apiKey),
+	);
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+export function encodeAuthRequest(authRequest: AuthRequest): string {
+	const bytes = new TextEncoder().encode(JSON.stringify(authRequest));
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/, "");
+}
+
+export function decodeAuthRequest(encoded: string): AuthRequest | null {
+	let parsed: unknown;
+	try {
+		const base64 = encoded.replaceAll("-", "+").replaceAll("_", "/");
+		const binary = atob(base64);
+		const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+		parsed = JSON.parse(new TextDecoder().decode(bytes));
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const candidate = parsed as Record<string, unknown>;
+	if (
+		typeof candidate.responseType !== "string" ||
+		typeof candidate.clientId !== "string" ||
+		candidate.clientId === "" ||
+		typeof candidate.redirectUri !== "string" ||
+		typeof candidate.state !== "string" ||
+		!Array.isArray(candidate.scope) ||
+		candidate.scope.some((scope) => typeof scope !== "string")
+	) {
+		return null;
+	}
+	return candidate as unknown as AuthRequest;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+const HTML_RESPONSE_HEADERS: Record<string, string> = {
+	"Content-Type": "text/html; charset=utf-8",
+	"Cache-Control": "no-store",
+	"X-Frame-Options": "DENY",
+	"Referrer-Policy": "no-referrer",
+	"Content-Security-Policy":
+		"default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; " +
+		"frame-ancestors 'none'; base-uri 'none'",
+};
+
+function htmlResponse(body: string, status = 200): Response {
+	return new Response(body, { status, headers: HTML_RESPONSE_HEADERS });
+}
+
+const AUTHORIZE_PAGE_STYLES = `
+	:root { color-scheme: light dark; }
+	body {
+		font-family: system-ui, -apple-system, sans-serif;
+		background: #f4f4f5; color: #18181b;
+		display: flex; justify-content: center;
+		margin: 0; padding: 2rem 1rem; min-height: 100vh;
+		box-sizing: border-box;
+	}
+	main {
+		background: #ffffff; border: 1px solid #e4e4e7; border-radius: 12px;
+		padding: 2rem; max-width: 26rem; width: 100%;
+		height: fit-content; box-sizing: border-box;
+	}
+	h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+	p { line-height: 1.5; margin: 0 0 1rem; }
+	label { display: block; font-weight: 600; margin-bottom: 0.5rem; }
+	input[type="password"] {
+		width: 100%; box-sizing: border-box; font-size: 1rem;
+		padding: 0.6rem 0.75rem; margin-bottom: 1rem;
+		border: 1px solid #d4d4d8; border-radius: 8px;
+		background: inherit; color: inherit;
+	}
+	button {
+		width: 100%; font-size: 1rem; font-weight: 600;
+		padding: 0.7rem; border: none; border-radius: 8px;
+		background: #2563eb; color: #ffffff; cursor: pointer;
+	}
+	.error {
+		background: #fef2f2; border: 1px solid #fecaca; color: #b91c1c;
+		border-radius: 8px; padding: 0.75rem; margin-bottom: 1rem;
+	}
+	.hint { font-size: 0.875rem; color: #52525b; }
+	a { color: #2563eb; }
+	@media (prefers-color-scheme: dark) {
+		body { background: #18181b; color: #fafafa; }
+		main { background: #27272a; border-color: #3f3f46; }
+		input[type="password"] { border-color: #52525b; }
+		.error { background: #450a0a; border-color: #7f1d1d; color: #fca5a5; }
+		.hint { color: #a1a1aa; }
+	}
+`;
+
+export interface AuthorizePageOptions {
+	clientName: string;
+	encodedRequest: string;
+	error?: string;
+}
+
+export function renderAuthorizePage(options: AuthorizePageOptions): string {
+	const clientName = escapeHtml(options.clientName);
+	const encodedRequest = escapeHtml(options.encodedRequest);
+	const errorBanner = options.error
+		? `<div class="error">${escapeHtml(options.error)}</div>`
+		: "";
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Connect ${clientName} to Hevy</title>
+<style>${AUTHORIZE_PAGE_STYLES}</style>
+</head>
+<body>
+<main>
+<h1>Connect to Hevy</h1>
+<p><strong>${clientName}</strong> is requesting access to your Hevy account
+through the hevy-mcp server.</p>
+${errorBanner}
+<form method="post" action="${AUTHORIZE_PATH}">
+<input type="hidden" name="oauth_request" value="${encodedRequest}">
+<label for="hevy_api_key">Hevy API key</label>
+<input type="password" id="hevy_api_key" name="hevy_api_key"
+	autocomplete="off" required>
+<button type="submit">Connect</button>
+</form>
+<p class="hint">Find your API key at
+<a href="https://hevy.com/settings?developer" rel="noreferrer">
+hevy.com/settings &rarr; Developer</a> (requires Hevy Pro). The key is
+validated with Hevy and stored encrypted for this connection only. Rotating
+the key in Hevy revokes access.</p>
+</main>
+</body>
+</html>`;
+}
+
+function authorizeErrorResponse(message: string, status: number): Response {
+	return htmlResponse(
+		`<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+			`<title>Authorization error</title></head>` +
+			`<body><p>${escapeHtml(message)}</p></body></html>`,
+		status,
+	);
+}
+
+export async function handleAuthorizeGet(
+	request: Request,
+	helpers: OAuthHelpers,
+): Promise<Response> {
+	let authRequest: AuthRequest;
+	try {
+		authRequest = await helpers.parseAuthRequest(request);
+	} catch {
+		return authorizeErrorResponse("Invalid authorization request.", 400);
+	}
+	if (!authRequest.clientId) {
+		return authorizeErrorResponse("Invalid authorization request.", 400);
+	}
+	const client = await helpers.lookupClient(authRequest.clientId);
+	if (!client) {
+		return authorizeErrorResponse("Unknown OAuth client.", 400);
+	}
+	return htmlResponse(
+		renderAuthorizePage({
+			clientName: client.clientName?.trim() || client.clientId,
+			encodedRequest: encodeAuthRequest(authRequest),
+		}),
+	);
+}
+
+export async function handleAuthorizePost<Env>(
+	request: Request,
+	env: Env,
+	helpers: OAuthHelpers,
+	dependencies: HevyOAuthDependencies<Env>,
+): Promise<Response> {
+	let form: FormData;
+	try {
+		form = await request.formData();
+	} catch {
+		return authorizeErrorResponse("Invalid form submission.", 400);
+	}
+	const encodedRequest = form.get("oauth_request");
+	const authRequest =
+		typeof encodedRequest === "string"
+			? decodeAuthRequest(encodedRequest)
+			: null;
+	if (!authRequest) {
+		return authorizeErrorResponse("Invalid authorization request.", 400);
+	}
+	const client = await helpers.lookupClient(authRequest.clientId);
+	if (!client) {
+		return authorizeErrorResponse("Unknown OAuth client.", 400);
+	}
+	const clientName = client.clientName?.trim() || client.clientId;
+	const rerender = (error: string, status: number): Response =>
+		htmlResponse(
+			renderAuthorizePage({
+				clientName,
+				encodedRequest: encodedRequest as string,
+				error,
+			}),
+			status,
+		);
+
+	const apiKeyEntry = form.get("hevy_api_key");
+	const apiKey = typeof apiKeyEntry === "string" ? apiKeyEntry.trim() : "";
+	if (!apiKey) return rerender("Enter your Hevy API key.", 400);
+
+	const validation = await dependencies.validateApiKey(apiKey, env);
+	if (validation === "config-error") {
+		return new Response("Worker configuration error", { status: 500 });
+	}
+	if (validation === "unavailable") {
+		return rerender(
+			"Hevy is temporarily unavailable. Please try again in a moment.",
+			502,
+		);
+	}
+	if (validation === "invalid") {
+		return rerender(
+			"Hevy rejected this API key. Check the key and try again.",
+			401,
+		);
+	}
+
+	const props: HevyGrantProps = { hevyApiKey: apiKey };
+	const { redirectTo } = await helpers.completeAuthorization({
+		request: authRequest,
+		userId: await deriveUserId(apiKey),
+		metadata: {},
+		scope: authRequest.scope,
+		props,
+	});
+	return new Response(null, {
+		status: 302,
+		headers: { Location: redirectTo, "Cache-Control": "no-store" },
+	});
+}
+
+function oauthUnauthorizedResponse(request: Request): Response {
+	const url = new URL(request.url);
+	const resourceMetadataUrl =
+		`${url.origin}/.well-known/oauth-protected-resource` + url.pathname;
+	return new Response("Unauthorized", {
+		status: 401,
+		headers: {
+			"WWW-Authenticate":
+				'Bearer error="invalid_token", ' +
+				'error_description="The Hevy API key behind this grant is no ' +
+				'longer valid", ' +
+				`resource_metadata="${resourceMetadataUrl}"`,
+		},
+	});
+}
+
+async function handleAuthorizedMcpRequest<Env>(
+	request: Request,
+	env: Env,
+	ctx: object,
+	dependencies: HevyOAuthDependencies<Env>,
+): Promise<Response> {
+	const props = (ctx as { props?: Partial<HevyGrantProps> }).props;
+	const apiKey =
+		typeof props?.hevyApiKey === "string" ? props.hevyApiKey : null;
+	if (!apiKey) return oauthUnauthorizedResponse(request);
+
+	const validation = await dependencies.validateApiKey(apiKey, env);
+	if (validation === "config-error") {
+		return new Response("Worker configuration error", { status: 500 });
+	}
+	if (validation === "invalid") return oauthUnauthorizedResponse(request);
+	if (validation === "unavailable") {
+		return new Response("Hevy API is temporarily unavailable", {
+			status: 502,
+		});
+	}
+	return dependencies.serveMcp(request, env, apiKey);
+}
+
+/**
+ * Build the OAuth provider that fronts the Worker when an `OAUTH_KV`
+ * namespace is bound. It implements OAuth 2.1 authorization code flow with
+ * PKCE, dynamic client registration, and RFC 8414 / RFC 9728 discovery
+ * metadata, which is what remote MCP clients such as Claude.ai require.
+ */
+export function createHevyOAuthProvider<Env extends object>(
+	dependencies: HevyOAuthDependencies<Env>,
+): HevyOAuthWorker<Env> {
+	const provider = new OAuthProvider({
+		apiRoute: MCP_PATH,
+		apiHandler: {
+			fetch: (request: Request, env: Env, ctx: object) =>
+				handleAuthorizedMcpRequest(request, env, ctx, dependencies),
+		},
+		defaultHandler: {
+			fetch: async (request: Request, env: Env & OAuthProviderEnv) => {
+				const url = new URL(request.url);
+				if (url.pathname !== AUTHORIZE_PATH) {
+					return new Response("Not found", { status: 404 });
+				}
+				if (request.method === "GET") {
+					return handleAuthorizeGet(request, env.OAUTH_PROVIDER);
+				}
+				if (request.method === "POST") {
+					return handleAuthorizePost(
+						request,
+						env,
+						env.OAUTH_PROVIDER,
+						dependencies,
+					);
+				}
+				return new Response("Method not allowed", {
+					status: 405,
+					headers: { Allow: "GET, POST" },
+				});
+			},
+		},
+		authorizeEndpoint: AUTHORIZE_PATH,
+		tokenEndpoint: TOKEN_PATH,
+		clientRegistrationEndpoint: REGISTER_PATH,
+		allowPlainPKCE: false,
+		resourceMetadata: { resource_name: "Hevy MCP Server" },
+	});
+	return provider as unknown as HevyOAuthWorker<Env>;
+}

--- a/src/worker-oauth.ts
+++ b/src/worker-oauth.ts
@@ -3,6 +3,8 @@ import {
 	OAuthProvider,
 	type OAuthHelpers,
 } from "@cloudflare/workers-oauth-provider";
+import { z } from "zod";
+import { createSafeErrorDiagnostic } from "./utils/safe-error-diagnostic.js";
 
 const MCP_PATH = "/mcp";
 const AUTHORIZE_PATH = "/authorize";
@@ -41,16 +43,33 @@ export interface HevyOAuthWorker<Env> {
 
 /**
  * Access tokens minted by the OAuth provider always have the shape
- * `userId:grantId:secret`. Hevy API keys never contain a colon, so the
- * presence of one is what routes a bearer value to the OAuth layer instead
- * of the legacy direct-API-key path.
+ * `userId:grantId:secret`. Hevy API keys never contain a colon, so a
+ * bearer value matching this shape routes to the OAuth layer while
+ * everything else keeps using the legacy direct-API-key path.
  */
 export function hasOAuthAccessTokenShape(token: string): boolean {
-	return token.includes(":");
+	return /^[^:]+:[^:]+:[^:]+$/.test(token);
 }
 
+function isKvNamespaceLike(value: unknown): boolean {
+	if (typeof value !== "object" || value === null) return false;
+	const kv = value as Record<string, unknown>;
+	return (
+		typeof kv.get === "function" &&
+		typeof kv.put === "function" &&
+		typeof kv.delete === "function" &&
+		typeof kv.list === "function"
+	);
+}
+
+/**
+ * OAuth is enabled only when OAUTH_KV is bound to something that actually
+ * looks like a KV namespace. A misconfigured binding (e.g. a plain string
+ * var) must not route requests into the OAuth provider, where it would
+ * fail at runtime.
+ */
 export function isOAuthEnabled(env: { OAUTH_KV?: unknown }): boolean {
-	return env.OAUTH_KV != null;
+	return isKvNamespaceLike(env.OAUTH_KV);
 }
 
 async function deriveUserId(apiKey: string): Promise<string> {
@@ -73,6 +92,31 @@ export function encodeAuthRequest(authRequest: AuthRequest): string {
 		.replace(/=+$/, "");
 }
 
+/**
+ * Shape an authorization request must have before this Worker completes it.
+ * PKCE with S256 is mandatory (the MCP authorization spec requires PKCE):
+ * without a stored code challenge the provider would treat the grant as
+ * non-PKCE and allow the authorization code to be redeemed without a
+ * verifier. `parseAuthRequest` output (`state` always a string, possibly
+ * empty) and round-tripped payloads both satisfy this schema; unknown
+ * fields such as `resource` pass through untouched.
+ */
+const authRequestSchema = z.looseObject({
+	responseType: z.literal("code"),
+	clientId: z.string().min(1),
+	redirectUri: z.string().min(1),
+	scope: z.array(z.string()),
+	state: z.string(),
+	codeChallenge: z.string().min(1),
+	codeChallengeMethod: z.literal("S256"),
+	resource: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
+export function validateAuthRequest(value: unknown): AuthRequest | null {
+	const result = authRequestSchema.safeParse(value);
+	return result.success ? result.data : null;
+}
+
 export function decodeAuthRequest(encoded: string): AuthRequest | null {
 	let parsed: unknown;
 	try {
@@ -83,20 +127,7 @@ export function decodeAuthRequest(encoded: string): AuthRequest | null {
 	} catch {
 		return null;
 	}
-	if (typeof parsed !== "object" || parsed === null) return null;
-	const candidate = parsed as Record<string, unknown>;
-	if (
-		typeof candidate.responseType !== "string" ||
-		typeof candidate.clientId !== "string" ||
-		candidate.clientId === "" ||
-		typeof candidate.redirectUri !== "string" ||
-		typeof candidate.state !== "string" ||
-		!Array.isArray(candidate.scope) ||
-		candidate.scope.some((scope) => typeof scope !== "string")
-	) {
-		return null;
-	}
-	return candidate as unknown as AuthRequest;
+	return validateAuthRequest(parsed);
 }
 
 function escapeHtml(value: string): string {
@@ -224,14 +255,19 @@ export async function handleAuthorizeGet(
 	request: Request,
 	helpers: OAuthHelpers,
 ): Promise<Response> {
-	let authRequest: AuthRequest;
+	let parsedRequest: AuthRequest;
 	try {
-		authRequest = await helpers.parseAuthRequest(request);
+		parsedRequest = await helpers.parseAuthRequest(request);
 	} catch {
 		return authorizeErrorResponse("Invalid authorization request.", 400);
 	}
-	if (!authRequest.clientId) {
-		return authorizeErrorResponse("Invalid authorization request.", 400);
+	const authRequest = validateAuthRequest(parsedRequest);
+	if (!authRequest) {
+		return authorizeErrorResponse(
+			"Invalid authorization request. This server requires the " +
+				"authorization code flow with PKCE (S256 code challenge).",
+			400,
+		);
 	}
 	const client = await helpers.lookupClient(authRequest.clientId);
 	if (!client) {
@@ -301,18 +337,29 @@ export async function handleAuthorizePost<Env>(
 		);
 	}
 
-	const props: HevyGrantProps = { hevyApiKey: apiKey };
-	const { redirectTo } = await helpers.completeAuthorization({
-		request: authRequest,
-		userId: await deriveUserId(apiKey),
-		metadata: {},
-		scope: authRequest.scope,
-		props,
-	});
-	return new Response(null, {
-		status: 302,
-		headers: { Location: redirectTo, "Cache-Control": "no-store" },
-	});
+	try {
+		const props: HevyGrantProps = { hevyApiKey: apiKey };
+		const { redirectTo } = await helpers.completeAuthorization({
+			request: authRequest,
+			userId: await deriveUserId(apiKey),
+			metadata: {},
+			scope: authRequest.scope,
+			props,
+		});
+		return new Response(null, {
+			status: 302,
+			headers: { Location: redirectTo, "Cache-Control": "no-store" },
+		});
+	} catch (error) {
+		console.error("Cloudflare Worker failure", {
+			context: "oauth-complete-authorization",
+			...createSafeErrorDiagnostic(error),
+		});
+		return authorizeErrorResponse(
+			"Authorization could not be completed. Please try again.",
+			502,
+		);
+	}
 }
 
 function oauthUnauthorizedResponse(request: Request): Response {
@@ -337,7 +384,8 @@ async function handleAuthorizedMcpRequest<Env>(
 	ctx: object,
 	dependencies: HevyOAuthDependencies<Env>,
 ): Promise<Response> {
-	const props = (ctx as { props?: Partial<HevyGrantProps> }).props;
+	const props = (ctx as { props?: Partial<HevyGrantProps> } | null | undefined)
+		?.props;
 	const apiKey =
 		typeof props?.hevyApiKey === "string" ? props.hevyApiKey : null;
 	if (!apiKey) return oauthUnauthorizedResponse(request);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -320,7 +320,17 @@ export function createWorkerFetchHandler(
 		env: WorkerEnv,
 		ctx?: object,
 	): Promise<Response> {
-		if (!isOAuthEnabled(env)) return legacyHandler(request, env);
+		if (!isOAuthEnabled(env)) {
+			if (env.OAUTH_KV != null) {
+				logWorkerFailure(
+					"oauth-kv-misconfigured",
+					new TypeError(
+						"OAUTH_KV binding is not a KV namespace; OAuth stays disabled",
+					),
+				);
+			}
+			return legacyHandler(request, env);
+		}
 
 		const url = new URL(request.url);
 		if (url.pathname === MCP_PATH) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,6 +4,13 @@ import { createSharedMcpServer } from "./shared-server.js";
 import { isHevyHttpError } from "./utils/hevy-http-error.js";
 import { createClient, type HevyClient } from "./utils/hevyClient.js";
 import { createSafeErrorDiagnostic } from "./utils/safe-error-diagnostic.js";
+import {
+	createHevyOAuthProvider,
+	hasOAuthAccessTokenShape,
+	type HevyApiKeyValidation,
+	type HevyOAuthWorker,
+	isOAuthEnabled,
+} from "./worker-oauth.js";
 
 const MCP_PATH = "/mcp";
 const HEVY_API_BASE_URL = "https://api.hevyapp.com";
@@ -16,6 +23,10 @@ export interface WorkerEnv {
 	// Trusted deployment/test binding; invalid values fail closed before auth.
 	HEVY_API_BASE_URL?: string;
 	MCP_ALLOWED_ORIGINS?: string;
+	// Optional KV namespace binding. When present, the Worker additionally
+	// exposes OAuth 2.1 endpoints for remote MCP clients such as Claude.ai.
+	// When absent, behavior is identical to the pre-OAuth Worker.
+	OAUTH_KV?: unknown;
 }
 
 interface WorkerDependencies {
@@ -24,6 +35,8 @@ interface WorkerDependencies {
 	createServer?: (apiKey: string, hevyClient: HevyClient) => McpServer;
 	createTransport?: () => WebStandardStreamableHTTPServerTransport;
 }
+
+type ResolvedWorkerDependencies = Required<WorkerDependencies>;
 
 export function parseBearerApiKey(authorization: string | null): string | null {
 	if (!authorization) return null;
@@ -141,14 +154,61 @@ function logWorkerFailure(context: string, error: unknown): void {
 	});
 }
 
+function resolveWorkerDependencies(
+	dependencies: WorkerDependencies,
+): ResolvedWorkerDependencies {
+	return {
+		createValidationClient:
+			dependencies.createValidationClient ?? createDefaultValidationClient,
+		createRequestClient:
+			dependencies.createRequestClient ?? createDefaultRequestClient,
+		createServer: dependencies.createServer ?? createDefaultServer,
+		createTransport: dependencies.createTransport ?? createDefaultTransport,
+	};
+}
+
+async function validateHevyApiKey(
+	apiKey: string,
+	hevyApiBaseUrl: string,
+	createValidationClient: ResolvedWorkerDependencies["createValidationClient"],
+): Promise<HevyApiKeyValidation> {
+	try {
+		await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo();
+		return "valid";
+	} catch (error) {
+		if (
+			isHevyHttpError(error) &&
+			(error.status === 401 || error.status === 403)
+		) {
+			return "invalid";
+		}
+		return "unavailable";
+	}
+}
+
+async function serveMcpRequest(
+	request: Request,
+	apiKey: string,
+	hevyApiBaseUrl: string,
+	dependencies: ResolvedWorkerDependencies,
+): Promise<Response> {
+	try {
+		const hevyClient = dependencies.createRequestClient(apiKey, hevyApiBaseUrl);
+		const server = dependencies.createServer(apiKey, hevyClient);
+		const transport = dependencies.createTransport();
+		transport.onerror = (error) => {
+			logWorkerFailure("streamable-http-transport", error);
+		};
+		await server.connect(transport);
+		return await transport.handleRequest(request);
+	} catch (error) {
+		logWorkerFailure("mcp-request-processing", error);
+		return new Response("Unable to process MCP request", { status: 500 });
+	}
+}
+
 export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
-	const createValidationClient =
-		dependencies.createValidationClient ?? createDefaultValidationClient;
-	const createRequestClient =
-		dependencies.createRequestClient ?? createDefaultRequestClient;
-	const createServer = dependencies.createServer ?? createDefaultServer;
-	const createTransport =
-		dependencies.createTransport ?? createDefaultTransport;
+	const resolved = resolveWorkerDependencies(dependencies);
 
 	return async function handleRequest(
 		request: Request,
@@ -189,41 +249,99 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 			});
 		}
 
-		try {
-			await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo();
-		} catch (error) {
-			if (
-				isHevyHttpError(error) &&
-				(error.status === 401 || error.status === 403)
-			) {
-				return response("Unauthorized", 401, origin, {
-					"WWW-Authenticate": "Bearer",
-				});
-			}
+		const validation = await validateHevyApiKey(
+			apiKey,
+			hevyApiBaseUrl,
+			resolved.createValidationClient,
+		);
+		if (validation === "invalid") {
+			return response("Unauthorized", 401, origin, {
+				"WWW-Authenticate": "Bearer",
+			});
+		}
+		if (validation !== "valid") {
 			return response("Hevy API is temporarily unavailable", 502, origin);
 		}
 
-		try {
-			const hevyClient = createRequestClient(apiKey, hevyApiBaseUrl);
-			const server = createServer(apiKey, hevyClient);
-			const transport = createTransport();
-			transport.onerror = (error) => {
-				logWorkerFailure("streamable-http-transport", error);
-			};
-			await server.connect(transport);
-			const mcpResponse = await transport.handleRequest(request);
-			return withCors(mcpResponse, origin);
-		} catch (error) {
-			logWorkerFailure("mcp-request-processing", error);
-			return response("Unable to process MCP request", 500, origin);
-		}
+		return withCors(
+			await serveMcpRequest(request, apiKey, hevyApiBaseUrl, resolved),
+			origin,
+		);
 	};
 }
 
-const handleRequest = createWorkerHandler();
+function createWorkerOAuthProvider(
+	resolved: ResolvedWorkerDependencies,
+): HevyOAuthWorker<WorkerEnv> {
+	return createHevyOAuthProvider<WorkerEnv>({
+		validateApiKey: async (apiKey, env) => {
+			let hevyApiBaseUrl: string;
+			try {
+				hevyApiBaseUrl = resolveHevyApiBaseUrl(env.HEVY_API_BASE_URL);
+			} catch {
+				return "config-error";
+			}
+			return validateHevyApiKey(
+				apiKey,
+				hevyApiBaseUrl,
+				resolved.createValidationClient,
+			);
+		},
+		serveMcp: async (request, env, apiKey) => {
+			let hevyApiBaseUrl: string;
+			try {
+				hevyApiBaseUrl = resolveHevyApiBaseUrl(env.HEVY_API_BASE_URL);
+			} catch {
+				return new Response("Worker configuration error", { status: 500 });
+			}
+			return serveMcpRequest(request, apiKey, hevyApiBaseUrl, resolved);
+		},
+	});
+}
+
+/**
+ * Compose the legacy direct-API-key handler with the optional OAuth layer.
+ *
+ * Without an `OAUTH_KV` binding every request takes the legacy path, so
+ * existing deployments are unaffected. With the binding, `/mcp` requests
+ * whose bearer value looks like an OAuth access token (and unauthenticated
+ * ones, so clients receive the RFC 9728 discovery challenge) go through the
+ * OAuth provider, while raw Hevy API keys keep using the legacy path.
+ */
+export function createWorkerFetchHandler(
+	dependencies: WorkerDependencies = {},
+) {
+	const resolved = resolveWorkerDependencies(dependencies);
+	const legacyHandler = createWorkerHandler(dependencies);
+	const oauthProvider = createWorkerOAuthProvider(resolved);
+
+	return async function handleWorkerFetch(
+		request: Request,
+		env: WorkerEnv,
+		ctx?: object,
+	): Promise<Response> {
+		if (!isOAuthEnabled(env)) return legacyHandler(request, env);
+
+		const url = new URL(request.url);
+		if (url.pathname === MCP_PATH) {
+			if (request.method !== "POST") return legacyHandler(request, env);
+			const bearer = parseBearerApiKey(request.headers.get("authorization"));
+			if (bearer && !hasOAuthAccessTokenShape(bearer)) {
+				return legacyHandler(request, env);
+			}
+			const originResult = validateOrigin(request, env);
+			if (originResult instanceof Response) return originResult;
+			const oauthResponse = await oauthProvider.fetch(request, env, ctx ?? {});
+			return withCors(oauthResponse, originResult);
+		}
+		return oauthProvider.fetch(request, env, ctx ?? {});
+	};
+}
+
+const handleWorkerFetch = createWorkerFetchHandler();
 
 export default {
-	fetch(request: Request, env: WorkerEnv): Promise<Response> {
-		return handleRequest(request, env);
+	fetch(request: Request, env: WorkerEnv, ctx?: object): Promise<Response> {
+		return handleWorkerFetch(request, env, ctx);
 	},
 };

--- a/tests/shims/cloudflare-workers.ts
+++ b/tests/shims/cloudflare-workers.ts
@@ -1,0 +1,5 @@
+// Minimal Node.js stand-in for the `cloudflare:workers` runtime module so
+// unit tests can import Worker code that depends on
+// @cloudflare/workers-oauth-provider. The library only uses this export for
+// `instanceof` checks on class-based handlers, which the tests do not use.
+export class WorkerEntrypoint {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,24 @@
+import { fileURLToPath } from "node:url";
 import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			// @cloudflare/workers-oauth-provider imports this Workers runtime
+			// module; outside workerd it needs a shim.
+			"cloudflare:workers": fileURLToPath(
+				new URL("./tests/shims/cloudflare-workers.ts", import.meta.url),
+			),
+		},
+	},
 	test: {
+		server: {
+			deps: {
+				// Inline so the `cloudflare:workers` alias above applies to the
+				// library's own import of that runtime-only module.
+				inline: ["@cloudflare/workers-oauth-provider"],
+			},
+		},
 		exclude: [...configDefaults.exclude, "tests/nightly/**"],
 		coverage: {
 			provider: "v8",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,4 +8,10 @@
 	"observability": {
 		"enabled": false,
 	},
+	// Optional OAuth 2.1 layer for remote MCP clients such as Claude.ai
+	// custom connectors. Create the namespace with
+	// `npx wrangler kv namespace create OAUTH_KV` and uncomment with the
+	// returned id. Without this binding the Worker serves only direct
+	// Hevy-API-key bearer auth, exactly as before.
+	// "kv_namespaces": [{ "binding": "OAUTH_KV", "id": "<namespace-id>" }],
 }


### PR DESCRIPTION
## Summary

Adds an opt-in OAuth 2.1 layer to the Cloudflare Worker so remote MCP clients that cannot send a fixed `Authorization` header — most notably **Claude.ai custom connectors** — can use the Worker. The Hevy API is API-key-only, so the Worker itself acts as the OAuth provider via [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider): the user pastes their Hevy API key once on an `/authorize` consent page, the key is validated against Hevy and stored **encrypted** inside the OAuth grant, and every OAuth-authenticated `/mcp` request decrypts it back and proceeds exactly like a direct-key request.

## Opt-in and fully backward compatible

- The layer activates **only when an `OAUTH_KV` namespace is bound** (commented block added to `wrangler.jsonc`). Without the binding, Worker behavior is unchanged — all existing tests pass unmodified.
- With the binding, raw Hevy-API-key bearer requests keep working: OAuth access tokens always contain colons (`userId:grantId:secret`), Hevy API keys never do, so routing between the two auth modes is deterministic.
- The only observable change when enabled: unauthenticated `POST /mcp` gets the RFC 9728 `WWW-Authenticate` challenge with `resource_metadata` (required for OAuth client discovery) instead of the bare `Bearer` challenge.

## What the Worker exposes when enabled

- `/.well-known/oauth-authorization-server` (RFC 8414) and `/.well-known/oauth-protected-resource` (RFC 9728) discovery metadata
- `/register` — dynamic client registration (RFC 7591)
- `/token` — authorization code + PKCE (S256 only) and refresh-token grants
- `/authorize` — minimal dependency-free consent page (dark-mode aware, HTML-escaped, `X-Frame-Options: DENY` + CSP)

## Security notes

- The Hevy API key is never persisted in plaintext — the library encrypts grant `props` end-to-end (verified by a test asserting the key does not appear anywhere in KV).
- OAuth `userId` is the SHA-256 of the API key, never the key itself.
- The strict `MCP_ALLOWED_ORIGINS` origin gate still runs in front of the OAuth provider for `/mcp`.
- Rotating the Hevy API key invalidates every grant created with it (keys are re-validated against Hevy per request, unchanged from the existing model).

## Testing

- 25 new unit tests, including a **full-flow test through the real `OAuthProvider`** with an in-memory KV: DCR → authorize → PKCE token exchange → authenticated MCP call → forged-token rejection → upstream-revocation 401.
- Verified end-to-end in workerd via `wrangler dev` (discovery, DCR, consent, token exchange, refresh grant, MCP `tools/list`, legacy coexistence) and against a live production deployment used as an actual Claude.ai custom connector.
- `npm run test:pr`, `check`, `check:types`, and `worker:dry-run` all pass; a `minor` changeset is included.

## Notes for review

- `tests/shims/cloudflare-workers.ts` + a vitest alias shim the `cloudflare:workers` runtime module the library imports (Node-only concern; wrangler resolves the real module in production).
- `createWorkerHandler` (legacy path) is refactored to share `validateHevyApiKey`/`serveMcpRequest` with the OAuth path but is behaviorally identical.
- The consent-page CSP deliberately omits `form-action`: Chrome enforces it against the redirect following form submission, which would block the post-approval 302 back to the OAuth client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OAuth 2.1 layer for remote MCP clients when an `OAUTH_KV` namespace is configured, including discovery, dynamic client registration, PKCE-based token exchange, and an `/authorize` flow that securely stores validated Hevy API keys.
  * Unauthenticated `POST /mcp` can return an OAuth-style challenge; fixed bearer requests still work when OAuth is disabled.

* **Documentation**
  * Expanded setup and compatibility guidance across the main guide and contributing docs, including Hosted Worker OAuth details.

* **Tests**
  * Added end-to-end OAuth and MCP routing coverage, including security and error handling scenarios.

* **Chores**
  * Added required OAuth provider runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement optional OAuth 2.1 layer in Cloudflare Worker enabling remote MCP clients like Claude.ai to authenticate without fixed Authorization headers.

Main changes:
- Created new `worker-oauth.ts` module with authorization code flow, PKCE, dynamic client registration, and encrypted grant storage via `@cloudflare/workers-oauth-provider`
- Refactored `worker.ts` to route requests through OAuth provider when `OAUTH_KV` binding present, preserving legacy API-key authentication path
- Added comprehensive test suite validating full OAuth flow, API key validation, token exchange, and revocation scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
