### PR TITLE
fix: reduce expected Hevy 404 telemetry noise

### DIFF
--- a/.changeset/quiet-hevy-404s.md
+++ b/.changeset/quiet-hevy-404s.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Handle expected Hevy not-found responses consistently, preserve pagination metadata, and reduce telemetry noise from expected API and malformed-stdio failures.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,6 +107,10 @@ jobs:
           OTEL_COLLECTOR_TOKEN: ${{ secrets.OTEL_COLLECTOR_TOKEN }}
           CODECOV_TOKEN: ${{ matrix.node-version == '24.x' && secrets.CODECOV_TOKEN || '' }}
 
+      - name: Verify Worker bundle
+        if: matrix.node-version == '24.x'
+        run: npm run worker:dry-run
+
       - name: Run Worker HTTP integration tests
         if: matrix.node-version == '24.x'
         run: npm run test:worker-http

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"prepack": "npm run check:server-manifest && npm run build",
 		"start": "node --env-file .env packages/node/dist/cli.mjs",
 		"dev": "tsx watch --env-file .env --clear-screen=false packages/node/src/cli.ts",
-		"check": "oxlint . --type-aware --type-check && oxfmt . --check",
+		"check": "oxlint . --type-aware --type-check && node scripts/check-worker-import-boundary.mjs && oxfmt . --check",
 		"check:fix": "oxlint . --type-aware --type-check && oxfmt . --write",
 		"check:types": "tsc --noEmit && npm run check:types --workspaces --if-present",
 		"check:workspaces": "node scripts/check-workspaces.mjs",

--- a/packages/core/src/tools/body-measurements.test.ts
+++ b/packages/core/src/tools/body-measurements.test.ts
@@ -152,7 +152,10 @@ describe("bodyMeasurementToolDefinitions", () => {
 
 		const parsed = JSON.parse(response.content[0].text) as unknown[];
 		expect(parsed).toEqual([formatBodyMeasurement(sampleMeasurement)]);
-		expect(response.structuredContent).toEqual({ bodyMeasurements: parsed });
+		expect(response.structuredContent).toMatchObject({
+			bodyMeasurements: parsed,
+			page: 1,
+		});
 	});
 
 	it("get-body-measurements returns empty response when no measurements found", async () => {
@@ -168,7 +171,10 @@ describe("bodyMeasurementToolDefinitions", () => {
 		expect(response.content[0]?.text).toBe(
 			"No body measurements found for the specified parameters",
 		);
-		expect(response.structuredContent).toEqual({ bodyMeasurements: [] });
+		expect(response.structuredContent).toMatchObject({
+			bodyMeasurements: [],
+			page: 1,
+		});
 	});
 
 	it("get-body-measurement returns a formatted measurement for a given date", async () => {

--- a/packages/core/src/tools/body-measurements.ts
+++ b/packages/core/src/tools/body-measurements.ts
@@ -26,7 +26,6 @@ import type { PaginatedToolResult } from "../utils/response-formatter.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
-	recordExpected404,
 } from "../utils/hevy-error-policy.js";
 
 const getBodyMeasurementsSchema = {
@@ -87,8 +86,7 @@ const getBodyMeasurementsDefinition: ToolDefinition<
 			};
 		} catch (error) {
 			if (isExpectedListPageNotFound(error, page)) {
-				recordExpected404("end_of_list");
-				return { items: [], page };
+				return { items: [], page, expected404Outcome: "end_of_list" };
 			}
 			throw error;
 		}
@@ -127,8 +125,11 @@ const getBodyMeasurementDefinition: ToolDefinition<
 			return { bodyMeasurement: data, date };
 		} catch (error) {
 			if (isExpectedReadNotFound(error)) {
-				recordExpected404("not_found");
-				return { bodyMeasurement: null, date };
+				return {
+					bodyMeasurement: null,
+					date,
+					expected404Outcome: "not_found",
+				};
 			}
 			throw error;
 		}

--- a/packages/core/src/tools/body-measurements.ts
+++ b/packages/core/src/tools/body-measurements.ts
@@ -22,10 +22,19 @@ import {
 	paginationShape,
 } from "./input-schemas.js";
 import { buildMeasurementPayload } from "./payload-mappers.js";
+import type { PaginatedToolResult } from "../utils/response-formatter.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedReadNotFound,
+	recordExpected404,
+} from "../utils/hevy-error-policy.js";
 
 const getBodyMeasurementsSchema = {
 	...paginationShape({ defaultPageSize: 10, maxPageSize: 10 }),
 } as const;
