### PR TITLE
fix: allow opaque origins for oauth forms

### DIFF
--- a/.changeset/opaque-oauth-origin.md
+++ b/.changeset/opaque-oauth-origin.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Allow sandboxed OAuth consent forms with an opaque browser origin to submit authorization safely.

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -128,6 +128,38 @@ describe("Cloudflare Worker routes and CORS", () => {
 		expect(rejected.headers.get("vary")).toBe("Origin");
 	});
 
+	it("allows opaque origins for OAuth form submissions only", async () => {
+		const oauthKv = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn(),
+			delete: vi.fn(),
+			list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+		};
+		const fetchHandler = createWorkerFetchHandler();
+		const oauthForm = await fetchHandler(
+			new Request("https://worker.example/authorize", {
+				method: "POST",
+				headers: {
+					origin: "null",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				body: "",
+			}),
+			{ OAUTH_KV: oauthKv },
+		);
+		expect(oauthForm.status).toBe(400);
+		expect(oauthForm.headers.get("access-control-allow-origin")).toBe("null");
+
+		const mcp = await fetchHandler(
+			new Request("https://worker.example/mcp", {
+				method: "OPTIONS",
+				headers: { origin: "null" },
+			}),
+			{ OAUTH_KV: oauthKv },
+		);
+		expect(mcp.status).toBe(403);
+	});
+
 	it("can disable origin validation explicitly for non-production clients", async () => {
 		const result = await handler(
 			new Request("https://worker.example/mcp", {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -20,6 +20,7 @@ import {
 } from "./worker-oauth.js";
 
 const MCP_PATH = "/mcp";
+const OAUTH_AUTHORIZE_PATH = "/authorize";
 const HEVY_API_BASE_URL = "https://api.hevyapp.com";
 const AUTH_VALIDATION_TIMEOUT_MS = 5_000;
 const CORS_ALLOWED_HEADERS =
@@ -116,17 +117,28 @@ function validateOrigin(
 	env: WorkerEnv,
 ): string | null | Response {
 	const origin = request.headers.get("origin");
+	const url = new URL(request.url);
 	if (!origin) return null;
+	if (
+		origin === "null" &&
+		request.method === "POST" &&
+		url.pathname === OAUTH_AUTHORIZE_PATH &&
+		isOAuthEnabled(env)
+	) {
+		// Sandboxed browser contexts submit OAuth consent forms with an opaque
+		// origin. Keep this exception route-specific; never allow it for MCP.
+		return origin;
+	}
 	if (env.MCP_DISABLE_ORIGIN_CHECK?.trim().toLowerCase() === "true") {
 		return origin;
 	}
-	if (origin === new URL(request.url).origin) return origin;
+	if (origin === url.origin) return origin;
 	if (!parseAllowedOrigins(env.MCP_ALLOWED_ORIGINS).has(origin)) {
 		console.warn({
 			event: "worker.origin_rejected",
 			requestId: request.headers.get("cf-ray") ?? null,
 			method: request.method,
-			path: new URL(request.url).pathname,
+			path: url.pathname,
 			origin,
 		});
 		return new Response("Forbidden", {


### PR DESCRIPTION
## Summary
- permit `Origin: null` only for authenticated Worker OAuth form POSTs to `/authorize`
- keep opaque origins rejected for MCP and other routes
- add regression coverage and a changeset

## Root cause
Sandboxed Chrome consent form submissions send `Origin: null`. The Worker rejected that opaque origin before reaching the OAuth form handler.

## Verification
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- `npx vitest run packages/worker/src/worker.test.ts packages/worker/src/worker-oauth.test.ts`