### PR TITLE
fix(release): preserve plugin manifest formatting

### DIFF
--- a/scripts/server-manifest.mjs
+++ b/scripts/server-manifest.mjs
@@ -213,7 +213,7 @@ export async function runServerManifest({ mode, rootDir = process.cwd() }) {
 
 	if (pluginJson && pluginJson.version !== packageJson.version) {
 		pluginJson.version = packageJson.version;
-		const updatedPluginContents = `${JSON.stringify(pluginJson, null, 2)}\n`;
+		const updatedPluginContents = `${JSON.stringify(pluginJson, null, "\t")}\n`;
 		await writeFile(pluginPath, updatedPluginContents, "utf8");
 	}
 


### PR DESCRIPTION
## Summary
- Generate `plugin.json` with tab indentation, matching repository formatting.
- Prevent release PRs from failing `oxfmt` after manifest synchronization.

## Validation
- `npm run sync:server-manifest`
- `npm run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated generated manifest files to use tab-based indentation for more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->