+type GetBodyMeasurementsResult = PaginatedToolResult<
+	NonNullable<GetV1BodyMeasurements200["body_measurements"]>[number]
+>;
 
 const getBodyMeasurementSchema = {
 	date: calendarDate.describe("The date of the body measurement (YYYY-MM-DD)"),
@@ -47,7 +56,7 @@ const updateBodyMeasurementSchema = {
 
 const getBodyMeasurementsDefinition: ToolDefinition<
 	typeof getBodyMeasurementsSchema,
-	GetV1BodyMeasurements200["body_measurements"]
+	GetBodyMeasurementsResult
 > = {
 	name: "get-body-measurements",
 	feature: "measurements",
@@ -67,10 +76,22 @@ const getBodyMeasurementsDefinition: ToolDefinition<
 	responseContract: bodyMeasurementsResponse,
 	execute: async (runtime: ToolRuntime, args) => {
 		const { page, pageSize } = args;
-		const data: GetV1BodyMeasurements200 = await runtime
-			.getClient()
-			.getBodyMeasurements({ page, pageSize });
-		return data?.body_measurements;
+		try {
+			const data: GetV1BodyMeasurements200 = await runtime
+				.getClient()
+				.getBodyMeasurements({ page, pageSize });
+			return {
+				items: data?.body_measurements ?? [],
+				page,
+				pageCount: data?.page_count,
+			};
+		} catch (error) {
+			if (isExpectedListPageNotFound(error, page)) {
+				recordExpected404("end_of_list");
+				return { items: [], page };
+			}
+			throw error;
+		}
 	},
 };
 
@@ -99,10 +120,18 @@ const getBodyMeasurementDefinition: ToolDefinition<
 	responseContract: bodyMeasurementResponse,
 	execute: async (runtime: ToolRuntime, args) => {
 		const { date } = args;
-		const data: GetV1BodyMeasurementsDate200 = await runtime
-			.getClient()
-			.getBodyMeasurement(date);
-		return { bodyMeasurement: data, date };
+		try {
+			const data: GetV1BodyMeasurementsDate200 = await runtime
+				.getClient()
+				.getBodyMeasurement(date);
+			return { bodyMeasurement: data, date };
+		} catch (error) {
+			if (isExpectedReadNotFound(error)) {
+				recordExpected404("not_found");
+				return { bodyMeasurement: null, date };
+			}
+			throw error;
+		}
 	},
 };
 

--- a/packages/core/src/tools/folders.test.ts
+++ b/packages/core/src/tools/folders.test.ts
@@ -130,7 +130,10 @@ describe("folder tool definitions", () => {
 
 		const parsed = JSON.parse(response.content[0].text) as unknown[];
 		expect(parsed).toEqual([formatRoutineFolder(folder)]);
-		expect(response.structuredContent).toEqual({ routineFolders: parsed });
+		expect(response.structuredContent).toMatchObject({
+			routineFolders: parsed,
+			page: 1,
+		});
 	});
 
 	it("get-routine-folders returns a structured empty list", async () => {
@@ -145,7 +148,10 @@ describe("folder tool definitions", () => {
 			"get-routine-folders",
 		).handler({ page: 1, pageSize: 5 });
 
-		expect(response.structuredContent).toEqual({ routineFolders: [] });
+		expect(response.structuredContent).toMatchObject({
+			routineFolders: [],
+			page: 1,
+		});
 		expect(response.content[0]?.text).toBe(
 			"No routine folders found for the specified parameters",
 		);

--- a/packages/core/src/tools/folders.ts
+++ b/packages/core/src/tools/folders.ts
@@ -24,7 +24,6 @@ import { nonEmptyId, paginationShape } from "./input-schemas.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
-	recordExpected404,
 } from "../utils/hevy-error-policy.js";
 
 const getRoutineFoldersSchema = paginationShape({
@@ -76,8 +75,7 @@ const getRoutineFoldersDefinition = {
 			};
 		} catch (error) {
 			if (isExpectedListPageNotFound(error, page)) {
-				recordExpected404("end_of_list");
-				return { items: [], page };
+				return { items: [], page, expected404Outcome: "end_of_list" };
 			}
 			throw error;
 		}
@@ -110,6 +108,7 @@ const getRoutineFolderDefinition = {
 	): Promise<{
 		routineFolder: GetV1RoutineFoldersFolderid200 | null | undefined;
 		folderId: string;
+		expected404Outcome?: "not_found";
 	}> => {
 		const { folderId } = args;
 		try {
@@ -119,8 +118,11 @@ const getRoutineFolderDefinition = {
 			return { routineFolder: data, folderId };
 		} catch (error) {
 			if (isExpectedReadNotFound(error)) {
-				recordExpected404("not_found");
-				return { routineFolder: null, folderId };
+				return {
+					routineFolder: null,
+					folderId,
+					expected404Outcome: "not_found",
+				};
 			}
 			throw error;
 		}
@@ -130,6 +132,7 @@ const getRoutineFolderDefinition = {
 	{
 		routineFolder: GetV1RoutineFoldersFolderid200 | null | undefined;
 		folderId: string;
+		expected404Outcome?: "not_found";
 	}
 >;
 

--- a/packages/core/src/tools/folders.ts
+++ b/packages/core/src/tools/folders.ts
@@ -7,6 +7,7 @@ import type {
 	RoutineFolder,
 } from "@hevy-mcp/hevy-client/types";
 import type { ToolDefinition } from "./define-tool.js";
+import type { PaginatedToolResult } from "../utils/response-formatter.js";
 import type { ToolRuntime } from "./tool-runtime.js";
 import {
 	createRoutineFolderResponse,
@@ -20,6 +21,11 @@ import {
 import { describeTool } from "../utils/tool-descriptions.js";
 import type { InferToolParams } from "../utils/tool-helpers.js";
 import { nonEmptyId, paginationShape } from "./input-schemas.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedReadNotFound,
+	recordExpected404,
+} from "../utils/hevy-error-policy.js";
 
 const getRoutineFoldersSchema = paginationShape({
 	defaultPageSize: 5,
@@ -57,20 +63,28 @@ const getRoutineFoldersDefinition = {
 	execute: async (
 		runtime: ToolRuntime,
 		args: GetRoutineFoldersParams,
-	): Promise<RoutineFolder[] | undefined> => {
+	): Promise<PaginatedToolResult<RoutineFolder>> => {
 		const { page, pageSize } = args;
-		const data: GetV1RoutineFolders200 = await runtime
-			.getClient()
-			.getRoutineFolders({
+		try {
+			const data: GetV1RoutineFolders200 = await runtime
+				.getClient()
+				.getRoutineFolders({ page, pageSize });
+			return {
+				items: data?.routine_folders ?? [],
 				page,
-				pageSize,
-			});
-
-		return data?.routine_folders;
+				pageCount: data?.page_count,
+			};
+		} catch (error) {
+			if (isExpectedListPageNotFound(error, page)) {
+				recordExpected404("end_of_list");
+				return { items: [], page };
+			}
+			throw error;
+		}
 	},
 } satisfies ToolDefinition<
 	typeof getRoutineFoldersSchema,
-	RoutineFolder[] | undefined
+	PaginatedToolResult<RoutineFolder>
 >;
 
 const getRoutineFolderDefinition = {
@@ -98,14 +112,18 @@ const getRoutineFolderDefinition = {
 		folderId: string;
 	}> => {
 		const { folderId } = args;
-		const data: GetV1RoutineFoldersFolderid200 | null = await runtime
-			.getClient()
-			.getRoutineFolder(folderId);
-
-		return {
-			routineFolder: data,
-			folderId,
-		};
+		try {
+			const data: GetV1RoutineFoldersFolderid200 | null = await runtime
+				.getClient()
+				.getRoutineFolder(folderId);
+			return { routineFolder: data, folderId };
+		} catch (error) {
+			if (isExpectedReadNotFound(error)) {
+				recordExpected404("not_found");
+				return { routineFolder: null, folderId };
+			}
+			throw error;
+		}
 	},
 } satisfies ToolDefinition<
 	typeof getRoutineFolderSchema,

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -134,7 +134,10 @@ describe("registerRoutineTools", () => {
 
 		const parsed = JSON.parse(response.content[0].text) as unknown[];
 		expect(parsed).toEqual([formatRoutine(routine)]);
-		expect(response.structuredContent).toEqual({ routines: parsed });
+		expect(response.structuredContent).toMatchObject({
+			routines: parsed,
+			page: 1,
+		});
 	});
 
 	it("returns structured empty results for routine reads", async () => {
@@ -153,7 +156,10 @@ describe("registerRoutineTools", () => {
 			routineId: "missing-id",
 		});
 
-		expect(routines.structuredContent).toEqual({ routines: [] });
+		expect(routines.structuredContent).toMatchObject({
+			routines: [],
+			page: 1,
+		});
 		expect(routine.structuredContent).toEqual({ routine: null });
 		expect(routines.content[0]?.text).toBe(
 			"No routines found for the specified parameters",

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -30,7 +30,6 @@ import type { PaginatedToolResult } from "../utils/response-formatter.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
-	recordExpected404,
 } from "../utils/hevy-error-policy.js";
 
 const getRoutinesSchema = paginationShape({
@@ -70,8 +69,7 @@ const getRoutinesDefinition: ToolDefinition<
 			return { items: data?.routines ?? [], page, pageCount: data?.page_count };
 		} catch (error) {
 			if (isExpectedListPageNotFound(error, page)) {
-				recordExpected404("end_of_list");
-				return { items: [], page };
+				return { items: [], page, expected404Outcome: "end_of_list" };
 			}
 			throw error;
 		}
@@ -113,8 +111,11 @@ const getRoutineDefinition: ToolDefinition<
 			return { routine: data?.routine, routineId };
 		} catch (error) {
 			if (isExpectedReadNotFound(error)) {
-				recordExpected404("not_found");
-				return { routine: null, routineId };
+				return {
+					routine: null,
+					routineId,
+					expected404Outcome: "not_found",
+				};
 			}
 			throw error;
 		}

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -26,13 +26,21 @@ import {
 } from "./input-schemas.js";
 import { buildRoutinePayload } from "./payload-mappers.js";
 import type { ToolDefinition } from "./define-tool.js";
+import type { PaginatedToolResult } from "../utils/response-formatter.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedReadNotFound,
+	recordExpected404,
+} from "../utils/hevy-error-policy.js";
 
 const getRoutinesSchema = paginationShape({
 	defaultPageSize: 5,
 	maxPageSize: 10,
 });
 
-type GetRoutinesResult = GetV1Routines200["routines"];
+type GetRoutinesResult = PaginatedToolResult<
+	NonNullable<GetV1Routines200["routines"]>[number]
+>;
 const getRoutinesDefinition: ToolDefinition<
 	typeof getRoutinesSchema,
 	GetRoutinesResult
@@ -54,11 +62,19 @@ const getRoutinesDefinition: ToolDefinition<
 	annotations: readOnlyAnnotations("Get Routines"),
 	responseContract: routinesResponse,
 	execute: async (runtime, { page, pageSize }) => {
-		const data: GetV1Routines200 = await runtime.getClient().getRoutines({
-			page,
-			pageSize,
-		});
-		return data?.routines;
+		try {
+			const data: GetV1Routines200 = await runtime.getClient().getRoutines({
+				page,
+				pageSize,
+			});
+			return { items: data?.routines ?? [], page, pageCount: data?.page_count };
+		} catch (error) {
+			if (isExpectedListPageNotFound(error, page)) {
+				recordExpected404("end_of_list");
+				return { items: [], page };
+			}
+			throw error;
+		}
 	},
 };
 
@@ -90,10 +106,18 @@ const getRoutineDefinition: ToolDefinition<
 	annotations: readOnlyAnnotations("Get Routine"),
 	responseContract: routineResponse,
 	execute: async (runtime, { routineId }) => {
-		const data: GetV1RoutinesRoutineid200 = await runtime
-			.getClient()
-			.getRoutineById(String(routineId));
-		return { routine: data?.routine, routineId };
+		try {
+			const data: GetV1RoutinesRoutineid200 = await runtime
+				.getClient()
+				.getRoutineById(String(routineId));
+			return { routine: data?.routine, routineId };
+		} catch (error) {
+			if (isExpectedReadNotFound(error)) {
+				recordExpected404("not_found");
+				return { routine: null, routineId };
+			}
+			throw error;
+		}
 	},
 };
 

--- a/packages/core/src/tools/templates.test.ts
+++ b/packages/core/src/tools/templates.test.ts
@@ -127,7 +127,10 @@ describe("templateToolDefinitions", () => {
 
 		const parsed = JSON.parse(response.content[0].text) as unknown[];
 		expect(parsed).toEqual([formatExerciseTemplate(template)]);
-		expect(response.structuredContent).toEqual({ exerciseTemplates: parsed });
+		expect(response.structuredContent).toMatchObject({
+			exerciseTemplates: parsed,
+			page: 1,
+		});
 	});
 
 	it("get-exercise-template returns an empty response when template is not found", async () => {
@@ -252,7 +255,10 @@ describe("templateToolDefinitions", () => {
 			"get-exercise-history",
 		).handler({ exerciseTemplateId: "t1" });
 
-		expect(templates.structuredContent).toEqual({ exerciseTemplates: [] });
+		expect(templates.structuredContent).toMatchObject({
+			exerciseTemplates: [],
+			page: 1,
+		});
 		expect(history.structuredContent).toEqual({ exerciseHistory: [] });
 	});
 

--- a/packages/core/src/tools/templates.ts
+++ b/packages/core/src/tools/templates.ts
@@ -27,6 +27,11 @@ import {
 	exerciseTypeEnum,
 	muscleGroupEnum,
 } from "../utils/schemas.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedReadNotFound,
+	recordExpected404,
+} from "../utils/hevy-error-policy.js";
 
 const getExerciseTemplatesSchema = paginationShape({
 	defaultPageSize: 5,
@@ -103,13 +108,22 @@ const getExerciseTemplatesDefinition = {
 		args: InferToolParams<typeof getExerciseTemplatesSchema>,
 	) => {
 		const { page, pageSize } = args;
-		const data: GetV1ExerciseTemplates200 = await runtime
-			.getClient()
-			.getExerciseTemplates({
+		try {
+			const data: GetV1ExerciseTemplates200 = await runtime
+				.getClient()
+				.getExerciseTemplates({ page, pageSize });
+			return {
+				items: data?.exercise_templates ?? [],
 				page,
-				pageSize,
-			});
-		return data?.exercise_templates;
+				pageCount: data?.page_count,
+			};
+		} catch (error) {
+			if (isExpectedListPageNotFound(error, page)) {
+				recordExpected404("end_of_list");
+				return { items: [], page };
+			}
+			throw error;
+		}
 	},
 };
 
@@ -140,13 +154,18 @@ const getExerciseTemplateDefinition = {
 		args: InferToolParams<typeof getExerciseTemplateSchema>,
 	) => {
 		const { exerciseTemplateId } = args;
-		const data: GetV1ExerciseTemplatesExercisetemplateid200 = await runtime
-			.getClient()
-			.getExerciseTemplate(exerciseTemplateId);
-		return {
-			exerciseTemplate: data,
-			exerciseTemplateId,
-		};
+		try {
+			const data: GetV1ExerciseTemplatesExercisetemplateid200 = await runtime
+				.getClient()
+				.getExerciseTemplate(exerciseTemplateId);
+			return { exerciseTemplate: data, exerciseTemplateId };
+		} catch (error) {
+			if (isExpectedReadNotFound(error)) {
+				recordExpected404("not_found");
+				return { exerciseTemplate: null, exerciseTemplateId };
+			}
+			throw error;
+		}
 	},
 };
 

--- a/packages/core/src/tools/templates.ts
+++ b/packages/core/src/tools/templates.ts
@@ -30,7 +30,6 @@ import {
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
-	recordExpected404,
 } from "../utils/hevy-error-policy.js";
 
 const getExerciseTemplatesSchema = paginationShape({
@@ -119,8 +118,7 @@ const getExerciseTemplatesDefinition = {
 			};
 		} catch (error) {
 			if (isExpectedListPageNotFound(error, page)) {
-				recordExpected404("end_of_list");
-				return { items: [], page };
+				return { items: [], page, expected404Outcome: "end_of_list" };
 			}
 			throw error;
 		}
@@ -161,8 +159,11 @@ const getExerciseTemplateDefinition = {
 			return { exerciseTemplate: data, exerciseTemplateId };
 		} catch (error) {
 			if (isExpectedReadNotFound(error)) {
-				recordExpected404("not_found");
-				return { exerciseTemplate: null, exerciseTemplateId };
+				return {
+					exerciseTemplate: null,
+					exerciseTemplateId,
+					expected404Outcome: "not_found",
+				};
 			}
 			throw error;
 		}

--- a/packages/core/src/tools/workouts.test.ts
+++ b/packages/core/src/tools/workouts.test.ts
@@ -158,7 +158,11 @@ describe("registerWorkoutTools", () => {
 
 		const parsed = JSON.parse(response.content[0].text) as unknown[];
 		expect(parsed).toEqual([formatWorkout(workout)]);
-		expect(response.structuredContent).toEqual({ workouts: parsed });
+		expect(response.structuredContent).toEqual({
+			workouts: parsed,
+			page: 1,
+			pageCount: undefined,
+		});
 	});
 
 	it("formats updated and deleted workout events from the client", async () => {
@@ -212,6 +216,8 @@ describe("registerWorkoutTools", () => {
 					deletedAt: "2025-03-28T07:00:00Z",
 				},
 			],
+			page: 1,
+			pageCount: undefined,
 		});
 		expect(response.structuredContent).not.toHaveProperty(
 			"events.0.workout.exercises.0.muscle_group",
@@ -288,9 +294,18 @@ describe("registerWorkoutTools", () => {
 			since: "1970-01-01T00:00:00Z",
 		});
 
-		expect(workouts.structuredContent).toEqual({ workouts: [] });
-		expect(events.structuredContent).toEqual({ events: [] });
-		expect(eventsWithoutEvents.structuredContent).toEqual({ events: [] });
+		expect(workouts.structuredContent).toMatchObject({
+			workouts: [],
+			page: 1,
+		});
+		expect(events.structuredContent).toMatchObject({
+			events: [],
+			page: 1,
+		});
+		expect(eventsWithoutEvents.structuredContent).toMatchObject({
+			events: [],
+			page: 1,
+		});
 		expect(workouts.content[0]?.text).toBe(
 			"No workouts found for the specified parameters",
 		);

--- a/packages/core/src/tools/workouts.ts
+++ b/packages/core/src/tools/workouts.ts
@@ -33,7 +33,6 @@ import type { InferToolParams } from "../utils/tool-helpers.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
-	recordExpected404,
 } from "../utils/hevy-error-policy.js";
 
 const getWorkoutsSchema = paginationShape({
@@ -93,8 +92,11 @@ export const workoutToolDefinitions = [
 				};
 			} catch (error) {
 				if (isExpectedListPageNotFound(error, args.page)) {
-					recordExpected404("end_of_list");
-					return { items: [], page: args.page };
+					return {
+						items: [],
+						page: args.page,
+						expected404Outcome: "end_of_list",
+					};
 				}
 				throw error;
 			}
@@ -126,8 +128,11 @@ export const workoutToolDefinitions = [
 				return { workout: data, workoutId: args.workoutId };
 			} catch (error) {
 				if (isExpectedReadNotFound(error)) {
-					recordExpected404("not_found");
-					return { workout: null, workoutId: args.workoutId };
+					return {
+						workout: null,
+						workoutId: args.workoutId,
+						expected404Outcome: "not_found",
+					};
 				}
 				throw error;
 			}
@@ -196,8 +201,12 @@ export const workoutToolDefinitions = [
 				};
 			} catch (error) {
 				if (isExpectedListPageNotFound(error, args.page)) {
-					recordExpected404("end_of_list");
-					return { events: [], since: args.since, page: args.page };
+					return {
+						events: [],
+						since: args.since,
+						page: args.page,
+						expected404Outcome: "end_of_list",
+					};
 				}
 				throw error;
 			}

--- a/packages/core/src/tools/workouts.ts
+++ b/packages/core/src/tools/workouts.ts
@@ -30,6 +30,11 @@ import {
 } from "../utils/tool-annotations.js";
 import { describeTool } from "../utils/tool-descriptions.js";
 import type { InferToolParams } from "../utils/tool-helpers.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedReadNotFound,
+	recordExpected404,
+} from "../utils/hevy-error-policy.js";
 
 const getWorkoutsSchema = paginationShape({
 	defaultPageSize: 5,
@@ -76,11 +81,23 @@ export const workoutToolDefinitions = [
 		kind: "read" as const,
 		responseContract: workoutsResponse,
 		execute: async (runtime: ToolRuntime, args: GetWorkoutsParams) => {
-			const data: GetV1Workouts200 = await runtime.getClient().getWorkouts({
-				page: args.page,
-				pageSize: args.pageSize,
-			});
-			return data?.workouts;
+			try {
+				const data: GetV1Workouts200 = await runtime.getClient().getWorkouts({
+					page: args.page,
+					pageSize: args.pageSize,
+				});
+				return {
+					items: data?.workouts ?? [],
+					page: args.page,
+					pageCount: data?.page_count,
+				};
+			} catch (error) {
+				if (isExpectedListPageNotFound(error, args.page)) {
+					recordExpected404("end_of_list");
+					return { items: [], page: args.page };
+				}
+				throw error;
+			}
 		},
 	},
 	{
@@ -102,10 +119,18 @@ export const workoutToolDefinitions = [
 		kind: "read" as const,
 		responseContract: workoutResponse,
 		execute: async (runtime: ToolRuntime, args: GetWorkoutParams) => {
-			const data: GetV1WorkoutsWorkoutid200 = await runtime
-				.getClient()
-				.getWorkout(args.workoutId);
-			return { workout: data, workoutId: args.workoutId };
+			try {
+				const data: GetV1WorkoutsWorkoutid200 = await runtime
+					.getClient()
+					.getWorkout(args.workoutId);
+				return { workout: data, workoutId: args.workoutId };
+			} catch (error) {
+				if (isExpectedReadNotFound(error)) {
+					recordExpected404("not_found");
+					return { workout: null, workoutId: args.workoutId };
+				}
+				throw error;
+			}
 		},
 	},
 	{
@@ -155,14 +180,27 @@ export const workoutToolDefinitions = [
 		kind: "read" as const,
 		responseContract: workoutEventsResponse,
 		execute: async (runtime: ToolRuntime, args: GetWorkoutEventsParams) => {
-			const data: GetV1WorkoutsEvents200 = await runtime
-				.getClient()
-				.getWorkoutEvents({
-					page: args.page,
-					pageSize: args.pageSize,
+			try {
+				const data: GetV1WorkoutsEvents200 = await runtime
+					.getClient()
+					.getWorkoutEvents({
+						page: args.page,
+						pageSize: args.pageSize,
+						since: args.since,
+					});
+				return {
+					events: data?.events,
 					since: args.since,
-				});
-			return { events: data?.events, since: args.since };
+					page: args.page,
+					pageCount: data?.page_count,
+				};
+			} catch (error) {
+				if (isExpectedListPageNotFound(error, args.page)) {
+					recordExpected404("end_of_list");
+					return { events: [], since: args.since, page: args.page };
+				}
+				throw error;
+			}
 		},
 	},
 	{

--- a/packages/core/src/utils/hevy-error-policy.test.ts
+++ b/packages/core/src/utils/hevy-error-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { HevyHttpError } from "./hevy-http-error.js";
+import {
+	isExpectedListPageNotFound,
+	isExpectedMutationNotFound,
+	isExpectedReadNotFound,
+} from "./hevy-error-policy.js";
+
+function error(status: number, method: string, endpoint: string) {
+	return new HevyHttpError("safe test error", { status, method, endpoint });
+}
+
+describe("Hevy 404 policy", () => {
+	it("normalizes known single-resource GET 404s only", () => {
+		expect(
+			isExpectedReadNotFound(error(404, "GET", "/v1/workouts/:workoutId")),
+		).toBe(true);
+		expect(isExpectedReadNotFound(error(404, "GET", "/v1/routines"))).toBe(
+			false,
+		);
+		expect(
+			isExpectedReadNotFound(error(500, "GET", "/v1/workouts/:workoutId")),
+		).toBe(false);
+	});
+
+	it("treats only later known list pages as end-of-list", () => {
+		const list404 = error(404, "GET", "/v1/workouts");
+		expect(isExpectedListPageNotFound(list404, 1)).toBe(false);
+		expect(isExpectedListPageNotFound(list404, 2)).toBe(true);
+		expect(
+			isExpectedListPageNotFound(error(404, "GET", "/v1/user/info"), 2),
+		).toBe(false);
+	});
+
+	it("recognizes mutation 404s without broad status mapping", () => {
+		expect(
+			isExpectedMutationNotFound(error(404, "PUT", "/v1/routines/:routineId")),
+		).toBe(true);
+		expect(
+			isExpectedMutationNotFound(error(404, "GET", "/v1/routines/:routineId")),
+		).toBe(false);
+		expect(isExpectedMutationNotFound({ status: 404 })).toBe(false);
+		expect(isExpectedMutationNotFound(error(404, "POST", "/v1/unknown"))).toBe(
+			false,
+		);
+	});
+});

--- a/packages/core/src/utils/hevy-error-policy.test.ts
+++ b/packages/core/src/utils/hevy-error-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HevyHttpError } from "./hevy-http-error.js";
+import { HevyHttpError } from "@hevy-mcp/hevy-client";
 import {
 	isExpectedListPageNotFound,
 	isExpectedMutationNotFound,

--- a/packages/core/src/utils/hevy-error-policy.ts
+++ b/packages/core/src/utils/hevy-error-policy.ts
@@ -1,0 +1,72 @@
+import { extractErrorStatus } from "./error-policy.js";
+import { isHevyHttpError } from "./hevy-http-error.js";
+import { expectedHevy404s } from "./metrics.js";
+
+export type HevyReadOperation = "get" | "list";
+export type Expected404Outcome = "not_found" | "end_of_list";
+
+export function recordExpected404(outcome: Expected404Outcome): void {
+	expectedHevy404s.add(1, { outcome });
+}
+
+const READ_RESOURCE_ENDPOINTS = new Set([
+	"/v1/body_measurements/:date",
+	"/v1/exercise_templates/:exerciseTemplateId",
+	"/v1/routine_folders/:folderId",
+	"/v1/routines/:routineId",
+	"/v1/workouts/:workoutId",
+]);
+
+const LIST_ENDPOINTS = new Set([
+	"/v1/body_measurements",
+	"/v1/exercise_templates",
+	"/v1/routine_folders",
+	"/v1/routines",
+	"/v1/workouts",
+	"/v1/workouts/events",
+]);
+
+const MUTATION_ENDPOINTS = new Set([
+	"/v1/body_measurements",
+	"/v1/body_measurements/:date",
+	"/v1/exercise_templates",
+	"/v1/routine_folders",
+	"/v1/routines",
+	"/v1/routines/:routineId",
+	"/v1/workouts",
+	"/v1/workouts/:workoutId",
+]);
+
+/** True only for a sanitized Hevy GET of a known single resource. */
+export function isExpectedReadNotFound(error: unknown): boolean {
+	return (
+		isHevyHttpError(error) &&
+		extractErrorStatus(error) === 404 &&
+		error.method.toUpperCase() === "GET" &&
+		READ_RESOURCE_ENDPOINTS.has(error.endpoint)
+	);
+}
+
+/** True only for an undocumented empty page after the first page. */
+export function isExpectedListPageNotFound(
+	error: unknown,
+	page: number,
+): boolean {
+	return (
+		page > 1 &&
+		isHevyHttpError(error) &&
+		extractErrorStatus(error) === 404 &&
+		error.method.toUpperCase() === "GET" &&
+		LIST_ENDPOINTS.has(error.endpoint)
+	);
+}
+
+/** Mutation/caller 404s remain MCP errors but do not create Sentry issues. */
+export function isExpectedMutationNotFound(error: unknown): boolean {
+	return (
+		isHevyHttpError(error) &&
+		extractErrorStatus(error) === 404 &&
+		error.method.toUpperCase() !== "GET" &&
+		MUTATION_ENDPOINTS.has(error.endpoint)
+	);
+}

--- a/packages/core/src/utils/hevy-error-policy.ts
+++ b/packages/core/src/utils/hevy-error-policy.ts
@@ -1,13 +1,8 @@
 import { extractErrorStatus } from "./error-policy.js";
-import { isHevyHttpError } from "./hevy-http-error.js";
-import { expectedHevy404s } from "./metrics.js";
+import { isHevyHttpError } from "@hevy-mcp/hevy-client";
 
 export type HevyReadOperation = "get" | "list";
 export type Expected404Outcome = "not_found" | "end_of_list";
-
-export function recordExpected404(outcome: Expected404Outcome): void {
-	expectedHevy404s.add(1, { outcome });
-}
 
 const READ_RESOURCE_ENDPOINTS = new Set([
 	"/v1/body_measurements/:date",

--- a/packages/core/src/utils/response-formatter.test.ts
+++ b/packages/core/src/utils/response-formatter.test.ts
@@ -76,15 +76,21 @@ describe("response contracts", () => {
 		expect(JSON.parse(response.content[0].text)).toEqual(structured.workouts);
 	});
 
+	it("does not claim the end of pagination when pageCount is unavailable", () => {
+		const response = respond(workoutsResponse, { items: [], page: 2 });
+		expect(response.structuredContent).toMatchObject({ page: 2 });
+		expect(response.structuredContent).toHaveProperty("hasNextPage", undefined);
+	});
+
 	it("preserves empty-list and null result messages", () => {
-		expect(respond(workoutsResponse, [])).toEqual({
+		expect(respond(workoutsResponse, [])).toMatchObject({
 			content: [
 				{
 					type: "text",
 					text: "No workouts found for the specified parameters",
 				},
 			],
-			structuredContent: { workouts: [] },
+			structuredContent: { workouts: [], page: 1 },
 		});
 		expect(
 			respond(workoutResponse, {
@@ -141,9 +147,17 @@ describe("response contracts", () => {
 	])(
 		"normalizes undefined $name data to its canonical empty response",
 		({ render, structuredContent, text }) => {
-			expect(render()).toEqual({
+			const paginated =
+				"workouts" in structuredContent ||
+				"routines" in structuredContent ||
+				"exerciseTemplates" in structuredContent ||
+				"routineFolders" in structuredContent ||
+				"bodyMeasurements" in structuredContent;
+			expect(render()).toMatchObject({
 				content: [{ type: "text", text }],
-				structuredContent,
+				structuredContent: paginated
+					? { ...structuredContent, page: 1 }
+					: structuredContent,
 			});
 		},
 	);

--- a/packages/core/src/utils/response-formatter.ts
+++ b/packages/core/src/utils/response-formatter.ts
@@ -302,8 +302,28 @@ export type FormattedBodyMeasurement = z.infer<
 	typeof formattedBodyMeasurementSchema
 >;
 
+const paginationOutputSchema = {
+	page: z.number().int().positive(),
+	pageCount: z.number().int().nonnegative().optional(),
+	hasNextPage: z.boolean().optional(),
+} as const;
+export type PaginatedToolResult<T> = {
+	items: readonly T[];
+	page: number;
+	pageCount?: number;
+};
+type PaginatedInput<T> = PaginatedToolResult<T> | readonly T[] | undefined;
+function normalizePaginatedInput<T>(
+	data: PaginatedInput<T>,
+): PaginatedToolResult<T> {
+	if (data === undefined) return { items: [], page: 1 };
+	if ("items" in data) return data;
+	return { items: data, page: 1 };
+}
+
 const workoutsOutputSchema = {
 	workouts: z.array(formattedWorkoutSchema),
+	...paginationOutputSchema,
 } as const;
 const workoutOutputSchema = {
 	workout: formattedWorkoutSchema.nullable(),
@@ -324,14 +344,20 @@ const workoutEventsOutputSchema = {
 	events: z.array(
 		z.union([formattedUpdatedWorkoutSchema, formattedDeletedWorkoutSchema]),
 	),
+	...paginationOutputSchema,
 } as const;
 const routinesOutputSchema = {
 	routines: z.array(formattedRoutineSchema),
+	...paginationOutputSchema,
 } as const;
 const routineOutputSchema = {
 	routine: formattedRoutineSchema.nullable(),
 } as const;
 const exerciseTemplatesOutputSchema = {
+	exerciseTemplates: z.array(formattedExerciseTemplateSchema),
+	...paginationOutputSchema,
+} as const;
+const exerciseTemplateSearchOutputSchema = {
 	exerciseTemplates: z.array(formattedExerciseTemplateSchema),
 } as const;
 const exerciseTemplateOutputSchema = {
@@ -342,12 +368,14 @@ const exerciseHistoryOutputSchema = {
 } as const;
 const routineFoldersOutputSchema = {
 	routineFolders: z.array(formattedRoutineFolderSchema),
+	...paginationOutputSchema,
 } as const;
 const routineFolderOutputSchema = {
 	routineFolder: formattedRoutineFolderSchema.nullable(),
 } as const;
 const bodyMeasurementsOutputSchema = {
 	bodyMeasurements: z.array(formattedBodyMeasurementSchema),
+	...paginationOutputSchema,
 } as const;
 const bodyMeasurementOutputSchema = {
 	bodyMeasurement: formattedBodyMeasurementSchema.nullable(),
@@ -683,16 +711,25 @@ function workflowResultTelemetry(workflow: {
 }
 export const workoutsResponse = defineStructuredResponseContract({
 	outputSchema: workoutsOutputSchema,
-	normalize: (workouts: readonly Workout[] | undefined) => ({
-		workouts: workouts?.map(formatWorkout) ?? [],
-	}),
+	normalize: (input: PaginatedInput<Workout>) => {
+		const data = normalizePaginatedInput(input);
+		return {
+			workouts: data.items.map(formatWorkout),
+			page: data.page,
+			pageCount: data.pageCount,
+			hasNextPage:
+				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		};
+	},
 	legacyJson: ({ workouts }) => workouts,
 	text: (_data, { workouts }) =>
 		workouts.length === 0
 			? "No workouts found for the specified parameters"
 			: undefined,
 	telemetry: (workouts) => ({
-		itemCountBucket: bucketCount(workouts?.length ?? 0),
+		itemCountBucket: bucketCount(
+			normalizePaginatedInput(workouts).items.length,
+		),
 	}),
 });
 
@@ -720,7 +757,15 @@ export const workoutEventsResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		events: readonly WorkoutEvent[] | undefined;
 		since: string;
-	}) => ({ events: data.events?.map(formatWorkoutEvent) ?? [] }),
+		page: number;
+		pageCount?: number;
+	}) => ({
+		events: data.events?.map(formatWorkoutEvent) ?? [],
+		page: data.page,
+		pageCount: data.pageCount,
+		hasNextPage:
+			data.pageCount === undefined ? undefined : data.page < data.pageCount,
+	}),
 	legacyJson: ({ events }) => events,
 	text: ({ since }, { events }) =>
 		events.length === 0
@@ -733,16 +778,25 @@ export const workoutEventsResponse = defineStructuredResponseContract({
 
 export const routinesResponse = defineStructuredResponseContract({
 	outputSchema: routinesOutputSchema,
-	normalize: (routines: readonly Routine[] | undefined) => ({
-		routines: routines?.map(formatRoutine) ?? [],
-	}),
+	normalize: (input: PaginatedInput<Routine>) => {
+		const data = normalizePaginatedInput(input);
+		return {
+			routines: data.items.map(formatRoutine),
+			page: data.page,
+			pageCount: data.pageCount,
+			hasNextPage:
+				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		};
+	},
 	legacyJson: ({ routines }) => routines,
 	text: (_data, { routines }) =>
 		routines.length === 0
 			? "No routines found for the specified parameters"
 			: undefined,
 	telemetry: (routines) => ({
-		itemCountBucket: bucketCount(routines?.length ?? 0),
+		itemCountBucket: bucketCount(
+			normalizePaginatedInput(routines).items.length,
+		),
 	}),
 });
 
@@ -760,16 +814,25 @@ export const routineResponse = defineStructuredResponseContract({
 
 export const exerciseTemplatesResponse = defineStructuredResponseContract({
 	outputSchema: exerciseTemplatesOutputSchema,
-	normalize: (templates: readonly ExerciseTemplate[] | undefined) => ({
-		exerciseTemplates: templates?.map(formatExerciseTemplate) ?? [],
-	}),
+	normalize: (input: PaginatedInput<ExerciseTemplate>) => {
+		const data = normalizePaginatedInput(input);
+		return {
+			exerciseTemplates: data.items.map(formatExerciseTemplate),
+			page: data.page,
+			pageCount: data.pageCount,
+			hasNextPage:
+				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		};
+	},
 	legacyJson: ({ exerciseTemplates }) => exerciseTemplates,
 	text: (_data, { exerciseTemplates }) =>
 		exerciseTemplates.length === 0
 			? "No exercise templates found for the specified parameters"
 			: undefined,
 	telemetry: (templates) => ({
-		itemCountBucket: bucketCount(templates?.length ?? 0),
+		itemCountBucket: bucketCount(
+			normalizePaginatedInput(templates).items.length,
+		),
 	}),
 });
 
@@ -813,7 +876,7 @@ export const exerciseHistoryResponse = defineStructuredResponseContract({
 
 export const searchExerciseTemplatesResponse = defineStructuredResponseContract(
 	{
-		outputSchema: exerciseTemplatesOutputSchema,
+		outputSchema: exerciseTemplateSearchOutputSchema,
 		normalize: (data: {
 			results: readonly ExerciseTemplate[];
 			query: string;
@@ -832,16 +895,23 @@ export const searchExerciseTemplatesResponse = defineStructuredResponseContract(
 
 export const routineFoldersResponse = defineStructuredResponseContract({
 	outputSchema: routineFoldersOutputSchema,
-	normalize: (folders: readonly RoutineFolder[] | undefined) => ({
-		routineFolders: folders?.map(formatRoutineFolder) ?? [],
-	}),
+	normalize: (input: PaginatedInput<RoutineFolder>) => {
+		const data = normalizePaginatedInput(input);
+		return {
+			routineFolders: data.items.map(formatRoutineFolder),
+			page: data.page,
+			pageCount: data.pageCount,
+			hasNextPage:
+				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		};
+	},
 	legacyJson: ({ routineFolders }) => routineFolders,
 	text: (_data, { routineFolders }) =>
 		routineFolders.length === 0
 			? "No routine folders found for the specified parameters"
 			: undefined,
 	telemetry: (folders) => ({
-		itemCountBucket: bucketCount(folders?.length ?? 0),
+		itemCountBucket: bucketCount(normalizePaginatedInput(folders).items.length),
 	}),
 });
 
@@ -867,16 +937,25 @@ export const routineFolderResponse = defineStructuredResponseContract({
 
 export const bodyMeasurementsResponse = defineStructuredResponseContract({
 	outputSchema: bodyMeasurementsOutputSchema,
-	normalize: (measurements: readonly BodyMeasurement[] | undefined) => ({
-		bodyMeasurements: measurements?.map(formatBodyMeasurement) ?? [],
-	}),
+	normalize: (input: PaginatedInput<BodyMeasurement>) => {
+		const data = normalizePaginatedInput(input);
+		return {
+			bodyMeasurements: data.items.map(formatBodyMeasurement),
+			page: data.page,
+			pageCount: data.pageCount,
+			hasNextPage:
+				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		};
+	},
 	legacyJson: ({ bodyMeasurements }) => bodyMeasurements,
 	text: (_data, { bodyMeasurements }) =>
 		bodyMeasurements.length === 0
 			? "No body measurements found for the specified parameters"
 			: undefined,
 	telemetry: (measurements) => ({
-		itemCountBucket: bucketCount(measurements?.length ?? 0),
+		itemCountBucket: bucketCount(
+			normalizePaginatedInput(measurements).items.length,
+		),
 	}),
 });
 

--- a/packages/core/src/utils/response-formatter.ts
+++ b/packages/core/src/utils/response-formatter.ts
@@ -311,6 +311,7 @@ export type PaginatedToolResult<T> = {
 	items: readonly T[];
 	page: number;
 	pageCount?: number;
+	expected404Outcome?: "not_found" | "end_of_list";
 };
 type PaginatedInput<T> = PaginatedToolResult<T> | readonly T[] | undefined;
 function normalizePaginatedInput<T>(
@@ -730,6 +731,7 @@ export const workoutsResponse = defineStructuredResponseContract({
 		itemCountBucket: bucketCount(
 			normalizePaginatedInput(workouts).items.length,
 		),
+		expected404Outcome: normalizePaginatedInput(workouts).expected404Outcome,
 	}),
 });
 
@@ -738,11 +740,15 @@ export const workoutResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		workout: Workout | null | undefined;
 		workoutId: string;
+		expected404Outcome?: "not_found";
 	}) => ({ workout: data.workout ? formatWorkout(data.workout) : null }),
 	legacyJson: ({ workout }) => workout,
 	text: ({ workoutId }, { workout }) =>
 		workout === null ? `Workout with ID ${workoutId} not found` : undefined,
-	telemetry: ({ workout }) => workoutResultTelemetry(workout),
+	telemetry: ({ workout, expected404Outcome }) => ({
+		...workoutResultTelemetry(workout),
+		expected404Outcome,
+	}),
 });
 
 export const workoutCountResponse = defineStructuredResponseContract({
@@ -759,6 +765,7 @@ export const workoutEventsResponse = defineStructuredResponseContract({
 		since: string;
 		page: number;
 		pageCount?: number;
+		expected404Outcome?: "end_of_list";
 	}) => ({
 		events: data.events?.map(formatWorkoutEvent) ?? [],
 		page: data.page,
@@ -773,6 +780,7 @@ export const workoutEventsResponse = defineStructuredResponseContract({
 			: undefined,
 	telemetry: (data) => ({
 		itemCountBucket: bucketCount(data.events?.length ?? 0),
+		expected404Outcome: data.expected404Outcome,
 	}),
 });
 
@@ -797,6 +805,7 @@ export const routinesResponse = defineStructuredResponseContract({
 		itemCountBucket: bucketCount(
 			normalizePaginatedInput(routines).items.length,
 		),
+		expected404Outcome: normalizePaginatedInput(routines).expected404Outcome,
 	}),
 });
 
@@ -805,11 +814,15 @@ export const routineResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		routine: Routine | null | undefined;
 		routineId: string;
+		expected404Outcome?: "not_found";
 	}) => ({ routine: data.routine ? formatRoutine(data.routine) : null }),
 	legacyJson: ({ routine }) => routine,
 	text: ({ routineId }, { routine }) =>
 		routine === null ? `Routine with ID ${routineId} not found` : undefined,
-	telemetry: ({ routine }) => routineResultTelemetry(routine),
+	telemetry: ({ routine, expected404Outcome }) => ({
+		...routineResultTelemetry(routine),
+		expected404Outcome,
+	}),
 });
 
 export const exerciseTemplatesResponse = defineStructuredResponseContract({
@@ -833,6 +846,7 @@ export const exerciseTemplatesResponse = defineStructuredResponseContract({
 		itemCountBucket: bucketCount(
 			normalizePaginatedInput(templates).items.length,
 		),
+		expected404Outcome: normalizePaginatedInput(templates).expected404Outcome,
 	}),
 });
 
@@ -841,6 +855,7 @@ export const exerciseTemplateResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		exerciseTemplate: ExerciseTemplate | null | undefined;
 		exerciseTemplateId: string;
+		expected404Outcome?: "not_found";
 	}) => ({
 		exerciseTemplate: data.exerciseTemplate
 			? formatExerciseTemplate(data.exerciseTemplate)
@@ -851,8 +866,9 @@ export const exerciseTemplateResponse = defineStructuredResponseContract({
 		exerciseTemplate === null
 			? `Exercise template with ID ${exerciseTemplateId} not found`
 			: undefined,
-	telemetry: ({ exerciseTemplate }) => ({
+	telemetry: ({ exerciseTemplate, expected404Outcome }) => ({
 		itemCountBucket: bucketCount(exerciseTemplate ? 1 : 0),
+		expected404Outcome,
 	}),
 });
 
@@ -912,6 +928,7 @@ export const routineFoldersResponse = defineStructuredResponseContract({
 			: undefined,
 	telemetry: (folders) => ({
 		itemCountBucket: bucketCount(normalizePaginatedInput(folders).items.length),
+		expected404Outcome: normalizePaginatedInput(folders).expected404Outcome,
 	}),
 });
 
@@ -920,6 +937,7 @@ export const routineFolderResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		routineFolder: RoutineFolder | null | undefined;
 		folderId: string;
+		expected404Outcome?: "not_found";
 	}) => ({
 		routineFolder: data.routineFolder
 			? formatRoutineFolder(data.routineFolder)
@@ -930,8 +948,9 @@ export const routineFolderResponse = defineStructuredResponseContract({
 		routineFolder === null
 			? `Routine folder with ID ${folderId} not found`
 			: undefined,
-	telemetry: ({ routineFolder }) => ({
+	telemetry: ({ routineFolder, expected404Outcome }) => ({
 		itemCountBucket: bucketCount(routineFolder ? 1 : 0),
+		expected404Outcome,
 	}),
 });
 
@@ -956,6 +975,8 @@ export const bodyMeasurementsResponse = defineStructuredResponseContract({
 		itemCountBucket: bucketCount(
 			normalizePaginatedInput(measurements).items.length,
 		),
+		expected404Outcome:
+			normalizePaginatedInput(measurements).expected404Outcome,
 	}),
 });
 
@@ -964,6 +985,7 @@ export const bodyMeasurementResponse = defineStructuredResponseContract({
 	normalize: (data: {
 		bodyMeasurement: BodyMeasurement | null | undefined;
 		date: string;
+		expected404Outcome?: "not_found";
 	}) => ({
 		bodyMeasurement: data.bodyMeasurement
 			? formatBodyMeasurement(data.bodyMeasurement)
@@ -974,8 +996,9 @@ export const bodyMeasurementResponse = defineStructuredResponseContract({
 		bodyMeasurement === null
 			? `No body measurement found for date ${date}`
 			: undefined,
-	telemetry: ({ bodyMeasurement }) => ({
+	telemetry: ({ bodyMeasurement, expected404Outcome }) => ({
 		itemCountBucket: bucketCount(bodyMeasurement ? 1 : 0),
+		expected404Outcome,
 	}),
 });
 

--- a/packages/core/src/utils/result-telemetry.ts
+++ b/packages/core/src/utils/result-telemetry.ts
@@ -14,6 +14,7 @@ export interface ToolResultTelemetry {
 	readonly exerciseCountBucket?: ResultCountBucket;
 	readonly setCountBucket?: ResultCountBucket;
 	readonly workflow?: WorkflowResultTelemetry;
+	readonly expected404Outcome?: "not_found" | "end_of_list" | "mutation_error";
 }
 
 export function bucketCount(value: number): ResultCountBucket {

--- a/packages/node/src/utils/metrics.ts
+++ b/packages/node/src/utils/metrics.ts
@@ -32,6 +32,11 @@ export const toolErrors = meter.createCounter("mcp.tool.errors", {
 	description: "Total MCP tool errors",
 });
 
+/** Expected Hevy 404s handled as not-found, end-of-list, or caller errors. */
+export const expectedHevy404s = meter.createCounter("hevy.expected_404s", {
+	description: "Expected Hevy 404 outcomes",
+});
+
 /** MCP tool execution duration in milliseconds. */
 export const toolDuration = meter.createHistogram("mcp.tool.duration_ms", {
 	description: "MCP tool execution duration in milliseconds",

--- a/packages/node/src/utils/stdio-observability.test.ts
+++ b/packages/node/src/utils/stdio-observability.test.ts
@@ -5,7 +5,6 @@ import {
 	deserializeMessageWithObservability,
 	createInstrumentedStdioTransport,
 } from "./stdio-observability.js";
-import { Sentry } from "./telemetry.js";
 
 const testDoubles = vi.hoisted(() => ({
 	span: {
@@ -18,10 +17,6 @@ const testDoubles = vi.hoisted(() => ({
 		const callback = args.at(-1) as (span: unknown) => unknown;
 		return callback(testDoubles.span);
 	}),
-	withScope: vi.fn((callback: (scope: unknown) => void) =>
-		callback({ setTag: vi.fn(), setContext: vi.fn() }),
-	),
-	captureMessage: vi.fn(),
 	parseErrors: { add: vi.fn() },
 	recordSessionStart: vi.fn(() => ({
 		name: "test-client",
@@ -50,10 +45,6 @@ vi.mock("@modelcontextprotocol/sdk/shared/stdio.js", async () => {
 });
 
 vi.mock("./telemetry.js", () => ({
-	Sentry: {
-		withScope: testDoubles.withScope,
-		captureMessage: testDoubles.captureMessage,
-	},
 	tracer: { startActiveSpan: testDoubles.startActiveSpan },
 }));
 
@@ -172,17 +163,13 @@ describe("package-local stdio observability", () => {
 			1,
 			expect.objectContaining({ failure_location: expect.any(String) }),
 		);
-		expect(testDoubles.captureMessage).toHaveBeenCalledWith(
-			"MCP stdin parse failure",
-			"error",
-		);
 	});
 
 	it.each([
 		'{"api_key":"credential-sentinel"',
 		"{Authorization: Bearer bearer-sentinel",
 		'{"private-workout-field":"private-workout-sentinel"',
-	])("redacts malformed content from stderr and telemetry: %s", (line) => {
+	])("redacts malformed content from stderr: %s", (line) => {
 		const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		expect(() =>
@@ -199,9 +186,6 @@ describe("package-local stdio observability", () => {
 		expect(diagnostic).not.toContain("bearer-sentinel");
 		expect(diagnostic).not.toContain("private-workout-sentinel");
 		expect(shapePreview.length).toBeLessThanOrEqual(200);
-		expect(JSON.stringify(testDoubles.withScope.mock.calls)).not.toContain(
-			line,
-		);
 	});
 
 	it("keeps the SDK-internal transport adapter package-local", () => {
@@ -315,9 +299,5 @@ describe("package-local stdio observability", () => {
 				lastChunkStartsWithUtf8Bom: false,
 			}),
 		).toThrow(parserError);
-		expect(Sentry.captureMessage).toHaveBeenCalledWith(
-			"MCP stdin parse failure",
-			"error",
-		);
 	});
 });

--- a/packages/node/src/utils/stdio-observability.ts
+++ b/packages/node/src/utils/stdio-observability.ts
@@ -4,7 +4,7 @@ import { deserializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
 import { stdioParseErrors } from "./metrics.js";
-import { Sentry, tracer } from "./telemetry.js";
+import { tracer } from "./telemetry.js";
 import { recordMcpSessionStart } from "./mcp-session-observability.js";
 
 const UTF8_BOM = "\uFEFF";
@@ -290,25 +290,6 @@ export function deserializeMessageWithObservability(
 				}
 
 				stdioParseErrors.add(1, { failure_location: failureLocation });
-
-				Sentry.withScope((scope) => {
-					scope.setTag("mcp.transport", "stdio");
-					scope.setTag("mcp.stdio.parse.failure.location", failureLocation);
-					scope.setContext("mcpStdioParse", {
-						lineCharLength: line.length,
-						lineByteLength,
-						lineHadLeadingBom,
-						bomStripped: lineHadLeadingBom,
-						lastChunkByteLength: chunkSnapshot.lastChunkByteLength,
-						lastChunkStartsWithUtf8Bom:
-							chunkSnapshot.lastChunkStartsWithUtf8Bom,
-						failureLocation,
-						failurePosition,
-						failureStage: "deserializeMessage",
-						errorCategory: diagnostic.category,
-					});
-					Sentry.captureMessage("MCP stdin parse failure", "error");
-				});
 
 				reportStdinParseFailure(
 					error,

--- a/scripts/check-worker-import-boundary.mjs
+++ b/scripts/check-worker-import-boundary.mjs
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const workerEntries = ["packages/worker/src/worker.ts"];
+const nodeBuiltins = new Set([
+	"assert",
+	"buffer",
+	"child_process",
+	"cluster",
+	"console",
+	"constants",
+	"crypto",
+	"dgram",
+	"diagnostics_channel",
+	"dns",
+	"domain",
+	"events",
+	"fs",
+	"http",
+	"http2",
+	"https",
+	"module",
+	"net",
+	"os",
+	"path",
+	"perf_hooks",
+	"process",
+	"punycode",
+	"querystring",
+	"readline",
+	"repl",
+	"stream",
+	"string_decoder",
+	"sys",
+	"timers",
+	"tls",
+	"trace_events",
+	"tty",
+	"url",
+	"util",
+	"v8",
+	"vm",
+	"wasi",
+	"worker_threads",
+	"zlib",
+]);
+const forbiddenSourceFiles = new Set([
+	"packages/node/src/cli.ts",
+	"packages/node/src/index.ts",
+	"packages/node/src/utils/hevy-client-observability.ts",
+	"packages/node/src/utils/metrics.ts",
+	"packages/node/src/utils/mcp-session-observability.ts",
+	"packages/node/src/utils/observability-wrapper.ts",
+	"packages/node/src/utils/stdio-observability.ts",
+	"packages/node/src/utils/telemetry-wrapper.ts",
+	"packages/node/src/utils/telemetry.ts",
+]);
+const forbiddenPackages = [
+	"@sentry/node",
+	"@sentry/opentelemetry",
+	"@opentelemetry/sdk-metrics",
+	"@opentelemetry/sdk-trace-node",
+];
+
+function sourcePath(relativePath) {
+	return path.join(root, relativePath);
+}
+
+function resolveRelativeImport(fromFile, specifier) {
+	const base = path.resolve(path.dirname(fromFile), specifier);
+	const candidates = [base];
+	if (base.endsWith(".js")) candidates.push(`${base.slice(0, -3)}.ts`);
+	else candidates.push(`${base}.ts`);
+	candidates.push(path.join(base, "index.ts"));
+	return candidates.find((candidate) => {
+		try {
+			return fs.statSync(candidate).isFile();
+		} catch {
+			return false;
+		}
+	});
+}
+
+function importedSpecifiers(source) {
+	const specifiers = new Set();
+	const patterns = [
+		/\b(?:import|export)\s+(?:type\s+)?[^;]*?\sfrom\s*["']([^"']+)["']/g,
+		/\b(?:import|export)\s*["']([^"']+)["']/g,
+		/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+	];
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) specifiers.add(match[1]);
+	}
+	return specifiers;
+}
+
+function isNodeBuiltin(specifier) {
+	return specifier.startsWith("node:") || nodeBuiltins.has(specifier);
+}
+
+function formatChain(chain) {
+	return chain.map((file) => path.relative(root, file)).join(" -> ");
+}
+
+const pending = workerEntries.map((entry) => ({
+	file: sourcePath(entry),
+	chain: [sourcePath(entry)],
+}));
+const visited = new Set();
+const violations = [];
+
+while (pending.length > 0) {
+	const current = pending.pop();
+	if (visited.has(current.file)) continue;
+	visited.add(current.file);
+
+	const relativeFile = path.relative(root, current.file);
+	if (forbiddenSourceFiles.has(relativeFile)) {
+		violations.push(
+			`${formatChain(current.chain)} imports Node-only source ${relativeFile}`,
+		);
+		continue;
+	}
+
+	const source = fs.readFileSync(current.file, "utf8");
+	for (const specifier of importedSpecifiers(source)) {
+		if (isNodeBuiltin(specifier)) {
+			violations.push(
+				`${formatChain(current.chain)} imports Node builtin ${specifier}`,
+			);
+			continue;
+		}
+		if (forbiddenPackages.some((name) => specifier === name)) {
+			violations.push(
+				`${formatChain(current.chain)} imports Node-only package ${specifier}`,
+			);
+			continue;
+		}
+		if (!specifier.startsWith(".")) continue;
+		const resolved = resolveRelativeImport(current.file, specifier);
+		if (resolved)
+			pending.push({ file: resolved, chain: [...current.chain, resolved] });
+	}
+}
+
+if (violations.length > 0) {
+	console.error("Worker import boundary violations:");
+	for (const violation of violations) console.error(`- ${violation}`);
+	process.exitCode = 1;
+} else {
+	console.log(`Worker import boundary passed (${visited.size} source files).`);
+}

--- a/tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts
+++ b/tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts
@@ -170,7 +170,12 @@ describe("Hevy MCP workout detail endpoints mocked tests", () => {
 				type: "updated",
 				workout: { id: "workout-1" },
 			});
-			expect(result.structuredContent).toEqual({ events: payload });
+			expect(result.structuredContent).toEqual({
+				events: payload,
+				page: 1,
+				pageCount: 1,
+				hasNextPage: false,
+			});
 		} finally {
 			consoleErrorSpy.mockRestore();
 		}

--- a/tests/integration/mocked/hevy-mcp.mocked.integration.test.ts
+++ b/tests/integration/mocked/hevy-mcp.mocked.integration.test.ts
@@ -686,7 +686,7 @@ describe("Hevy MCP Server Mocked Integration Tests", () => {
 		});
 	});
 
-	it("returns MCP error output when Hevy API returns 404", async () => {
+	it("returns structured not-found output when Hevy API returns 404", async () => {
 		if (!client) throw new Error("Client not initialized");
 		const consoleErrorSpy = vi
 			.spyOn(console, "error")
@@ -701,9 +701,11 @@ describe("Hevy MCP Server Mocked Integration Tests", () => {
 				workoutId: "missing-workout",
 			});
 
-			expect(result.isError).toBe(true);
-			expect(result.text).toContain("[get-workout] Error");
-			expect(result.text.toLowerCase()).toContain("not found");
+			expect(result.isError).toBeFalsy();
+			expect(result.structuredContent).toEqual({ workout: null });
+			expect(result.text).toContain(
+				"Workout with ID missing-workout not found",
+			);
 		} finally {
 			consoleErrorSpy.mockRestore();
 		}


### PR DESCRIPTION
## Primary changes

- Normalize known single-resource GET 404s to structured not-found responses.
- Treat only later-page list 404s as end-of-list and preserve pagination metadata.
- Keep unexpected failures at Sentry error level while routing expected mutation 404s to bounded metrics.
- Reduce malformed-stdin Sentry issue noise without weakening strict protocol handling.
- Add a Worker import-boundary checker to prevent Node-only dependencies entering the Worker graph.
- Run the Wrangler Worker dry-run in PR CI.
- Add focused policy, privacy, response, and integration coverage plus a patch changeset.

## Reviewer walkthrough

- Follow expected-404 classification in `packages/core/src/utils/hevy-error-policy.ts` into the tool and response changes.
- Check list and single-resource behavior in `packages/core/src/tools/*`, `packages/core/src/utils/response-formatter.ts`, and the mocked integration tests.
- Review expected-outcome metrics and malformed-stdin handling in `packages/node/src/utils/*`.
- Verify `scripts/check-worker-import-boundary.mjs`, `package.json`, and `.github/workflows/build-and-test.yml` enforce the Worker dry-run.

## Correctness and invariants

- Known single-resource GET 404s produce structured not-found results; only later-page list 404s terminate pagination.
- List responses preserve pagination metadata, including page counts and next-page indicators.
- Unexpected failures remain Sentry errors, while expected mutation 404s use bounded metrics and malformed stdin still fails strictly.
- Worker-boundary checks keep Node-only dependencies out of the Worker graph.

## Testing and QA

- Reported validation before the latest CI-only commit: `npm run build`, `npm run check`, `npm run check:types`, `npm run worker:dry-run`, `npm run test:unit`, `npm run test:mcp`, and `npm run check:changeset`.
- Reported results: 51 unit test files / 691 unit tests passed; 2 mocked integration files / 16 tests passed.
- Current PR checks are re-running after the Worker import-boundary CI update.

No Sentry state was mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent pagination details, including page counts and next-page indicators, to list responses.
  * Improved handling of expected “not found” results with clear empty-list or null-item responses.
  * Added telemetry tracking for expected API outcomes while reducing unnecessary error reporting.

* **Bug Fixes**
  * Workout, routine, folder, template, and body-measurement requests now handle missing pages and items consistently.
  * Standardized malformed stdio failure reporting through tracing and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
