### PR TITLE
feat(node): add opt-in streamable HTTP transport

### DIFF
--- a/.changeset/quiet-http-transport.md
+++ b/.changeset/quiet-http-transport.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": minor
+---
+
+Add opt-in Streamable HTTP transport to the Node package while preserving stdio as the default.

--- a/README.md
+++ b/README.md
@@ -458,20 +458,37 @@ self-hosted Streamable HTTP.
 
 ## Advanced configuration
 
-| Setting                | Default                        | Scope                         | Notes                                                                                                               |
-| ---------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `HEVY_API_KEY`         | None; required                 | Local stdio                   | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
-| `HEVY_MCP_API_TIMEOUT` | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
-| `HEVY_MCP_DEBUG`       | Disabled                       | Local stdio                   | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
-| `XDG_CACHE_HOME`       | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
-| `SENTRY_DSN`           | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
-| `SENTRY_RELEASE`       | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
-| `-h`, `--help`         | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
-| `-v`, `--version`      | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
+| Setting                      | Default                        | Scope                         | Notes                                                                                                               |
+| ---------------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
+| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
+| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
+| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                               |
+| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
+| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
+| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
+| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
+| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
 
-The local executable is stdio-only. It does not support `PORT`,
-`HEVY_MCP_TRANSPORT`, or `--transport`, and it does not provide local HTTP or
-SSE behavior.
+The local Node executable uses stdio by default. Opt into local Streamable
+HTTP with:
+
+```bash
+HEVY_API_KEY=your-hevy-api-key npx hevy-mcp --transport http --host 127.0.0.1 --port 3000
+```
+
+The local MCP endpoint is `http://127.0.0.1:3000/mcp`; non-loopback binds
+require the separate `HEVY_MCP_HTTP_BEARER_TOKEN` environment variable. A
+Docker deployment must publish the port explicitly:
+
+```bash
+docker run --rm -p 3000:3000 -e HEVY_API_KEY -e HEVY_MCP_HTTP_BEARER_TOKEN \\
+  ghcr.io/chrisdoc/hevy-mcp:latest --transport http --host 0.0.0.0 --port 3000
+```
+
+This Node HTTP mode is distinct from the stateless Cloudflare Worker HTTP
+endpoint described above: the Node server owns stateful client sessions, while
+the Worker is designed for hosted deployment and does not import Node code.
 
 ### Cache behavior
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -414,20 +414,37 @@ self-hosted Streamable HTTP.
 
 ## Advanced configuration
 
-| Setting                | Default                        | Scope                         | Notes                                                                                                               |
-| ---------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `HEVY_API_KEY`         | None; required                 | Local stdio                   | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
-| `HEVY_MCP_API_TIMEOUT` | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
-| `HEVY_MCP_DEBUG`       | Disabled                       | Local stdio                   | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
-| `XDG_CACHE_HOME`       | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
-| `SENTRY_DSN`           | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
-| `SENTRY_RELEASE`       | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
-| `-h`, `--help`         | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
-| `-v`, `--version`      | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
+| Setting                      | Default                        | Scope                         | Notes                                                                                                               |
+| ---------------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
+| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
+| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
+| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                               |
+| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
+| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
+| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
+| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
+| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
 
-The local executable is stdio-only. It does not support `PORT`,
-`HEVY_MCP_TRANSPORT`, or `--transport`, and it does not provide local HTTP or
-SSE behavior.
+The local executable uses stdio by default. To opt into Streamable HTTP, run:
+
+```bash
+HEVY_API_KEY=your-hevy-api-key npx hevy-mcp --transport http --host 127.0.0.1 --port 3000
+```
+
+The MCP endpoint is `http://127.0.0.1:3000/mcp`. HTTP mode validates the Host
+header against the configured bind host. Loopback is the default; exposing the
+server on a LAN address requires `HEVY_MCP_HTTP_BEARER_TOKEN` and a separate
+authentication token. Do not expose an unprotected shared Hevy account to the
+public internet. For Docker HTTP mode, publish the port explicitly:
+
+```bash
+docker run --rm -p 3000:3000 -e HEVY_API_KEY -e HEVY_MCP_HTTP_BEARER_TOKEN \
+  ghcr.io/chrisdoc/hevy-mcp:latest --transport http --host 0.0.0.0 --port 3000
+```
+
+Wildcard binds are allowed only with the separate bearer token; publish the
+container port deliberately and keep that token private.
 
 ### Cache behavior
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -432,9 +432,11 @@ The local executable uses stdio by default. To opt into Streamable HTTP, run:
 HEVY_API_KEY=your-hevy-api-key npx hevy-mcp --transport http --host 127.0.0.1 --port 3000
 ```
 
-The MCP endpoint is `http://127.0.0.1:3000/mcp`. HTTP mode validates the Host
-header against the configured bind host. Loopback is the default; exposing the
-server on a LAN address requires `HEVY_MCP_HTTP_BEARER_TOKEN` and a separate
+The MCP endpoint is `http://127.0.0.1:3000/mcp`. For a specific bind host,
+HTTP mode validates the Host header and configured port to protect against DNS
+rebinding. Loopback is the default. Wildcard binds (`0.0.0.0` or `::`) accept
+any hostname so they can be used behind Docker port mappings or a reverse
+proxy; they require `HEVY_MCP_HTTP_BEARER_TOKEN` and rely on that separate
 authentication token. Do not expose an unprotected shared Hevy account to the
 public internet. For Docker HTTP mode, publish the port explicitly:
 

--- a/packages/node/src/cli.ts
+++ b/packages/node/src/cli.ts
@@ -1,9 +1,9 @@
-import { runStdioServer } from "./index.js";
+import { runServer } from "./index.js";
 import { MissingHevyApiKeyError } from "./utils/config.js";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
 import { flushTelemetry } from "./utils/telemetry.js";
 
