### PR TITLE
fix: restore npm provenance metadata

### DIFF
--- a/.changeset/clever-repos-prove.md
+++ b/.changeset/clever-repos-prove.md
@@ -1,0 +1,6 @@
+---
+"@chrisdoc/hevy-cli": patch
+"hevy-mcp": patch
+---
+
+Include repository metadata in published package manifests for npm provenance validation.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,10 @@
 	"version": "0.1.0",
 	"description": "Command-line client for the Hevy API",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/chrisdoc/hevy-mcp"
+	},
 	"bin": {
 		"hevy": "dist/cli.mjs"
 	},

--- a/packages/cli/tests/npm-pack-smoke.mjs
+++ b/packages/cli/tests/npm-pack-smoke.mjs
@@ -20,6 +20,8 @@ try {
 	);
 	if (manifest.name !== "@chrisdoc/hevy-cli")
 		throw new Error("CLI package metadata missing");
+	if (manifest.repository?.url !== "https://github.com/chrisdoc/hevy-mcp")
+		throw new Error("CLI package repository metadata missing");
 	if (manifest.dependencies && Object.keys(manifest.dependencies).length)
 		throw new Error("CLI has runtime dependencies");
 	await exec("tar", ["-xzf", join(dir, names[0]), "-C", dir]);

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,6 +3,10 @@
 	"version": "4.0.0",
 	"private": false,
 	"description": "A Model Context Protocol (MCP) server implementation that interfaces with the Hevy fitness tracking app and its API.",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/chrisdoc/hevy-mcp"
+	},
 	"bin": {
 		"hevy-mcp": "dist/cli.mjs"
 	},

--- a/tests/package/npm-pack-smoke.mjs
+++ b/tests/package/npm-pack-smoke.mjs
@@ -210,6 +210,16 @@ try {
 		throw new Error("npm pack did not produce a real Node workspace tarball");
 	}
 	const tarball = join(tempDir, tarballName);
+	const packedManifest = JSON.parse(
+		spawnSync("tar", ["-xOf", tarball, "package/package.json"], {
+			encoding: "utf8",
+		}).stdout,
+	);
+	if (
+		packedManifest.repository?.url !== "https://github.com/chrisdoc/hevy-mcp"
+	) {
+		throw new Error("Package repository metadata missing");
+	}
 	const installDir = join(tempDir, "consumer");
 	mkdirSync(installDir, { recursive: true });
 	runNpm(["init", "--yes"], { cwd: installDir, stdio: "pipe" });


### PR DESCRIPTION
## Summary

- add the canonical repository URL to the published CLI and Node package manifests
- assert repository metadata in both npm package smoke tests
- add patch changesets for both publishable packages

## Root cause

The release job reached the npm publish step successfully, but trusted publishing rejected both packages because their packed `package.json` files had an empty `repository.url`. npm expected `https://github.com/chrisdoc/hevy-mcp` to match the GitHub Actions provenance.

## Validation

- `npm run build`
- `npx vitest run --exclude tests/integration/**`
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- `npm run test:pr` (also run by the pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added repository metadata to published CLI and MCP package manifests.
  * Improved npm package provenance validation by including the project’s source repository details.

* **Tests**
  * Added package smoke-test checks to verify repository metadata is preserved in generated npm archives.

* **Release**
  * Scheduled patch releases for the CLI and MCP packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->