### PR TITLE
Split MCP tool failure issues by context

### DIFF
--- a/.changeset/bright-tools-group.md
+++ b/.changeset/bright-tools-group.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": minor
+---
+
+Improve Sentry MCP tool-failure diagnostics by preserving tool context and grouping failures by their normalized error dimensions.

--- a/src/utils/observability-wrapper.test.ts
+++ b/src/utils/observability-wrapper.test.ts
@@ -4,7 +4,7 @@ import { withObservability } from "./observability-wrapper.js";
 import { Sentry } from "./telemetry.js";
 
 const testDoubles = vi.hoisted(() => ({
-	scope: { setTag: vi.fn(), setContext: vi.fn() },
+	scope: { setTag: vi.fn(), setContext: vi.fn(), setFingerprint: vi.fn() },
 	sentry: {
 		withScope: vi.fn((callback: (scope: unknown) => void) =>
 			callback(testDoubles.scope),
@@ -57,6 +57,14 @@ describe("withObservability", () => {
 			"http.status_code",
 			"503",
 		);
+		expect(testDoubles.scope.setTag).toHaveBeenCalledWith(
+			"mcp.tool.context",
+			"get-user-info",
+		);
+		expect(testDoubles.scope.setTag).toHaveBeenCalledWith(
+			"hevy.api.endpoint",
+			"/v1/user/info",
+		);
 		expect(testDoubles.scope.setContext).toHaveBeenCalledWith(
 			"safeError",
 			expect.objectContaining({
@@ -67,8 +75,17 @@ describe("withObservability", () => {
 			}),
 		);
 		expect(testDoubles.scope.setContext).toHaveBeenCalledWith("mcpTool", {
+			context: "get-user-info",
 			argumentKeyCount: 2,
 		});
+		expect(testDoubles.scope.setFingerprint).toHaveBeenCalledWith([
+			"mcp-tool-failure",
+			"get-user-info",
+			"HevyHttpError",
+			"HEVY_RETRY_EXHAUSTED",
+			"503",
+			"/v1/user/info",
+		]);
 		expect(Sentry.captureMessage).toHaveBeenCalledWith(
 			"MCP tool failure",
 			"error",

--- a/src/utils/observability-wrapper.ts
+++ b/src/utils/observability-wrapper.ts
@@ -14,16 +14,31 @@ export function withObservability<TParams extends Record<string, unknown>>(
 	return withErrorHandling(
 		withTelemetry(fn, context),
 		context,
-		(error, _toolContext, argumentKeyCount) => {
+		(error, toolContext, argumentKeyCount) => {
 			const { diagnostic } = resolveErrorPolicy(error, "");
 			Sentry.withScope((scope) => {
+				scope.setTag("mcp.tool.context", toolContext);
 				scope.setTag("error.category", diagnostic.category);
 				if (diagnostic.code) scope.setTag("error.code", diagnostic.code);
 				if (diagnostic.status !== undefined) {
 					scope.setTag("http.status_code", String(diagnostic.status));
 				}
-				scope.setContext("mcpTool", { argumentKeyCount });
+				if (diagnostic.endpoint) {
+					scope.setTag("hevy.api.endpoint", diagnostic.endpoint);
+				}
+				scope.setContext("mcpTool", {
+					context: toolContext,
+					argumentKeyCount,
+				});
 				scope.setContext("safeError", { ...diagnostic });
+				scope.setFingerprint([
+					"mcp-tool-failure",
+					toolContext,
+					diagnostic.category,
+					diagnostic.code ?? "none",
+					String(diagnostic.status ?? "none"),
+					diagnostic.endpoint ?? "none",
+				]);
 				Sentry.captureMessage("MCP tool failure", "error");
 			});
 		},


### PR DESCRIPTION
## Summary

- Add MCP tool and normalized Hevy endpoint tags to synthetic Sentry tool-failure events.
- Include the tool name in the `mcpTool` context.
- Set a bounded Sentry fingerprint using tool, error category, code/status, and endpoint.

## Why

HEVY-MCP-2G currently groups unrelated failures under the single message `MCP tool failure`, including routine/workout 404s and routine-creation 409s. This makes the issue difficult to triage despite affecting 59 users and 316 events.

## Validation

- `npm run test:unit -- src/utils/observability-wrapper.test.ts` — 3 passed
- `npm run test:mcp` — 16 passed
- `npm run check` — passed
- `npm run check:types` — passed
- `npm test` — build succeeded; environment-dependent tests failed because local listeners are blocked with EPERM, live Hevy integration has no usable API response, and child-process shutdown tests exit early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry diagnostics for MCP tool and API failures by preserving richer tool context.
  * Added/updated telemetry tags for MCP tool context and API endpoint when available.
  * Enhanced fingerprinting for tool-failure events to improve grouping using normalized error details (category, code, status, endpoint) while avoiding sensitive data.
* **Documentation**
  * Updated release notes for the `hevy-mcp` package with the improved observability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhanced Sentry error grouping for MCP tool failures by adding contextual metadata and fingerprinting for better issue segregation.

Main changes:
- Added tool context tag and fingerprint generation using error dimensions (category, code, status, endpoint) for normalized error grouping
- Expanded mcpTool context to include tool context alongside argument count for improved diagnostic tracking
- Updated tests to verify new Sentry tags, context fields, and fingerprint generation logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