-void runStdioServer().catch(async (error) => {
+void runServer().catch(async (error) => {
 	if (error instanceof MissingHevyApiKeyError) {
 		console.error(error.message);
 	} else {

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -15,15 +15,18 @@ const testDoubles = vi.hoisted(() => {
 		getUserInfo: vi.fn().mockResolvedValue({ id: "user" }),
 	};
 	const runtimeClient = { kind: "runtime-client" };
+	const httpHandle = { close: vi.fn().mockResolvedValue(undefined) };
 
 	return {
 		span,
 		server,
 		startupClient,
 		runtimeClient,
+		httpHandle,
 		transport: { kind: "stdio-transport" },
 		createHevyClient: vi.fn(),
 		createHevyMcpServer: vi.fn(),
+		startStreamableHttpServer: vi.fn(),
 		wrapMcpServerWithSentry: vi.fn((value: unknown) => value),
 		setSentryUser: vi.fn(),
 		setCurrentUserHash: vi.fn(),
@@ -83,6 +86,10 @@ vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
 	StdioServerTransport: class StdioServerTransport {},
 }));
 
+vi.mock("./utils/streamable-http.js", () => ({
+	startStreamableHttpServer: testDoubles.startStreamableHttpServer,
+}));
+
 vi.mock("./utils/graceful-shutdown.js", () => ({
 	installGracefulShutdown: testDoubles.installGracefulShutdown,
 }));
@@ -140,6 +147,9 @@ describe("Node package entrypoint", () => {
 		testDoubles.server.connect.mockResolvedValue(undefined);
 		testDoubles.startupClient.getUserInfo.mockResolvedValue({ id: "user" });
 		configureSuccessfulConstruction();
+		testDoubles.startStreamableHttpServer.mockResolvedValue(
+			testDoubles.httpHandle,
+		);
 		process.argv = [originalArgv[0] ?? "node", "hevy-mcp"];
 		delete process.env.HEVY_API_KEY;
 		vi.spyOn(console, "error").mockImplementation(() => {});
@@ -265,6 +275,46 @@ describe("Node package entrypoint", () => {
 			expect(testDoubles.createHevyClient).not.toHaveBeenCalled();
 		},
 	);
+
+	it("validates the HTTP key once and builds sessions without re-probing", async () => {
+		process.env.HEVY_API_KEY = "runtime-key";
+		process.argv.push("--transport", "http");
+		testDoubles.startStreamableHttpServer.mockImplementationOnce(
+			async (
+				_options: unknown,
+				_apiKey: string,
+				factory: (params: { apiKey: string }) => Promise<unknown>,
+			) => {
+				await factory({ apiKey: "runtime-key" });
+				return testDoubles.httpHandle;
+			},
+		);
+
+		await runServer();
+
+		expect(testDoubles.startupClient.getUserInfo).toHaveBeenCalledOnce();
+		expect(testDoubles.createHevyMcpServer).toHaveBeenCalledOnce();
+		expect(testDoubles.installGracefulShutdown).toHaveBeenCalledWith(
+			expect.objectContaining({ target: testDoubles.httpHandle }),
+		);
+	});
+
+	it("fails HTTP startup when the key is rejected", async () => {
+		process.env.HEVY_API_KEY = "invalid-key";
+		process.argv.push("--transport", "http");
+		testDoubles.startupClient.getUserInfo.mockRejectedValueOnce({
+			isHevyHttpError: true,
+			status: 401,
+		});
+
+		await expect(runServer()).rejects.toThrow(
+			"HEVY_API_KEY is invalid or expired",
+		);
+		expect(testDoubles.startStreamableHttpServer).not.toHaveBeenCalled();
+		expect(testDoubles.recordSessionTermination).toHaveBeenCalledWith(
+			"startup_failure",
+		);
+	});
 
 	it("connects stdio and installs lifecycle ownership", async () => {
 		process.env.HEVY_API_KEY = "runtime-key";

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -108,7 +108,7 @@ vi.mock("./utils/version-check.js", () => ({
 	scheduleUpdateCheck: testDoubles.scheduleUpdateCheck,
 }));
 
-import { createNodeMcpServer, runStdioServer } from "./index.js";
+import { createNodeMcpServer, runServer, runStdioServer } from "./index.js";
 
 const originalArgv = [...process.argv];
 const originalApiKey = process.env.HEVY_API_KEY;
@@ -240,6 +240,18 @@ describe("Node package entrypoint", () => {
 		expect(testDoubles.serverStartups.add).not.toHaveBeenCalled();
 		expect(testDoubles.createHevyClient).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		["--help", "--transport", "http"],
+		["--version", "--transport", "http"],
+	])(
+		"prioritizes %s over transport dispatch",
+		async (flag, transportFlag, transport) => {
+			process.argv.push(flag, transportFlag, transport);
+			await runServer();
+			expect(testDoubles.createHevyClient).not.toHaveBeenCalled();
+		},
+	);
 
 	it.each(["--version", "-v"])(
 		"prints the package version for %s without starting",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -17,6 +17,8 @@ import { z } from "zod";
 import { createHevyMcpServer } from "@hevy-mcp/core";
 import { createHevyClient, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { assertApiKey, parseConfig } from "./utils/config.js";
+import { parseNodeCliOptions, type NodeTransport } from "./utils/arguments.js";
+import { startStreamableHttpServer } from "./utils/streamable-http.js";
 import { installGracefulShutdown } from "./utils/graceful-shutdown.js";
 import { createNodeHevyClientOptions } from "./utils/hevy-client-observability.js";
 import { createNodeToolObserver } from "./utils/tool-observer.js";
@@ -37,13 +39,18 @@ const HELP_TEXT = [
 	"Options:",
 	"  -h, --help                 Show this help message and exit",
 	"  -v, --version              Show version and exit",
+	"  --transport stdio|http     Select the transport (default: stdio)",
+	"  --host <host>              HTTP bind host (default: 127.0.0.1)",
+	"  --port <port>              HTTP bind port (default: 3000)",
 	"",
 	"Environment:",
 	"  HEVY_API_KEY=<api-key>     Hevy API key from Hevy app settings",
 	"  HEVY_MCP_DEBUG=1           Enable verbose diagnostics on stderr",
+	"  HEVY_MCP_HTTP_BEARER_TOKEN Protect non-loopback HTTP deployments",
 	"",
 	"Examples:",
 	"  HEVY_API_KEY=your-key npx hevy-mcp",
+	"  HEVY_API_KEY=your-key npx hevy-mcp --transport http --port 3000",
 ].join("\n");
 
 function getCliAction(args: string[]): "start" | "version" | "help" {
@@ -163,14 +170,14 @@ async function validateApiKey(apiKey: string) {
 	}
 }
 
-function buildServer(apiKey: string) {
+function buildServer(apiKey: string, transport: NodeTransport = "stdio") {
 	return tracer.startActiveSpan(
 		"mcp.server.build",
 		{
 			attributes: {
 				"mcp.server.name": name,
 				"mcp.server.version": version,
-				"mcp.transport": "stdio",
+				"mcp.transport": transport,
 			},
 		},
 		(span) => {
@@ -205,13 +212,16 @@ function buildServer(apiKey: string) {
 	);
 }
 
-export async function createNodeMcpServer({ apiKey }: { apiKey: string }) {
+export async function createNodeMcpServer(
+	{ apiKey }: { apiKey: string },
+	transport: NodeTransport = "stdio",
+) {
 	const { apiKey: validatedApiKey } = serverConfigSchema.parse({ apiKey });
 	const userHash = fingerprintApiKey(validatedApiKey);
 	setCurrentUserHash(userHash);
 	Sentry.setUser({ id: userHash });
 	await validateApiKey(validatedApiKey);
-	return buildServer(validatedApiKey);
+	return buildServer(validatedApiKey, transport);
 }
 
 export async function runStdioServer() {
@@ -302,6 +312,61 @@ export async function runStdioServer() {
 				);
 				span.setStatus({ code: SpanStatusCode.ERROR });
 				throw e;
+			} finally {
+				span.end();
+			}
+		},
+	);
+}
+
+export async function runServer(): Promise<void> {
+	const args = process.argv.slice(2);
+	const cliAction = getCliAction(args);
+	if (cliAction === "version") {
+		console.error(`${name} v${version}`);
+		return;
+	}
+	if (cliAction === "help") {
+		console.log(HELP_TEXT);
+		return;
+	}
+
+	const options = parseNodeCliOptions(args);
+	if (options.transport === "stdio") {
+		await runStdioServer();
+		return;
+	}
+
+	await tracer.startActiveSpan(
+		"mcp.server.run",
+		{ attributes: { "mcp.transport": "http" } },
+		async (span) => {
+			try {
+				const cfg = parseConfig(process.env);
+				assertApiKey(cfg.apiKey);
+				serverStartups.add(1, { version });
+				const handle = await startStreamableHttpServer(
+					options,
+					cfg.apiKey,
+					(params) => createNodeMcpServer(params, "http"),
+				);
+				console.error(
+					`Starting MCP server in HTTP mode at ${options.host}:${options.port}/mcp`,
+				);
+				scheduleUpdateCheck({
+					packageName: serviceName,
+					currentVersion: serviceVersion,
+				});
+				installGracefulShutdown({
+					target: handle,
+					onComplete: async () => {
+						await flushTelemetry();
+					},
+				});
+				span.setStatus({ code: SpanStatusCode.OK });
+			} catch (error) {
+				span.setStatus({ code: SpanStatusCode.ERROR });
+				throw error;
 			} finally {
 				span.end();
 			}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -341,15 +341,18 @@ export async function runServer(): Promise<void> {
 		"mcp.server.run",
 		{ attributes: { "mcp.transport": "http" } },
 		async (span) => {
+			let listening = false;
+			serverStartups.add(1, { version });
 			try {
 				const cfg = parseConfig(process.env);
 				assertApiKey(cfg.apiKey);
-				serverStartups.add(1, { version });
+				await validateApiKey(cfg.apiKey);
 				const handle = await startStreamableHttpServer(
 					options,
 					cfg.apiKey,
-					(params) => createNodeMcpServer(params, "http"),
+					(params) => Promise.resolve(buildServer(params.apiKey, "http")),
 				);
+				listening = true;
 				console.error(
 					`Starting MCP server in HTTP mode at ${options.host}:${options.port}/mcp`,
 				);
@@ -365,6 +368,7 @@ export async function runServer(): Promise<void> {
 				});
 				span.setStatus({ code: SpanStatusCode.OK });
 			} catch (error) {
+				recordMcpSessionTermination(listening ? "unknown" : "startup_failure");
 				span.setStatus({ code: SpanStatusCode.ERROR });
 				throw error;
 			} finally {

--- a/packages/node/src/utils/arguments.test.ts
+++ b/packages/node/src/utils/arguments.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseNodeCliOptions } from "./arguments.js";
+
+describe("parseNodeCliOptions", () => {
+	it("defaults to stdio without binding HTTP", () => {
+		expect(parseNodeCliOptions([])).toEqual({
+			transport: "stdio",
+			host: "127.0.0.1",
+			port: 3000,
+		});
+	});
+
+	it("keeps explicit stdio on the stdio defaults", () => {
+		expect(parseNodeCliOptions(["--transport", "stdio"])).toEqual({
+			transport: "stdio",
+			host: "127.0.0.1",
+			port: 3000,
+		});
+	});
+
+	it("parses HTTP options", () => {
+		expect(
+			parseNodeCliOptions([
+				"--transport",
+				"http",
+				"--host",
+				"localhost",
+				"--port",
+				"8080",
+			]),
+		).toEqual({ transport: "http", host: "localhost", port: 8080 });
+	});
+
+	it.each([
+		["--transport", "invalid transport"],
+		["--unknown", "unknown option"],
+	])("rejects %s", (option) => {
+		expect(() =>
+			parseNodeCliOptions(
+				option === "--transport" ? [option, "wat"] : [option],
+			),
+		).toThrow();
+	});
+
+	it("rejects HTTP-only options in stdio mode", () => {
+		expect(() => parseNodeCliOptions(["--port", "3001"])).toThrow(
+			"only be used with --transport http",
+		);
+	});
+
+	it("rejects invalid ports", () => {
+		expect(() =>
+			parseNodeCliOptions(["--transport", "http", "--port", "65536"]),
+		).toThrow("1 to 65535");
+	});
+
+	it.each(["bad host", "[127.0.0.1]", "example.com/path", "127.0.0.1:3000"])(
+		"rejects invalid host %s",
+		(host) => {
+			expect(() =>
+				parseNodeCliOptions(["--transport", "http", "--host", host]),
+			).toThrow("Invalid host");
+		},
+	);
+
+	it("accepts bracketed IPv6 input and normalizes it for listen", () => {
+		expect(
+			parseNodeCliOptions(["--transport", "http", "--host", "[::1]"]),
+		).toMatchObject({ host: "::1" });
+	});
+});

--- a/packages/node/src/utils/arguments.test.ts
+++ b/packages/node/src/utils/arguments.test.ts
@@ -31,15 +31,10 @@ describe("parseNodeCliOptions", () => {
 		).toEqual({ transport: "http", host: "localhost", port: 8080 });
 	});
 
-	it.each([
-		["--transport", "invalid transport"],
-		["--unknown", "unknown option"],
-	])("rejects %s", (option) => {
-		expect(() =>
-			parseNodeCliOptions(
-				option === "--transport" ? [option, "wat"] : [option],
-			),
-		).toThrow();
+	it("rejects invalid transport and unknown options", () => {
+		for (const argv of [["--transport", "wat"], ["--unknown"]]) {
+			expect(() => parseNodeCliOptions(argv)).toThrow();
+		}
 	});
 
 	it("rejects HTTP-only options in stdio mode", () => {

--- a/packages/node/src/utils/arguments.ts
+++ b/packages/node/src/utils/arguments.ts
@@ -1,0 +1,111 @@
+import { isIP } from "node:net";
+
+export type NodeTransport = "stdio" | "http";
+
+export interface NodeCliOptions {
+	transport: NodeTransport;
+	host: string;
+	port: number;
+}
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 3000;
+
+function valueAfter(args: string[], index: number, option: string): string {
+	const value = args[index + 1];
+	if (!value || value.startsWith("-")) {
+		throw new Error(`${option} requires a value.`);
+	}
+	return value;
+}
+
+function parseHost(value: string): string {
+	const host = value.trim();
+	const unbracketed =
+		host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+	const isBracketed = host.startsWith("[") || host.endsWith("]");
+	const validHostname =
+		/^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/u;
+	if (
+		host.length === 0 ||
+		(isBracketed && !(host.startsWith("[") && host.endsWith("]"))) ||
+		(isBracketed && isIP(unbracketed) !== 6) ||
+		(!isBracketed && host.includes(":") && isIP(host) !== 6) ||
+		(!isBracketed &&
+			!host.includes(":") &&
+			isIP(host) === 0 &&
+			!validHostname.test(host)) ||
+		/\s/u.test(host) ||
+		host.includes("/") ||
+		host.includes("@") ||
+		host.includes("://")
+	) {
+		throw new Error(
+			`Invalid host: ${value}. Provide a hostname or IP address.`,
+		);
+	}
+	return unbracketed;
+}
+
+function parsePort(value: string): number {
+	if (!/^[0-9]+$/u.test(value)) {
+		throw new Error(`Invalid port: ${value}. Use an integer from 1 to 65535.`);
+	}
+	const port = Number(value);
+	if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`Invalid port: ${value}. Use an integer from 1 to 65535.`);
+	}
+	return port;
+}
+
+export function parseNodeCliOptions(args: string[]): NodeCliOptions {
+	let transport: NodeTransport = "stdio";
+	let host = DEFAULT_HOST;
+	let port = DEFAULT_PORT;
+	let transportExplicit = false;
+	let hostExplicit = false;
+	let portExplicit = false;
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (!arg || ["--help", "-h", "--version", "-v"].includes(arg)) {
+			continue;
+		}
+		switch (arg) {
+			case "--transport": {
+				const value = valueAfter(args, index, arg);
+				index += 1;
+				if (value !== "stdio" && value !== "http") {
+					throw new Error(
+						`Invalid transport: ${value}. Use either stdio or http.`,
+					);
+				}
+				transport = value;
+				transportExplicit = true;
+				break;
+			}
+			case "--host":
+				host = parseHost(valueAfter(args, index, arg));
+				hostExplicit = true;
+				index += 1;
+				break;
+			case "--port":
+				port = parsePort(valueAfter(args, index, arg));
+				portExplicit = true;
+				index += 1;
+				break;
+			default:
+				throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+
+	if (transport === "stdio" && (hostExplicit || portExplicit)) {
+		throw new Error(
+			"--host and --port can only be used with --transport http.",
+		);
+	}
+	if (transport === "stdio" && transportExplicit) {
+		return { transport, host: DEFAULT_HOST, port: DEFAULT_PORT };
+	}
+	return { transport, host, port };
+}

--- a/packages/node/src/utils/mcp-session-observability.ts
+++ b/packages/node/src/utils/mcp-session-observability.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { sessionEnded, sessionStarted } from "./metrics.js";
 import { bucketCount } from "./result-telemetry.js";
 
@@ -11,6 +12,7 @@ export const MCP_SESSION_TERMINATION_CATEGORIES = [
 
 export type McpSessionTerminationCategory =
 	(typeof MCP_SESSION_TERMINATION_CATEGORIES)[number];
+export type McpTransport = "stdio" | "http";
 
 export interface McpClientMetadata {
 	readonly name: string;
@@ -23,21 +25,25 @@ export interface McpClientMetricAttributes {
 	readonly client_name: string;
 	readonly client_version: string;
 	readonly protocol_version: string;
-	readonly transport: "stdio";
+	readonly transport: McpTransport;
+}
+
+export interface McpSessionContext {
+	metadata: McpClientMetadata;
+	startedAt: number;
+	toolCalls: number;
+	hadToolFailure: boolean;
+	transport: McpTransport;
 }
 
 const UNKNOWN_METADATA = "unknown";
 const MAX_METADATA_LENGTH = 64;
 const SAFE_METADATA_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:/@-]{0,63}$/u;
-
-let currentSession:
-	| {
-			metadata: McpClientMetadata;
-			startedAt: number;
-			toolCalls: number;
-			hadToolFailure: boolean;
-	  }
-	| undefined;
+const contextStorage = new AsyncLocalStorage<McpSessionContext>();
+// Stdio has one process-wide connection and its parser callbacks are not
+// attached to an AsyncLocalStorage scope. HTTP never uses this fallback: every
+// request is explicitly run with its own session context.
+let activeStdioSession: McpSessionContext | undefined;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -71,14 +77,40 @@ export function extractMcpClientMetadata(message: unknown): McpClientMetadata {
 	};
 }
 
+export function createMcpSessionContext(
+	message: unknown,
+	transport: McpTransport = "stdio",
+): McpSessionContext {
+	return {
+		metadata: extractMcpClientMetadata(message),
+		startedAt: Date.now(),
+		toolCalls: 0,
+		hadToolFailure: false,
+		transport,
+	};
+}
+
+export function runWithMcpSessionContext<T>(
+	context: McpSessionContext,
+	callback: () => T,
+): T {
+	return contextStorage.run(context, callback);
+}
+
+function getSession(): McpSessionContext | undefined {
+	const scopedSession = contextStorage.getStore();
+	return scopedSession ?? activeStdioSession;
+}
+
 function metadataAttributes(
 	metadata: McpClientMetadata,
+	transport: McpTransport,
 ): McpClientMetricAttributes {
 	return {
 		client_name: metadata.name,
 		client_version: metadata.version,
 		protocol_version: metadata.protocolVersion,
-		transport: "stdio",
+		transport,
 	};
 }
 
@@ -90,37 +122,39 @@ function durationBucket(durationMs: number): string {
 	return "5m+";
 }
 
-export function recordMcpSessionStart(message: unknown): McpClientMetadata {
-	const metadata = extractMcpClientMetadata(message);
-	currentSession = {
-		metadata,
-		startedAt: Date.now(),
-		toolCalls: 0,
-		hadToolFailure: false,
-	};
-	const attributes = metadataAttributes(metadata);
+export function recordMcpSessionStart(
+	message: unknown,
+	transport: McpTransport = "stdio",
+	context?: McpSessionContext,
+): McpClientMetadata {
+	const session = context ?? createMcpSessionContext(message, transport);
+	if (transport === "stdio") activeStdioSession = session;
+	const attributes = metadataAttributes(session.metadata, transport);
 	sessionStarted.add(1, attributes);
-	return metadata;
+	return session.metadata;
 }
 
 export function recordMcpToolInvocation(): McpClientMetricAttributes {
-	if (currentSession) currentSession.toolCalls += 1;
+	const session = getSession();
+	if (session) session.toolCalls += 1;
 	return metadataAttributes(
-		currentSession?.metadata ?? {
+		session?.metadata ?? {
 			name: UNKNOWN_METADATA,
 			version: UNKNOWN_METADATA,
 			protocolVersion: UNKNOWN_METADATA,
 		},
+		session?.transport ?? "stdio",
 	);
 }
 
 export function recordMcpToolFailure(): void {
-	if (currentSession) currentSession.hadToolFailure = true;
+	const session = getSession();
+	if (session) session.hadToolFailure = true;
 }
 
 export function getCurrentMcpClientMetadata(): McpClientMetadata {
 	return (
-		currentSession?.metadata ?? {
+		getSession()?.metadata ?? {
 			name: UNKNOWN_METADATA,
 			version: UNKNOWN_METADATA,
 			protocolVersion: UNKNOWN_METADATA,
@@ -128,10 +162,15 @@ export function getCurrentMcpClientMetadata(): McpClientMetadata {
 	);
 }
 
+export function getCurrentMcpTransport(): McpTransport {
+	return getSession()?.transport ?? "stdio";
+}
+
 export function recordMcpSessionTermination(
 	category: McpSessionTerminationCategory,
+	context?: McpSessionContext,
 ): void {
-	const session = currentSession;
+	const session = context ?? getSession();
 	const durationMs = session ? Math.max(0, Date.now() - session.startedAt) : 0;
 	const metadata = session?.metadata ?? {
 		name: UNKNOWN_METADATA,
@@ -139,18 +178,20 @@ export function recordMcpSessionTermination(
 		protocolVersion: UNKNOWN_METADATA,
 	};
 	const attributes = {
-		...metadataAttributes(metadata),
+		...metadataAttributes(metadata, session?.transport ?? "stdio"),
 		termination_category: category,
 		session_duration_bucket: durationBucket(durationMs),
 		tool_calls_bucket: bucketCount(session?.toolCalls ?? 0),
 	};
 	sessionEnded.add(1, attributes);
-	currentSession = undefined;
+	if (!context || context === activeStdioSession)
+		activeStdioSession = undefined;
 }
 
 export function resolveSessionTerminationCategory(
 	shutdownSucceeded: boolean,
+	context?: McpSessionContext,
 ): McpSessionTerminationCategory {
 	if (!shutdownSucceeded) return "unknown";
-	return currentSession?.hadToolFailure ? "tool_failure" : "clean";
+	return (context ?? getSession())?.hadToolFailure ? "tool_failure" : "clean";
 }

--- a/packages/node/src/utils/mcp-session-observability.ts
+++ b/packages/node/src/utils/mcp-session-observability.ts
@@ -128,8 +128,8 @@ export function recordMcpSessionStart(
 	context?: McpSessionContext,
 ): McpClientMetadata {
 	const session = context ?? createMcpSessionContext(message, transport);
-	if (transport === "stdio") activeStdioSession = session;
-	const attributes = metadataAttributes(session.metadata, transport);
+	if (session.transport === "stdio") activeStdioSession = session;
+	const attributes = metadataAttributes(session.metadata, session.transport);
 	sessionStarted.add(1, attributes);
 	return session.metadata;
 }

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -1,0 +1,303 @@
+import { request, type Server } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { startStreamableHttpServer } from "./streamable-http.js";
+
+const createMcpServer = async () => {
+	const server = new McpServer({ name: "test-server", version: "1.0.0" });
+	server.registerTool(
+		"mock-tool",
+		{ description: "A mocked tool" },
+		async () => ({ content: [{ type: "text", text: "mock result" }] }),
+	);
+	return server;
+};
+
+const handles: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+	await Promise.all(handles.splice(0).map((handle) => handle.close()));
+});
+
+interface HttpResult {
+	statusCode?: number;
+	headers: Record<string, string | string[] | undefined>;
+	body: string;
+}
+
+function openStream(
+	port: number,
+	headers: Record<string, string>,
+): Promise<{ ended: Promise<void> }> {
+	return new Promise((resolve, reject) => {
+		const client = request(
+			{ host: "127.0.0.1", port, path: "/mcp", method: "GET", headers },
+			(response) => {
+				const ended = new Promise<void>((finish) => {
+					response.once("end", finish);
+					response.once("close", finish);
+				});
+				resolve({ ended });
+			},
+		);
+		client.once("error", reject);
+		client.end();
+	});
+}
+
+function call(
+	port: number,
+	method: string,
+	body?: unknown,
+	extraHeaders: Record<string, string> = {},
+): Promise<HttpResult> {
+	return new Promise((resolve, reject) => {
+		const payload = body === undefined ? undefined : JSON.stringify(body);
+		const client = request(
+			{
+				host: "127.0.0.1",
+				port,
+				path: "/mcp",
+				method,
+				headers: {
+					Accept: "application/json, text/event-stream",
+					...(payload ? { "Content-Type": "application/json" } : {}),
+					...extraHeaders,
+				},
+			},
+			(response) => {
+				const chunks: Buffer[] = [];
+				response.on("data", (chunk: Buffer) => chunks.push(chunk));
+				response.once("end", () =>
+					resolve({
+						statusCode: response.statusCode,
+						headers: response.headers,
+						body: Buffer.concat(chunks).toString("utf8"),
+					}),
+				);
+			},
+		);
+		client.once("error", reject);
+		if (payload) client.write(payload);
+		client.end();
+	});
+}
+
+function serverPort(handle: { server: Server }): number {
+	const address = handle.server.address();
+	if (!address || typeof address === "string") throw new Error("No address");
+	return address.port;
+}
+
+function jsonBody(result: HttpResult): Record<string, unknown> {
+	const json = result.body.startsWith("event:")
+		? result.body
+				.split("\n")
+				.filter((line) => line.startsWith("data:"))
+				.map((line) => line.slice("data:".length).trim())
+				.join("\n")
+		: result.body;
+	if (!json) throw new Error(`empty response: ${JSON.stringify(result)}`);
+	return JSON.parse(json) as Record<string, unknown>;
+}
+
+async function startTestServer(host = "127.0.0.1") {
+	const handle = await startStreamableHttpServer(
+		{ transport: "http", host, port: 0 },
+		"test-key",
+		createMcpServer,
+	);
+	handles.push(handle);
+	return { handle, port: serverPort(handle) };
+}
+
+async function initialize(port: number, headers: Record<string, string> = {}) {
+	return call(
+		port,
+		"POST",
+		{
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2025-06-18",
+				capabilities: {},
+				clientInfo: { name: "protocol-test", version: "1.0.0" },
+			},
+		},
+		headers,
+	);
+}
+
+describe("Streamable HTTP server", () => {
+	it("supports initialize, tools/list, and a mocked tools/call", async () => {
+		const { port } = await startTestServer();
+		const initialized = await initialize(port);
+		expect(initialized.statusCode).toBe(200);
+		const sessionId = initialized.headers["mcp-session-id"];
+		expect(typeof sessionId).toBe("string");
+
+		const headers = { "mcp-session-id": String(sessionId) };
+		const listed = await call(
+			port,
+			"POST",
+			{
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+				params: {},
+			},
+			headers,
+		);
+		expect(listed.statusCode).toBe(200);
+		expect(JSON.stringify(jsonBody(listed))).toContain("mock-tool");
+
+		const called = await call(
+			port,
+			"POST",
+			{
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: { name: "mock-tool", arguments: {} },
+			},
+			headers,
+		);
+		expect(called.statusCode).toBe(200);
+		expect(JSON.stringify(jsonBody(called))).toContain("mock result");
+	});
+
+	it("keeps two clients isolated and routes unknown sessions safely", async () => {
+		const { port } = await startTestServer();
+		const first = await initialize(port);
+		const second = await initialize(port);
+		const firstSession = String(first.headers["mcp-session-id"]);
+		const secondSession = String(second.headers["mcp-session-id"]);
+		expect(firstSession).not.toBe(secondSession);
+
+		const firstList = await call(
+			port,
+			"POST",
+			{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+			{ "mcp-session-id": firstSession },
+		);
+		const secondList = await call(
+			port,
+			"POST",
+			{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+			{ "mcp-session-id": secondSession },
+		);
+		expect(firstList.statusCode).toBe(200);
+		expect(secondList.statusCode).toBe(200);
+
+		expect((await call(port, "POST", { jsonrpc: "2.0" })).statusCode).toBe(400);
+		expect(
+			(
+				await call(
+					port,
+					"POST",
+					{ jsonrpc: "2.0", id: 4, method: "tools/list" },
+					{ "mcp-session-id": "missing-session" },
+				)
+			).statusCode,
+		).toBe(404);
+	});
+
+	it("removes a session on DELETE", async () => {
+		const { port } = await startTestServer();
+		const initialized = await initialize(port);
+		const sessionId = String(initialized.headers["mcp-session-id"]);
+		const deleted = await call(port, "DELETE", undefined, {
+			"mcp-session-id": sessionId,
+		});
+		expect(deleted.statusCode).toBe(200);
+		expect(
+			(
+				await call(
+					port,
+					"POST",
+					{ jsonrpc: "2.0", id: 2, method: "tools/list" },
+					{ "mcp-session-id": sessionId },
+				)
+			).statusCode,
+		).toBe(404);
+	});
+
+	it("requires bearer authentication for wildcard binds", async () => {
+		process.env.HEVY_MCP_HTTP_BEARER_TOKEN = "http-test-token";
+		try {
+			const { port } = await startTestServer("0.0.0.0");
+			expect((await initialize(port)).statusCode).toBe(401);
+			const authorized = await initialize(port, {
+				authorization: "Bearer http-test-token",
+			});
+			expect(authorized.statusCode).toBe(200);
+		} finally {
+			delete process.env.HEVY_MCP_HTTP_BEARER_TOKEN;
+		}
+	});
+
+	it("returns safe 400/413 responses for malformed and oversized bodies", async () => {
+		const { port } = await startTestServer();
+		const malformed = await call(port, "POST", undefined, {
+			"content-type": "application/json",
+		});
+		// The helper omits an empty body, so send malformed JSON directly.
+		const invalid = await new Promise<HttpResult>((resolve, reject) => {
+			const client = request(
+				{ host: "127.0.0.1", port, path: "/mcp", method: "POST" },
+				(response) => {
+					const chunks: Buffer[] = [];
+					response.on("data", (chunk: Buffer) => chunks.push(chunk));
+					response.once("end", () =>
+						resolve({
+							statusCode: response.statusCode,
+							headers: response.headers,
+							body: Buffer.concat(chunks).toString("utf8"),
+						}),
+					);
+				},
+			);
+			client.once("error", reject);
+			client.end("not-json");
+		});
+		expect(malformed.statusCode).toBe(400);
+		expect(invalid.statusCode).toBe(400);
+		expect(invalid.body).not.toContain("not-json");
+
+		const oversized = await call(port, "POST", "x".repeat(1_048_577));
+		expect(oversized.statusCode).toBe(413);
+	});
+
+	it("rejects a DNS-rebinding Host header and closes active sessions", async () => {
+		const { handle, port } = await startTestServer();
+		expect(
+			(
+				await call(
+					port,
+					"POST",
+					{ jsonrpc: "2.0" },
+					{ host: "attacker.example" },
+				)
+			).statusCode,
+		).toBe(403);
+		const initialized = await initialize(port);
+		expect(initialized.statusCode).toBe(200);
+		const stream = await openStream(port, {
+			"mcp-session-id": String(initialized.headers["mcp-session-id"]),
+		});
+		await expect(handle.close()).resolves.toBeUndefined();
+		void stream.ended;
+		expect(handle.server.listening).toBe(false);
+	});
+
+	it("rejects non-loopback startup without a bearer token", async () => {
+		await expect(
+			startStreamableHttpServer(
+				{ transport: "http", host: "192.0.2.1", port: 3000 },
+				"test-key",
+				createMcpServer,
+			),
+		).rejects.toThrow("HEVY_MCP_HTTP_BEARER_TOKEN");
+	});
+});

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -31,7 +31,13 @@ function openStream(
 ): Promise<{ ended: Promise<void> }> {
 	return new Promise((resolve, reject) => {
 		const client = request(
-			{ host: "127.0.0.1", port, path: "/mcp", method: "GET", headers },
+			{
+				host: "127.0.0.1",
+				port,
+				path: "/mcp",
+				method: "GET",
+				headers: { Accept: "text/event-stream", ...headers },
+			},
 			(response) => {
 				const ended = new Promise<void>((finish) => {
 					response.once("end", finish);
@@ -239,10 +245,7 @@ describe("Streamable HTTP server", () => {
 
 	it("returns safe 400/413 responses for malformed and oversized bodies", async () => {
 		const { port } = await startTestServer();
-		const malformed = await call(port, "POST", undefined, {
-			"content-type": "application/json",
-		});
-		// The helper omits an empty body, so send malformed JSON directly.
+		// Send malformed JSON directly because the helper serializes valid bodies.
 		const invalid = await new Promise<HttpResult>((resolve, reject) => {
 			const client = request(
 				{ host: "127.0.0.1", port, path: "/mcp", method: "POST" },
@@ -261,7 +264,6 @@ describe("Streamable HTTP server", () => {
 			client.once("error", reject);
 			client.end("not-json");
 		});
-		expect(malformed.statusCode).toBe(400);
 		expect(invalid.statusCode).toBe(400);
 		expect(invalid.body).not.toContain("not-json");
 
@@ -287,7 +289,7 @@ describe("Streamable HTTP server", () => {
 			"mcp-session-id": String(initialized.headers["mcp-session-id"]),
 		});
 		await expect(handle.close()).resolves.toBeUndefined();
-		void stream.ended;
+		await expect(stream.ended).resolves.toBeUndefined();
 		expect(handle.server.listening).toBe(false);
 	});
 

--- a/packages/node/src/utils/streamable-http.ts
+++ b/packages/node/src/utils/streamable-http.ts
@@ -1,0 +1,425 @@
+import { randomUUID } from "node:crypto";
+import {
+	createServer,
+	type IncomingMessage,
+	type Server,
+	type ServerResponse,
+} from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import type { NodeCliOptions } from "./arguments.js";
+import {
+	runWithMcpSessionContext,
+	createMcpSessionContext,
+	recordMcpSessionStart,
+	recordMcpSessionTermination,
+	resolveSessionTerminationCategory,
+	type McpSessionContext,
+} from "./mcp-session-observability.js";
+
+const MCP_PATH = "/mcp";
+const MAX_BODY_BYTES = 1_048_576;
+const HTTP_BEARER_TOKEN = "HEVY_MCP_HTTP_BEARER_TOKEN";
+
+type HttpTransport = StreamableHTTPServerTransport;
+export interface OwnedMcpServer {
+	connect(transport: HttpTransport): Promise<void>;
+	close(): Promise<void>;
+}
+
+export type McpServerFactory = (params: {
+	apiKey: string;
+}) => Promise<OwnedMcpServer>;
+
+interface HttpSession {
+	transport: HttpTransport;
+	server: OwnedMcpServer;
+	context: McpSessionContext;
+	responses: Set<ServerResponse>;
+	closed: boolean;
+}
+
+export interface HttpServerHandle {
+	close(): Promise<void>;
+	server: Server;
+}
+
+class HttpRequestError extends Error {
+	readonly statusCode: number;
+
+	constructor(statusCode: number, message: string) {
+		super(message);
+		this.name = "HttpRequestError";
+		this.statusCode = statusCode;
+	}
+}
+
+function normalizeHost(host: string): string {
+	return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+function isLoopbackHost(host: string): boolean {
+	const normalized = normalizeHost(host).toLowerCase();
+	return (
+		normalized === "localhost" ||
+		normalized === "127.0.0.1" ||
+		normalized === "::1"
+	);
+}
+
+function hostNamesFor(options: NodeCliOptions): Set<string> {
+	const configured = normalizeHost(options.host).toLowerCase();
+	const names = new Set([configured]);
+	if (isLoopbackHost(options.host)) {
+		names.add("localhost");
+		names.add("127.0.0.1");
+		names.add("::1");
+	}
+	return names;
+}
+
+function expectedPort(options: NodeCliOptions, server: Server): number {
+	if (options.port !== 0) return options.port;
+	const address = server.address();
+	return address && typeof address !== "string" ? address.port : 0;
+}
+
+function validateHostHeader(
+	request: IncomingMessage,
+	allowedHosts: Set<string>,
+	port: number,
+	allowAnyHostname = false,
+): boolean {
+	const header = request.headers.host;
+	if (!header || Array.isArray(header)) return false;
+	try {
+		const parsed = new URL(`http://${header}`);
+		if (
+			parsed.username ||
+			parsed.password ||
+			parsed.pathname !== "/" ||
+			parsed.search ||
+			parsed.hash ||
+			(parsed.port ? Number(parsed.port) : 80) !== port
+		) {
+			return false;
+		}
+		return (
+			allowAnyHostname ||
+			allowedHosts.has(normalizeHost(parsed.hostname).toLowerCase())
+		);
+	} catch {
+		return false;
+	}
+}
+
+function safeDiagnostic(error: unknown): string {
+	return JSON.stringify(createSafeErrorDiagnostic(error));
+}
+
+function writeJson(res: ServerResponse, status: number, message: string): void {
+	if (res.headersSent) return;
+	res.statusCode = status;
+	res.setHeader("Content-Type", "application/json");
+	res.end(JSON.stringify({ error: message }));
+}
+
+function readBody(request: IncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let size = 0;
+		let rejected = false;
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer | string) => {
+			const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+			size += buffer.byteLength;
+			if (size > MAX_BODY_BYTES) {
+				if (!rejected) {
+					rejected = true;
+					reject(new HttpRequestError(413, "Request body is too large."));
+				}
+				return;
+			}
+			if (!rejected) chunks.push(buffer);
+		});
+		request.once("error", (error) => {
+			if (!rejected) reject(error);
+		});
+		request.once("end", () => {
+			if (rejected) return;
+			try {
+				const raw = Buffer.concat(chunks).toString("utf8");
+				resolve(raw.length === 0 ? undefined : JSON.parse(raw));
+			} catch {
+				reject(new HttpRequestError(400, "Request body must be valid JSON."));
+			}
+		});
+	});
+}
+
+function isInitializeRequest(body: unknown): boolean {
+	return Boolean(
+		body &&
+		typeof body === "object" &&
+		!Array.isArray(body) &&
+		"method" in body &&
+		body.method === "initialize",
+	);
+}
+
+function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (!server.listening) {
+			resolve();
+			return;
+		}
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+function isBearerAuthorized(
+	request: IncomingMessage,
+	token: string | undefined,
+): boolean {
+	if (!token) return false;
+	const header = request.headers.authorization;
+	return typeof header === "string" && header === `Bearer ${token}`;
+}
+
+function aggregateErrors(errors: unknown[], message: string): unknown {
+	if (errors.length === 1) return errors[0];
+	return new AggregateError(errors, message);
+}
+
+export function isHttpHostAllowed(host: string): boolean {
+	return isLoopbackHost(host);
+}
+
+export async function startStreamableHttpServer(
+	options: NodeCliOptions,
+	apiKey: string,
+	createMcpServer: McpServerFactory,
+): Promise<HttpServerHandle> {
+	const wildcard =
+		options.host === "0.0.0.0" ||
+		options.host === "::" ||
+		options.host === "[::]";
+	const loopback = isLoopbackHost(options.host);
+	const bearerToken = process.env[HTTP_BEARER_TOKEN];
+	if (!loopback && !bearerToken) {
+		throw new Error(
+			`Non-loopback HTTP mode requires ${HTTP_BEARER_TOKEN} to protect the shared Hevy account.`,
+		);
+	}
+
+	const sessions = new Map<string, HttpSession>();
+	const cleanupErrors: unknown[] = [];
+	const server = createServer((request, response) => {
+		void handleRequest(request, response).catch((error: unknown) => {
+			if (error instanceof HttpRequestError) {
+				writeJson(response, error.statusCode, error.message);
+				return;
+			}
+			console.error(`HTTP request failed: ${safeDiagnostic(error)}`);
+			writeJson(response, 500, "Internal server error.");
+		});
+	});
+
+	async function closeSession(
+		session: HttpSession,
+		failureCategory?: "connect_failure" | "startup_failure" | "unknown",
+	): Promise<void> {
+		if (session.closed) return;
+		session.closed = true;
+		for (const [id, current] of sessions) {
+			if (current === session) sessions.delete(id);
+		}
+		for (const response of session.responses) {
+			if (!response.writableEnded) response.destroy();
+		}
+
+		const results = await Promise.allSettled([
+			Promise.resolve().then(() => session.transport.close()),
+			Promise.resolve().then(() => session.server.close()),
+		]);
+		const errors = results.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		const succeeded = errors.length === 0;
+		recordMcpSessionTermination(
+			failureCategory && succeeded
+				? failureCategory
+				: resolveSessionTerminationCategory(succeeded, session.context),
+			session.context,
+		);
+		if (errors.length > 0) {
+			throw aggregateErrors(errors, "MCP session cleanup failed.");
+		}
+	}
+
+	async function closeUnregistered(
+		transport: HttpTransport,
+		mcpServer: OwnedMcpServer | undefined,
+	): Promise<void> {
+		const results = await Promise.allSettled([
+			Promise.resolve().then(() => transport.close()),
+			...(mcpServer ? [Promise.resolve().then(() => mcpServer.close())] : []),
+		]);
+		const errors = results.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+		if (errors.length > 0) throw aggregateErrors(errors, "MCP cleanup failed.");
+		return;
+	}
+
+	async function handleRequest(
+		request: IncomingMessage,
+		response: ServerResponse,
+	): Promise<void> {
+		if (request.url?.split("?", 1)[0] !== MCP_PATH) {
+			writeJson(response, 404, "Not found");
+			return;
+		}
+		if (
+			!validateHostHeader(
+				request,
+				hostNamesFor(options),
+				expectedPort(options, server),
+				wildcard,
+			)
+		) {
+			writeJson(response, 403, "Invalid Host header");
+			return;
+		}
+		if (!loopback && !isBearerAuthorized(request, bearerToken)) {
+			writeJson(response, 401, "Authorization required");
+			return;
+		}
+
+		const body =
+			request.method === "POST" ? await readBody(request) : undefined;
+		const initializing = request.method === "POST" && isInitializeRequest(body);
+		const sessionHeader = request.headers["mcp-session-id"];
+		const sessionId =
+			typeof sessionHeader === "string" ? sessionHeader : undefined;
+
+		if (initializing) {
+			if (sessionId) {
+				writeJson(
+					response,
+					400,
+					"Initialization must not include Mcp-Session-Id.",
+				);
+				return;
+			}
+			const context = createMcpSessionContext(body, "http");
+			recordMcpSessionStart(body, "http", context);
+			let session: HttpSession | undefined;
+			let mcpServer: OwnedMcpServer | undefined;
+			let connected = false;
+			const transport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: randomUUID,
+				onsessioninitialized: (id) => {
+					if (session) sessions.set(id, session);
+				},
+			});
+			transport.onclose = () => {
+				if (session) {
+					void closeSession(session).catch((error: unknown) => {
+						cleanupErrors.push(error);
+					});
+				}
+			};
+			try {
+				mcpServer = await createMcpServer({ apiKey });
+				session = {
+					transport,
+					server: mcpServer,
+					context,
+					responses: new Set(),
+					closed: false,
+				};
+				await mcpServer.connect(transport);
+				connected = true;
+				session.responses.add(response);
+				response.once("close", () => session?.responses.delete(response));
+				await runWithMcpSessionContext(context, () =>
+					transport.handleRequest(request, response, body),
+				);
+			} catch (error) {
+				console.error(`HTTP session request failed: ${safeDiagnostic(error)}`);
+				let cleanupError: unknown;
+				try {
+					if (session) {
+						await closeSession(
+							session,
+							connected ? "unknown" : "connect_failure",
+						);
+					} else {
+						await closeUnregistered(transport, mcpServer);
+						recordMcpSessionTermination("startup_failure", context);
+					}
+				} catch (cleanupFailure) {
+					cleanupError = cleanupFailure;
+					if (!session) recordMcpSessionTermination("unknown", context);
+				}
+				if (cleanupError) {
+					console.error(`HTTP cleanup failed: ${safeDiagnostic(cleanupError)}`);
+				}
+				if (!response.writableEnded)
+					writeJson(response, 500, "Internal server error.");
+			}
+			return;
+		}
+
+		if (!sessionId) {
+			writeJson(response, 400, "Mcp-Session-Id header is required.");
+			return;
+		}
+		const session = sessions.get(sessionId);
+		if (!session) {
+			writeJson(response, 404, "Unknown Mcp-Session-Id.");
+			return;
+		}
+		if (request.method !== "DELETE") {
+			session.responses.add(response);
+			response.once("close", () => session.responses.delete(response));
+		}
+		await runWithMcpSessionContext(session.context, () =>
+			session.transport.handleRequest(request, response, body),
+		);
+	}
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(options.port, options.host, () => {
+			server.removeListener("error", reject);
+			resolve();
+		});
+	});
+
+	let closePromise: Promise<void> | undefined;
+	return {
+		server,
+		close: () => {
+			if (closePromise) return closePromise;
+			closePromise = (async () => {
+				const sessionsToClose = [...sessions.values()];
+				const results = await Promise.allSettled([
+					...sessionsToClose.map((session) => closeSession(session)),
+					closeServer(server),
+				]);
+				sessions.clear();
+				const errors = [
+					...cleanupErrors,
+					...results.flatMap((result) =>
+						result.status === "rejected" ? [result.reason] : [],
+					),
+				];
+				if (errors.length > 0) {
+					throw aggregateErrors(errors, "HTTP server cleanup failed.");
+				}
+			})();
+			return closePromise;
+		},
+	};
+}

--- a/packages/node/src/utils/streamable-http.ts
+++ b/packages/node/src/utils/streamable-http.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import {
 	createServer,
 	type IncomingMessage,
@@ -100,7 +100,7 @@ function validateHostHeader(
 			parsed.pathname !== "/" ||
 			parsed.search ||
 			parsed.hash ||
-			(parsed.port ? Number(parsed.port) : 80) !== port
+			(!allowAnyHostname && (parsed.port ? Number(parsed.port) : 80) !== port)
 		) {
 			return false;
 		}
@@ -129,18 +129,21 @@ function readBody(request: IncomingMessage): Promise<unknown> {
 		let size = 0;
 		let rejected = false;
 		const chunks: Buffer[] = [];
-		request.on("data", (chunk: Buffer | string) => {
+		const onData = (chunk: Buffer | string) => {
 			const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 			size += buffer.byteLength;
 			if (size > MAX_BODY_BYTES) {
 				if (!rejected) {
 					rejected = true;
+					request.removeListener("data", onData);
+					request.resume();
 					reject(new HttpRequestError(413, "Request body is too large."));
 				}
 				return;
 			}
 			if (!rejected) chunks.push(buffer);
-		});
+		};
+		request.on("data", onData);
 		request.once("error", (error) => {
 			if (!rejected) reject(error);
 		});
@@ -173,6 +176,8 @@ function closeServer(server: Server): Promise<void> {
 			return;
 		}
 		server.close((error) => (error ? reject(error) : resolve()));
+		server.closeIdleConnections();
+		server.closeAllConnections();
 	});
 }
 
@@ -182,7 +187,13 @@ function isBearerAuthorized(
 ): boolean {
 	if (!token) return false;
 	const header = request.headers.authorization;
-	return typeof header === "string" && header === `Bearer ${token}`;
+	if (typeof header !== "string") return false;
+	const expected = Buffer.from(`Bearer ${token}`);
+	const actual = Buffer.from(header);
+	return (
+		expected.byteLength === actual.byteLength &&
+		timingSafeEqual(expected, actual)
+	);
 }
 
 function aggregateErrors(errors: unknown[], message: string): unknown {
@@ -215,6 +226,10 @@ export async function startStreamableHttpServer(
 	const cleanupErrors: unknown[] = [];
 	const server = createServer((request, response) => {
 		void handleRequest(request, response).catch((error: unknown) => {
+			if (response.headersSent) {
+				if (!response.writableEnded) response.destroy();
+				return;
+			}
 			if (error instanceof HttpRequestError) {
 				writeJson(response, error.statusCode, error.message);
 				return;

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -73,6 +73,7 @@ vi.mock("./mcp-session-observability.js", () => ({
 	recordMcpToolInvocation: testDoubles.recordMcpToolInvocation,
 	recordMcpToolFailure: testDoubles.recordMcpToolFailure,
 	getCurrentMcpClientMetadata: testDoubles.getCurrentMcpClientMetadata,
+	getCurrentMcpTransport: vi.fn(() => "stdio"),
 }));
 
 vi.mock("@opentelemetry/api", () => ({

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -13,6 +13,7 @@ import {
 } from "./metrics.js";
 import {
 	getCurrentMcpClientMetadata,
+	getCurrentMcpTransport,
 	recordMcpToolFailure,
 	recordMcpToolInvocation,
 } from "./mcp-session-observability.js";
@@ -63,7 +64,7 @@ function createAttributes(
 		"mcp.client.name": clientMetadata.name,
 		"mcp.client.version": clientMetadata.version,
 		"mcp.protocol.version": clientMetadata.protocolVersion,
-		"mcp.transport": "stdio",
+		"mcp.transport": getCurrentMcpTransport(),
 		"mcp.tool.args.key_count_bucket":
 			invocation.argumentKeyCountBucket ?? "unknown",
 		"mcp.tool.args.keys": invocation.argumentKeys?.join(",") ?? "",


### PR DESCRIPTION
## Summary

- add opt-in Streamable HTTP transport to the Node package
- preserve stdio as the default and explicit `--transport stdio` behavior
- add per-session MCP server isolation, Host validation, bearer authentication for non-loopback binds, and graceful shutdown
- update observability, documentation, Docker guidance, and add protocol-level tests
- include a minor changeset for `hevy-mcp`

## Validation

- `npm run check`
- `npm run check:types`
- `npm run build`
- `npm run test:unit` (686 tests)
- `npm run test:mcp` (16 tests)
- `npm run test:stdio` (29 tests)
- `npm run check:server-manifest`
- `npm run check:changeset`
- `git diff --check`

`npm run test:pack` reaches the package smoke-test success but the environment's npm install step fails with `EALLOWSCRIPTS`.

Closes #750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in Streamable HTTP transport for the Node package, while keeping stdio as the default.
  * Added CLI options for HTTP transport, host, and port configuration.
  * Added secure bearer-token authentication for non-local HTTP bindings.
  * Added session handling, request validation, streaming responses, and graceful shutdown for HTTP connections.

* **Documentation**
  * Updated configuration guidance with local HTTP, Docker, networking, authentication, and endpoint examples.

* **Tests**
  * Added coverage for transport selection, validation, sessions, authentication, malformed requests, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->