### PR TITLE
fix: observe prompt failures and allow previews

### DIFF
--- a/.changeset/clever-prompts.md
+++ b/.changeset/clever-prompts.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Observe workout prompt failures safely and support prompt previews when routine arguments are omitted.

--- a/packages/core/src/observation.ts
+++ b/packages/core/src/observation.ts
@@ -51,6 +51,8 @@ export type SafeToolBooleanArgumentKey = Extract<
 
 export interface ToolInvocationObservation {
 	readonly name: string;
+	/** The MCP primitive being observed; omitted values remain tool-compatible. */
+	readonly kind?: "tool" | "prompt";
 	readonly taxonomy?: ToolTelemetryMetadata;
 	readonly argumentKeys?: readonly SafeToolArgumentKey[];
 	readonly argumentPresence?: Partial<

--- a/packages/core/src/prompts/workouts.test.ts
+++ b/packages/core/src/prompts/workouts.test.ts
@@ -47,8 +47,8 @@ describe("workout prompts", () => {
 					title: "Create Workout From Routine",
 					description: expect.stringContaining("routine"),
 					arguments: expect.arrayContaining([
-						expect.objectContaining({ name: "routineId", required: true }),
-						expect.objectContaining({ name: "startTime", required: true }),
+						expect.objectContaining({ name: "routineId", required: false }),
+						expect.objectContaining({ name: "startTime", required: false }),
 					]),
 				}),
 			]),
@@ -141,5 +141,18 @@ describe("workout prompts", () => {
 				},
 			}),
 		).rejects.toThrow();
+	});
+
+	it("returns a generic preview when routine arguments are omitted", async () => {
+		const result = await client.getPrompt({
+			name: "create-workout-from-routine",
+			arguments: {},
+		});
+
+		expect(result.messages[0]?.content).toEqual(
+			expect.objectContaining({
+				text: "Provide a routineId and startTime to generate the full prompt.",
+			}),
+		);
 	});
 });

--- a/packages/core/src/prompts/workouts.ts
+++ b/packages/core/src/prompts/workouts.ts
@@ -1,10 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { utcSecondTimestamp } from "../utils/schemas.js";
-import {
-	memoizeObservationScope,
-	type ToolObserver,
-} from "../observation.js";
+import { memoizeObservationScope, type ToolObserver } from "../observation.js";
 import { bucketCount } from "../utils/result-telemetry.js";
 import { resolveErrorPolicy } from "../utils/error-policy.js";
 
@@ -28,12 +25,10 @@ function withPromptObservation<TArgs extends Record<string, unknown>>(
 				observer?.start({
 					name,
 					kind: "prompt",
-					argumentKeys: Object.keys(args).filter((key) =>
-						key === "routineId",
-					) as ("routineId")[],
-					argumentPresence: args.routineId
-						? { routineId: true }
-						: {},
+					argumentKeys: Object.keys(args).filter(
+						(key) => key === "routineId",
+					) as "routineId"[],
+					argumentPresence: args.routineId ? { routineId: true } : {},
 					argumentKeyCountBucket: bucketCount(Object.keys(args).length),
 				}),
 			);
@@ -89,23 +84,27 @@ export function registerWorkoutPrompts(
 					.describe("Number of recent weeks to analyze (1-12)."),
 			},
 		},
