### PR TITLE
fix: group Sentry tool failures by status (#729)

### DIFF
--- a/.changeset/stable-fingerprints.md
+++ b/.changeset/stable-fingerprints.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Group MCP tool failure telemetry by sanitized error category and HTTP status while preserving per-event context tags.

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -203,11 +203,8 @@ describe("createNodeToolObserver", () => {
 		);
 		expect(testDoubles.sentrySetFingerprint).toHaveBeenCalledWith([
 			"mcp-tool-failure",
-			"get-workouts",
 			"HevyHttpError",
-			"ETIMEDOUT",
 			"503",
-			"/v1/workouts",
 		]);
 		expect(testDoubles.span.addEvent).toHaveBeenCalledWith("mcp.tool.failure", {
 			"error.category": "HevyHttpError",

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -266,6 +266,27 @@ describe("createNodeToolObserver", () => {
 		]);
 	});
 
+	it("keeps sanitized status-less error codes distinct in Sentry", async () => {
+		const scope = startScope();
+
+		await scope.finish({
+			outcome: "thrown_error",
+			durationMs: 7,
+			errorType: ErrorType.NETWORK_ERROR,
+			error: {
+				category: "Error",
+				code: "ENOTFOUND",
+			},
+		});
+
+		expect(testDoubles.sentrySetFingerprint).toHaveBeenCalledWith([
+			"mcp-tool-failure",
+			"Error",
+			"none",
+			"ENOTFOUND",
+		]);
+	});
+
 	it("marks returned MCP errors as session failures without error exceptions", async () => {
 		const scope = startScope();
 		await scope.run(() => Promise.resolve("returned error"));

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -213,7 +213,7 @@ function captureSafeToolFailure(
 				isPrompt ? "mcp-prompt-failure" : "mcp-tool-failure",
 				category,
 				String(diagnostic?.status ?? "none"),
-				...(!isPrompt && diagnostic?.status === undefined && diagnostic.code
+				...(diagnostic && diagnostic.status === undefined && diagnostic.code
 					? [diagnostic.code]
 					: []),
 			]);

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -211,11 +211,11 @@ function captureSafeToolFailure(
 			scope.setContext("safeError", diagnostic ? { ...diagnostic } : {});
 			scope.setFingerprint([
 				isPrompt ? "mcp-prompt-failure" : "mcp-tool-failure",
-				...(isPrompt ? [] : [invocation.name]),
 				category,
-				...(isPrompt ? [] : [diagnostic?.code ?? "none"]),
 				String(diagnostic?.status ?? "none"),
-				...(isPrompt ? [] : [diagnostic?.endpoint ?? "none"]),
+				...(!isPrompt && diagnostic?.status === undefined && diagnostic.code
+					? [diagnostic.code]
+					: []),
 			]);
 			Sentry.captureMessage(
 				isPrompt ? "MCP prompt failure" : "MCP tool failure",


### PR DESCRIPTION
## Primary changes
- Group MCP tool failure events in Sentry by the fixed failure marker, sanitized error category, and HTTP status instead of tool name, call stack/context, or endpoint.
- Preserve per-event tool context, endpoint, status, and other diagnostic tags for investigation.
- Include a sanitized error code for status-less failures so distinct network errors remain separately actionable.
- Add regression coverage and a patch changeset for the stable fingerprint shape.

## Reviewer walkthrough
- `packages/node/src/utils/tool-observer.ts`: `captureSafeToolFailure` keeps prompt/tool markers and diagnostic tags/context while reducing fingerprints to stable grouping fields.
- `packages/node/src/utils/tool-observer.test.ts`: updates the HTTP-status expectation and covers status-less code handling.
- `.changeset/stable-fingerprints.md`: records the runtime-visible telemetry change.

## Correctness and invariants
- HTTP-status-bearing failures group by failure kind, sanitized category, and status; tool name and endpoint remain event-level context rather than fingerprint components.
- Status-less failures append the already sanitized diagnostic code when present; absent codes remain grouped under the category and `none` status.
- Prompt failures retain their prompt-specific fingerprint marker, and observability failures remain best-effort so tool responses are unaffected.

## Testing and QA
- `npx vitest run packages/node/src/utils/tool-observer.test.ts`
- `git diff --check`
- The full workspace typecheck remains blocked by pre-existing dependency/type issues in `packages/node`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MCP tool failure telemetry fingerprinting to standardize grouping using a fixed failure marker plus sanitized error category and HTTP status.
  * Reduced noisy fingerprint variations by omitting tool name and endpoint details; diagnostic codes are included only when HTTP status is unavailable (using a `none` placeholder when needed).
* **Tests**
  * Updated and added telemetry assertions to match the new fingerprint structure, including scenarios without HTTP status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #729