### PR TITLE
fix: build cli during npm packaging

### DIFF
--- a/.changeset/brave-cli-packaging.md
+++ b/.changeset/brave-cli-packaging.md
@@ -1,0 +1,5 @@
+---
+"@chrisdoc/hevy-cli": patch
+---
+
+Build the CLI bundle during npm packaging so published installs include the `hevy` executable.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
 	},
 	"scripts": {
 		"build": "tsdown",
+		"prepack": "npm run build",
 		"check:types": "tsc --noEmit",
 		"test": "vitest run"
 	},

--- a/packages/cli/tests/npm-pack-smoke.mjs
+++ b/packages/cli/tests/npm-pack-smoke.mjs
@@ -1,22 +1,36 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+
 const exec = promisify(execFile);
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const packageDist = fileURLToPath(new URL("../dist", import.meta.url));
 const dir = await mkdtemp(join(tmpdir(), "hevy-cli-pack-"));
+const backupDir = await mkdtemp(join(tmpdir(), "hevy-cli-dist-"));
+const backupDist = join(backupDir, "dist");
+let hadDist = false;
+
 try {
+	try {
+		await access(packageDist);
+		hadDist = true;
+		await rename(packageDist, backupDist);
+	} catch {}
+
 	await exec(
 		"npm",
 		["pack", "--workspace=@chrisdoc/hevy-cli", "--pack-destination", dir],
-		{ cwd: new URL("../../..", import.meta.url) },
+		{ cwd: repositoryRoot },
 	);
-	const names = await (await import("node:fs/promises")).readdir(dir);
+	const names = await readdir(dir);
 	if (names.length !== 1 || !names[0].endsWith(".tgz"))
 		throw new Error("CLI tarball was not created");
+	const tarball = join(dir, names[0]);
 	const manifest = JSON.parse(
-		(await exec("tar", ["-xOf", join(dir, names[0]), "package/package.json"]))
-			.stdout,
+		(await exec("tar", ["-xOf", tarball, "package/package.json"])).stdout,
 	);
 	if (manifest.name !== "@chrisdoc/hevy-cli")
 		throw new Error("CLI package metadata missing");
@@ -24,16 +38,35 @@ try {
 		throw new Error("CLI package repository metadata missing");
 	if (manifest.dependencies && Object.keys(manifest.dependencies).length)
 		throw new Error("CLI has runtime dependencies");
-	await exec("tar", ["-xzf", join(dir, names[0]), "-C", dir]);
+	if (manifest.scripts?.prepack !== "npm run build")
+		throw new Error("CLI package does not build before packing");
+
+	await exec("tar", ["-xzf", tarball, "-C", dir]);
+	const consumer = join(dir, "consumer");
+	await mkdir(consumer);
+	await exec(
+		"npm",
+		[
+			"install",
+			"--no-audit",
+			"--no-fund",
+			"--ignore-scripts",
+			"--prefix",
+			consumer,
+			tarball,
+		],
+		{ cwd: repositoryRoot },
+	);
 	const version = await exec(
-		"node",
-		[join(dir, "package/dist/cli.mjs"), "--version"],
-		{
-			env: { ...process.env, HEVY_API_KEY: undefined },
-		},
+		join(consumer, "node_modules/.bin/hevy"),
+		["--version"],
+		{ env: { ...process.env, HEVY_API_KEY: "" } },
 	);
 	if (version.stdout !== `${manifest.version}\n` || version.stderr !== "")
 		throw new Error("Packed CLI executable did not report its version");
 } finally {
+	await rm(packageDist, { recursive: true, force: true });
+	if (hadDist) await rename(backupDist, packageDist);
+	await rm(backupDir, { recursive: true, force: true });
 	await rm(dir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- build the bundled CLI during npm packaging so published tarballs include `dist/cli.mjs`
- verify a clean packed install exposes the `hevy` executable
- add a patch changeset for `@chrisdoc/hevy-cli`

## Verification
- `npm run build --workspace=@chrisdoc/hevy-cli`
- `npm run test --workspace=@chrisdoc/hevy-cli`
- `npm run check:types --workspace=@chrisdoc/hevy-cli`
- `npm run check`
- `npm run check:changeset`
- `npm run test:pack:cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CLI packages now build automatically before publication, ensuring installed packages include the `hevy` executable.
  - Published CLI installations can run the version command successfully immediately after installation.

- **Tests**
  - Added packaging verification to confirm the published archive contains the expected metadata and executable.
  - Validated installation and execution from a freshly packed CLI archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->