-		withPromptObservation("analyze-workout-progress", observer, ({ weeks = 4 }) => ({
-			messages: [
-				{
-					role: "user",
-					content: {
-						type: "text",
-						text: [
-							`Analyze my workout progress over the last ${weeks} weeks.`,
-							"Call get-training-summary with the requested weeks; it combines recent workouts and body measurements into one compact evidence set.",
-							"Use the returned period, workout frequency, volume, exercise variety, session list, and measurement trend fields rather than issuing separate count and pagination calls.",
-							"Base the analysis on retrieved evidence and discuss workout frequency, training volume, exercise variety, consistency, and body-measurement trends.",
-							"Distinguish observations from suggestions, note missing or limited data, and do not make unsupported claims or medical conclusions.",
-						].join("\n"),
+		withPromptObservation(
+			"analyze-workout-progress",
+			observer,
+			({ weeks = 4 }) => ({
+				messages: [
+					{
+						role: "user",
+						content: {
+							type: "text",
+							text: [
+								`Analyze my workout progress over the last ${weeks} weeks.`,
+								"Call get-training-summary with the requested weeks; it combines recent workouts and body measurements into one compact evidence set.",
+								"Use the returned period, workout frequency, volume, exercise variety, session list, and measurement trend fields rather than issuing separate count and pagination calls.",
+								"Base the analysis on retrieved evidence and discuss workout frequency, training volume, exercise variety, consistency, and body-measurement trends.",
+								"Distinguish observations from suggestions, note missing or limited data, and do not make unsupported claims or medical conclusions.",
+							].join("\n"),
+						},
 					},
-				},
-			],
-		})),
+				],
+			}),
+		),
 	);
 
 	server.registerPrompt(
@@ -114,32 +113,41 @@ export function registerWorkoutPrompts(
 			title: "Create Workout From Routine",
 			description: "Create a completed workout from an existing routine.",
 			argsSchema: {
-				routineId: z.string().min(1).optional().describe("Routine ID to use as a guide."),
-				startTime: utcSecondTimestamp.optional().describe(
-					"Workout start time in UTC as YYYY-MM-DDTHH:mm:ssZ.",
-				),
+				routineId: z
+					.string()
+					.min(1)
+					.optional()
+					.describe("Routine ID to use as a guide."),
+				startTime: utcSecondTimestamp
+					.optional()
+					.describe("Workout start time in UTC as YYYY-MM-DDTHH:mm:ssZ."),
 			},
 		},
-		withPromptObservation("create-workout-from-routine", observer, ({ routineId, startTime }) => ({
-			messages: [
-				{
-					role: "user",
-					content: {
-						type: "text",
-						text: routineId && startTime
-							? [
-							`Create a workout from routine ${routineId}, starting at ${startTime}.`,
-							"First call get-routine with the routineId and map supported plan fields: routine title to workout title, plus each exerciseTemplateId, supersetId, exercise notes, and set type.",
-							"Do not copy routine-only restSeconds or repRange fields into create-workout.",
-							"Before calling create-workout, confirm or collect the user's actual completed set data for every set, including applicable weight, reps, distance, duration, RPE, or custom metric values.",
-							"Also collect the required endTime in strict UTC YYYY-MM-DDTHH:mm:ssZ format and confirm any other missing required workout fields.",
-							"Never invent completion data. If the actual results or endTime are unavailable, ask the user for them instead of creating the workout.",
-							"Once confirmed, call create-workout with only fields supported by that tool.",
-							].join("\n")
-							: "Provide a routineId and startTime to generate the full prompt.",
+		withPromptObservation(
+			"create-workout-from-routine",
+			observer,
+			({ routineId, startTime }) => ({
+				messages: [
+					{
+						role: "user",
+						content: {
+							type: "text",
+							text:
+								routineId && startTime
+									? [
+											`Create a workout from routine ${routineId}, starting at ${startTime}.`,
+											"First call get-routine with the routineId and map supported plan fields: routine title to workout title, plus each exerciseTemplateId, supersetId, exercise notes, and set type.",
+											"Do not copy routine-only restSeconds or repRange fields into create-workout.",
+											"Before calling create-workout, confirm or collect the user's actual completed set data for every set, including applicable weight, reps, distance, duration, RPE, or custom metric values.",
+											"Also collect the required endTime in strict UTC YYYY-MM-DDTHH:mm:ssZ format and confirm any other missing required workout fields.",
+											"Never invent completion data. If the actual results or endTime are unavailable, ask the user for them instead of creating the workout.",
+											"Once confirmed, call create-workout with only fields supported by that tool.",
+										].join("\n")
+									: "Provide a routineId and startTime to generate the full prompt.",
+						},
 					},
-				},
-			],
-		})),
+				],
+			}),
+		),
 	);
 }

--- a/packages/core/src/prompts/workouts.ts
+++ b/packages/core/src/prompts/workouts.ts
@@ -1,9 +1,78 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { utcSecondTimestamp } from "../utils/schemas.js";
+import {
+	memoizeObservationScope,
+	type ToolObserver,
+} from "../observation.js";
+import { bucketCount } from "../utils/result-telemetry.js";
+import { resolveErrorPolicy } from "../utils/error-policy.js";
+
+type PromptResult = {
+	messages: Array<{
+		role: "user" | "assistant";
+		content: { type: "text"; text: string };
+	}>;
+};
+
+function withPromptObservation<TArgs extends Record<string, unknown>>(
+	name: string,
+	observer: ToolObserver | undefined,
+	handler: (args: TArgs) => Promise<PromptResult> | PromptResult,
+) {
+	return async (args: TArgs): Promise<PromptResult> => {
+		const startedAt = Date.now();
+		let scope;
+		try {
+			scope = memoizeObservationScope(
+				observer?.start({
+					name,
+					kind: "prompt",
+					argumentKeys: Object.keys(args).filter((key) =>
+						key === "routineId",
+					) as ("routineId")[],
+					argumentPresence: args.routineId
+						? { routineId: true }
+						: {},
+					argumentKeyCountBucket: bucketCount(Object.keys(args).length),
+				}),
+			);
+		} catch {
+			scope = undefined;
+		}
+
+		try {
+			const invoke = () => Promise.resolve(handler(args));
+			const result = await (scope ? scope.run(invoke) : invoke());
+			void scope?.finish({
+				outcome: "success",
+				durationMs: Date.now() - startedAt,
+				result: {
+					isError: false,
+					hasStructuredContent: false,
+					contentCountBucket: bucketCount(result.messages.length),
+				},
+			});
+			return result;
+		} catch (error) {
+			const policy = resolveErrorPolicy(error, "MCP prompt failed");
+			void scope?.finish({
+				outcome: "thrown_error",
+				durationMs: Date.now() - startedAt,
+				errorType: policy.type,
+				error: policy.diagnostic,
+			});
+			console.error("MCP prompt failure", policy.diagnostic);
+			throw error;
+		}
+	};
+}
 
 /** Register guided workout workflow prompts. */
-export function registerWorkoutPrompts(server: McpServer) {
+export function registerWorkoutPrompts(
+	server: McpServer,
+	observer?: ToolObserver,
+) {
 	server.registerPrompt(
 		"analyze-workout-progress",
 		{
@@ -20,7 +89,7 @@ export function registerWorkoutPrompts(server: McpServer) {
 					.describe("Number of recent weeks to analyze (1-12)."),
 			},
 		},
-		({ weeks = 4 }) => ({
+		withPromptObservation("analyze-workout-progress", observer, ({ weeks = 4 }) => ({
 			messages: [
 				{
 					role: "user",
@@ -36,7 +105,7 @@ export function registerWorkoutPrompts(server: McpServer) {
 					},
 				},
 			],
-		}),
+		})),
 	);
 
 	server.registerPrompt(
@@ -45,19 +114,20 @@ export function registerWorkoutPrompts(server: McpServer) {
 			title: "Create Workout From Routine",
 			description: "Create a completed workout from an existing routine.",
 			argsSchema: {
-				routineId: z.string().min(1).describe("Routine ID to use as a guide."),
-				startTime: utcSecondTimestamp.describe(
+				routineId: z.string().min(1).optional().describe("Routine ID to use as a guide."),
+				startTime: utcSecondTimestamp.optional().describe(
 					"Workout start time in UTC as YYYY-MM-DDTHH:mm:ssZ.",
 				),
 			},
 		},
-		({ routineId, startTime }) => ({
+		withPromptObservation("create-workout-from-routine", observer, ({ routineId, startTime }) => ({
 			messages: [
 				{
 					role: "user",
 					content: {
 						type: "text",
-						text: [
+						text: routineId && startTime
+							? [
 							`Create a workout from routine ${routineId}, starting at ${startTime}.`,
 							"First call get-routine with the routineId and map supported plan fields: routine title to workout title, plus each exerciseTemplateId, supersetId, exercise notes, and set type.",
 							"Do not copy routine-only restSeconds or repRange fields into create-workout.",
@@ -65,10 +135,11 @@ export function registerWorkoutPrompts(server: McpServer) {
 							"Also collect the required endTime in strict UTC YYYY-MM-DDTHH:mm:ssZ format and confirm any other missing required workout fields.",
 							"Never invent completion data. If the actual results or endTime are unavailable, ask the user for them instead of creating the workout.",
 							"Once confirmed, call create-workout with only fields supported by that tool.",
-						].join("\n"),
+							].join("\n")
+							: "Provide a routineId and startTime to generate the full prompt.",
 					},
 				},
 			],
-		}),
+		})),
 	);
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -72,7 +72,7 @@ export function createHevyMcpServer(
 	const counting = createCountingServer(server);
 	registerHevyTools(counting.server, runtime);
 	options.onToolsRegistered?.(counting.getCount());
-	registerWorkoutPrompts(server);
+	registerWorkoutPrompts(server, options.observer);
 	registerHevyResources(server, runtime);
 	return server;
 }

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -239,6 +239,34 @@ describe("createNodeToolObserver", () => {
 		expect(testDoubles.span.end).toHaveBeenCalledOnce();
 	});
 
+	it("uses prompt-specific telemetry for prompt failures", async () => {
+		const promptInvocation = {
+			name: "create-workout-from-routine",
+			kind: "prompt",
+			argumentKeyCountBucket: "0",
+		} satisfies SafeToolInvocation;
+		const scope = createNodeToolObserver().start(promptInvocation);
+		if (!scope) throw new Error("Expected the Node observer to create a scope");
+
+		await expect(scope.run(() => Promise.reject(new Error("prompt failure")))).rejects.toThrow();
+		await scope.finish({
+			outcome: "thrown_error",
+			durationMs: 3,
+			errorType: ErrorType.UNKNOWN_ERROR,
+			error: { category: "Error", status: 500 },
+		});
+
+		expect(testDoubles.sentryCaptureMessage).toHaveBeenCalledWith(
+			"MCP prompt failure",
+			"error",
+		);
+		expect(testDoubles.sentrySetFingerprint).toHaveBeenCalledWith([
+			"mcp-prompt-failure",
+			"Error",
+			"500",
+		]);
+	});
+
 	it("marks returned MCP errors as session failures without error exceptions", async () => {
 		const scope = startScope();
 		await scope.run(() => Promise.resolve("returned error"));

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -248,7 +248,9 @@ describe("createNodeToolObserver", () => {
 		const scope = createNodeToolObserver().start(promptInvocation);
 		if (!scope) throw new Error("Expected the Node observer to create a scope");
 
-		await expect(scope.run(() => Promise.reject(new Error("prompt failure")))).rejects.toThrow();
+		await expect(
+			scope.run(() => Promise.reject(new Error("prompt failure"))),
+		).rejects.toThrow();
 		await scope.finish({
 			outcome: "thrown_error",
 			durationMs: 3,

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -55,8 +55,10 @@ function createAttributes(
 	invocation: SafeToolInvocation,
 ): Record<string, AttributeValue> {
 	const clientMetadata = getCurrentMcpClientMetadata();
+	const isPrompt = invocation.kind === "prompt";
 	const attributes: Record<string, AttributeValue> = {
-		"mcp.tool.name": invocation.name,
+		[isPrompt ? "mcp.prompt.name" : "mcp.tool.name"]: invocation.name,
+		"mcp.operation.kind": invocation.kind ?? "tool",
 		...taxonomyAttributes(invocation),
 		"mcp.client.name": clientMetadata.name,
 		"mcp.client.version": clientMetadata.version,
@@ -188,7 +190,12 @@ function captureSafeToolFailure(
 	const category = diagnostic?.category ?? "UnknownError";
 	try {
 		Sentry.withScope((scope) => {
-			scope.setTag("mcp.tool.context", invocation.name);
+			const isPrompt = invocation.kind === "prompt";
+			if (isPrompt) {
+				scope.setTag("mcp.prompt.name", invocation.name);
+			} else {
+				scope.setTag("mcp.tool.context", invocation.name);
+			}
 			scope.setTag("error.category", category);
 			if (diagnostic?.code) scope.setTag("error.code", diagnostic.code);
 			if (diagnostic?.status !== undefined) {
@@ -197,20 +204,23 @@ function captureSafeToolFailure(
 			if (diagnostic?.endpoint) {
 				scope.setTag("hevy.api.endpoint", diagnostic.endpoint);
 			}
-			scope.setContext("mcpTool", {
+			scope.setContext(invocation.kind === "prompt" ? "mcpPrompt" : "mcpTool", {
 				context: invocation.name,
 				argumentKeyCountBucket: invocation.argumentKeyCountBucket ?? "unknown",
 			});
 			scope.setContext("safeError", diagnostic ? { ...diagnostic } : {});
 			scope.setFingerprint([
-				"mcp-tool-failure",
-				invocation.name,
+				isPrompt ? "mcp-prompt-failure" : "mcp-tool-failure",
+				...(isPrompt ? [] : [invocation.name]),
 				category,
-				diagnostic?.code ?? "none",
+				...(isPrompt ? [] : [diagnostic?.code ?? "none"]),
 				String(diagnostic?.status ?? "none"),
-				diagnostic?.endpoint ?? "none",
+				...(isPrompt ? [] : [diagnostic?.endpoint ?? "none"]),
 			]);
-			Sentry.captureMessage("MCP tool failure", "error");
+			Sentry.captureMessage(
+				isPrompt ? "MCP prompt failure" : "MCP tool failure",
+				"error",
+			);
 		});
 	} catch {
 		// Sentry failures must never affect tool responses.


### PR DESCRIPTION
Closes #728

## Summary
- Observe workout prompt invocations through the existing privacy-safe observer path.
- Capture prompt failures with prompt-specific Sentry context and fingerprints, then rethrow MCP errors.
- Allow create-workout-from-routine to return a generic preview when arguments are omitted.
- Add regression coverage and a patch changeset.

## Validation
- `npx tsc --noEmit -p packages/core/tsconfig.json`
- `npx vitest run packages/core/src/prompts/workouts.test.ts packages/node/src/utils/tool-observer.test.ts`
- `git diff --check`

The full workspace typecheck remains blocked by pre-existing dependency/type issues in packages/node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workout prompts now support preview messages when routine details are omitted.
  * Prompt activity is now tracked separately from tool activity.
* **Bug Fixes**
  * Prompt failures are safely captured and reported with prompt-specific diagnostics.
  * Workout prompt errors now preserve the original error while recording useful failure details.
* **Tests**
  * Added coverage for prompt previews and prompt failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->