### PR TITLE
feat: add node telemetry opt-out

### DIFF
--- a/.changeset/node-telemetry-opt-out.md
+++ b/.changeset/node-telemetry-opt-out.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Add `HEVY_MCP_TELEMETRY=0` to disable all Node project telemetry while preserving telemetry by default.

--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,8 @@ HEVY_API_KEY=HEVY_KEY
 # HEVY_MCP_API_TIMEOUT=30000
 # Enable privacy-bounded debug diagnostics on stderr (only 1 enables it)
 # HEVY_MCP_DEBUG=1
+# Disable all local Node project telemetry (only the exact value 0 opts out)
+# HEVY_MCP_TELEMETRY=0
 
 # Sentry Configuration (optional - for source map uploads during build)
 # SENTRY_AUTH_TOKEN=your_sentry_auth_token_here

--- a/README.md
+++ b/README.md
@@ -474,17 +474,18 @@ self-hosted Streamable HTTP.
 
 ## Advanced configuration
 
-| Setting                      | Default                        | Scope                         | Notes                                                                                                               |
-| ---------------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
-| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
-| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
-| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                               |
-| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
-| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
-| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
-| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
-| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
+| Setting                      | Default                        | Scope                         | Notes                                                                                                                                                                            |
+| ---------------------------- | ------------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                                                                                          |
+| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                                                                               |
+| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.                                                                          |
+| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                                                                                            |
+| `HEVY_MCP_TELEMETRY`         | Enabled                        | Local Node                    | Set to exactly `0` before startup/import to disable Sentry errors/traces and OTLP traces/metrics. Takes precedence over `SENTRY_DSN` and packaged/runtime collector credentials. |
+| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                                                                                 |
+| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Sentry-only override for the destination. An empty value disables Sentry export. The Worker does not import Node telemetry.                                                      |
+| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                                                                                          |
+| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                                                                                |
+| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                                                                                            |
 
 The local Node executable uses stdio by default. Opt into local Streamable
 HTTP with:
@@ -516,6 +517,42 @@ server-scoped in-memory catalog cache:
 - `search-exercise-templates` accepts `refresh: true` to invalidate the cache.
 - Paginated `get-exercise-templates` calls always fetch their requested page.
 - Each hosted Worker request gets a fresh cache, preventing cross-key sharing.
+
+### Local Node telemetry and privacy
+
+The local Node package enables project telemetry by default. It is local Node
+behavior only; the Cloudflare Worker does not import Node telemetry. Set
+`HEVY_MCP_TELEMETRY=0` before startup or import to disable all project
+telemetry. Only the literal value `0` opts out: an unset value, an empty value,
+`1`, `false`, and every other value remain enabled. The master setting takes
+precedence over `SENTRY_DSN` and packaged or runtime `OTEL_COLLECTOR_TOKEN`
+credentials, so the disabled path creates no telemetry exporters or periodic
+metric readers and makes no telemetry network requests. `SENTRY_DSN` remains a
+Sentry-only setting; when telemetry is enabled, an empty value disables only
+Sentry export.
+
+When enabled, errors and traces are sent to the packaged Sentry project at
+<https://o4508975499575296.ingest.de.sentry.io/4509049671647312>. Traces and
+metrics are sent to the collector at
+<https://otel.chrisdoc.dev/v1/traces> and
+<https://otel.chrisdoc.dev/v1/metrics>, which forward to Honeycomb. Metrics
+export every 10 seconds.
+
+The API key is never exported. Enabled telemetry derives a deterministic
+ten-character HMAC-SHA-256 pseudonym from it solely for cross-span
+correlation. The pseudonym is attached to spans only, never used as a metric
+dimension, and is not intended for per-user behavior histories.
+
+The privacy allowlist contains service/version/transport; fixed tool feature,
+read/write kind, operation, and short-lived tool name; bounded
+outcome/error/count/retry/duration/session/cache/workflow values; normalized API
+method/endpoint/status; shape-only key names, presence, count, and boolean
+fields; sanitized client/protocol tokens; and the span-only pseudonym. It
+explicitly prohibits raw prompts, tool argument values, tool result content,
+request bodies, API keys, raw identifiers/queries/exact dates,
+workout/routine/folder/template/body-measurement content, names/titles/
+descriptions/notes, measurement values, arbitrary client metadata, and
+unnormalized endpoint paths.
 
 ## Security and mutations
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -414,17 +414,18 @@ self-hosted Streamable HTTP.
 
 ## Advanced configuration
 
-| Setting                      | Default                        | Scope                         | Notes                                                                                                               |
-| ---------------------------- | ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                             |
-| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                  |
-| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.             |
-| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                               |
-| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                    |
-| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Overrides the Sentry destination. An empty value disables Sentry export. The Worker does not import Node telemetry. |
-| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                             |
-| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                   |
-| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                               |
+| Setting                      | Default                        | Scope                         | Notes                                                                                                                                                                            |
+| ---------------------------- | ------------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HEVY_API_KEY`               | None; required                 | Local stdio or HTTP           | Hevy API key from the Hevy app. Never pass it in a URL.                                                                                                                          |
+| `HEVY_MCP_API_TIMEOUT`       | `30000` ms                     | Local stdio                   | Positive Hevy API timeout in milliseconds. Invalid values fall back to 30 seconds.                                                                                               |
+| `HEVY_MCP_DEBUG`             | Disabled                       | Local Node                    | Set to exactly `1` for privacy-bounded diagnostics on stderr. Stdout remains reserved for MCP JSON-RPC.                                                                          |
+| `HEVY_MCP_HTTP_BEARER_TOKEN` | None                           | Non-loopback HTTP             | Required when `--host` is not loopback; use a separate token, never the Hevy API key.                                                                                            |
+| `HEVY_MCP_TELEMETRY`         | Enabled                        | Local Node                    | Set to exactly `0` before startup/import to disable Sentry errors/traces and OTLP traces/metrics. Takes precedence over `SENTRY_DSN` and packaged/runtime collector credentials. |
+| `XDG_CACHE_HOME`             | `~/.cache`                     | Local stdio                   | Changes the root for the npm update-check cache at `hevy-mcp/update-check.json`.                                                                                                 |
+| `SENTRY_DSN`                 | Packaged project DSN           | Optional local Node telemetry | Sentry-only override for the destination. An empty value disables Sentry export. The Worker does not import Node telemetry.                                                      |
+| `SENTRY_RELEASE`             | `hevy-mcp@<installed-version>` | Optional local Node telemetry | Overrides the release label attached to local Sentry events and traces.                                                                                                          |
+| `-h`, `--help`               | N/A                            | Local stdio CLI               | Print supported options and exit.                                                                                                                                                |
+| `-v`, `--version`            | N/A                            | Local stdio CLI               | Print the installed version and exit.                                                                                                                                            |
 
 The local executable uses stdio by default. To opt into Streamable HTTP, run:
 
@@ -458,6 +459,42 @@ server-scoped in-memory catalog cache:
 - `search-exercise-templates` accepts `refresh: true` to invalidate the cache.
 - Paginated `get-exercise-templates` calls always fetch their requested page.
 - Each hosted Worker request gets a fresh cache, preventing cross-key sharing.
+
+### Local Node telemetry and privacy
+
+The local Node package enables project telemetry by default. It is local Node
+behavior only; the Cloudflare Worker does not import Node telemetry. Set
+`HEVY_MCP_TELEMETRY=0` before startup or import to disable all project
+telemetry. Only the literal value `0` opts out: an unset value, an empty value,
+`1`, `false`, and every other value remain enabled. The master setting takes
+precedence over `SENTRY_DSN` and packaged or runtime `OTEL_COLLECTOR_TOKEN`
+credentials, so the disabled path creates no telemetry exporters or periodic
+metric readers and makes no telemetry network requests. `SENTRY_DSN` remains a
+Sentry-only setting; when telemetry is enabled, an empty value disables only
+Sentry export.
+
+When enabled, errors and traces are sent to the packaged Sentry project at
+<https://o4508975499575296.ingest.de.sentry.io/4509049671647312>. Traces and
+metrics are sent to the collector at
+<https://otel.chrisdoc.dev/v1/traces> and
+<https://otel.chrisdoc.dev/v1/metrics>, which forward to Honeycomb. Metrics
+export every 10 seconds.
+
+The API key is never exported. Enabled telemetry derives a deterministic
+ten-character HMAC-SHA-256 pseudonym from it solely for cross-span
+correlation. The pseudonym is attached to spans only, never used as a metric
+dimension, and is not intended for per-user behavior histories.
+
+The privacy allowlist contains service/version/transport; fixed tool feature,
+read/write kind, operation, and short-lived tool name; bounded
+outcome/error/count/retry/duration/session/cache/workflow values; normalized API
+method/endpoint/status; shape-only key names, presence, count, and boolean
+fields; sanitized client/protocol tokens; and the span-only pseudonym. It
+explicitly prohibits raw prompts, tool argument values, tool result content,
+request bodies, API keys, raw identifiers/queries/exact dates,
+workout/routine/folder/template/body-measurement content, names/titles/
+descriptions/notes, measurement values, arbitrary client metadata, and
+unnormalized endpoint paths.
 
 ## Security and mutations
 

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -298,6 +298,8 @@ describe("Node package entrypoint", () => {
 		);
 
 		await runServer();
+		expect(testDoubles.setTelemetryUser).toHaveBeenCalledOnce();
+		expect(testDoubles.setTelemetryUser).toHaveBeenCalledWith("runtime-key");
 
 		expect(testDoubles.startupClient.getUserInfo).toHaveBeenCalledOnce();
 		expect(testDoubles.createHevyMcpServer).toHaveBeenCalledOnce();
@@ -317,6 +319,7 @@ describe("Node package entrypoint", () => {
 		await expect(runServer()).rejects.toThrow(
 			"HEVY_API_KEY is invalid or expired",
 		);
+		expect(testDoubles.setTelemetryUser).toHaveBeenCalledWith("invalid-key");
 		expect(testDoubles.startStreamableHttpServer).not.toHaveBeenCalled();
 		expect(testDoubles.recordSessionTermination).toHaveBeenCalledWith(
 			"startup_failure",

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -28,8 +28,7 @@ const testDoubles = vi.hoisted(() => {
 		createHevyMcpServer: vi.fn(),
 		startStreamableHttpServer: vi.fn(),
 		wrapMcpServerWithSentry: vi.fn((value: unknown) => value),
-		setSentryUser: vi.fn(),
-		setCurrentUserHash: vi.fn(),
+		setTelemetryUser: vi.fn(),
 		flushTelemetry: vi.fn().mockResolvedValue(undefined),
 		serverStartups: { add: vi.fn() },
 		installGracefulShutdown: vi.fn(),
@@ -46,7 +45,6 @@ const testDoubles = vi.hoisted(() => {
 
 vi.mock("./utils/telemetry.js", () => ({
 	Sentry: {
-		setUser: testDoubles.setSentryUser,
 		wrapMcpServerWithSentry: testDoubles.wrapMcpServerWithSentry,
 	},
 	flushTelemetry: testDoubles.flushTelemetry,
@@ -60,7 +58,7 @@ vi.mock("./utils/telemetry.js", () => ({
 	},
 	serviceName: "hevy-mcp",
 	serviceVersion: "3.4.1",
-	setCurrentUserHash: testDoubles.setCurrentUserHash,
+	setTelemetryUser: testDoubles.setTelemetryUser,
 }));
 
 vi.mock("./utils/metrics.js", () => ({
@@ -172,6 +170,9 @@ describe("Node package entrypoint", () => {
 		await expect(
 			createNodeMcpServer({ apiKey: "programmatic-key" }),
 		).resolves.toBe(testDoubles.server);
+		expect(testDoubles.setTelemetryUser).toHaveBeenCalledWith(
+			"programmatic-key",
+		);
 
 		expect(testDoubles.createHevyClient).toHaveBeenNthCalledWith(
 			1,
@@ -245,8 +246,14 @@ describe("Node package entrypoint", () => {
 		process.argv.push(flag);
 
 		await runStdioServer();
-
 		expect(console.log).toHaveBeenCalledWith(expect.stringContaining(output));
+
+		expect(console.log).toHaveBeenCalledWith(
+			expect.stringContaining("HEVY_MCP_TELEMETRY=0"),
+		);
+		expect(console.log).toHaveBeenCalledWith(
+			expect.stringContaining("Disable all project telemetry"),
+		);
 		expect(testDoubles.serverStartups.add).not.toHaveBeenCalled();
 		expect(testDoubles.createHevyClient).not.toHaveBeenCalled();
 	});
@@ -320,6 +327,10 @@ describe("Node package entrypoint", () => {
 		process.env.HEVY_API_KEY = "runtime-key";
 
 		await runStdioServer();
+		expect(testDoubles.setTelemetryUser).toHaveBeenNthCalledWith(
+			1,
+			"runtime-key",
+		);
 
 		expect(testDoubles.serverStartups.add).toHaveBeenCalledWith(1, {
 			version: "3.4.1",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -6,12 +6,11 @@ import {
 	tracer,
 	serviceName,
 	serviceVersion,
-	setCurrentUserHash,
+	setTelemetryUser,
 } from "./utils/telemetry.js";
 import { serverStartups } from "./utils/metrics.js";
 
 import { SpanStatusCode } from "@opentelemetry/api";
-import { createHmac } from "node:crypto";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { createHevyMcpServer } from "@hevy-mcp/core";
@@ -47,6 +46,7 @@ const HELP_TEXT = [
 	"  HEVY_API_KEY=<api-key>     Hevy API key from Hevy app settings",
 	"  HEVY_MCP_DEBUG=1           Enable verbose diagnostics on stderr",
 	"  HEVY_MCP_HTTP_BEARER_TOKEN Protect non-loopback HTTP deployments",
+	"  HEVY_MCP_TELEMETRY=0     Disable all project telemetry",
 	"",
 	"Examples:",
 	"  HEVY_API_KEY=your-key npx hevy-mcp",
@@ -87,17 +87,6 @@ const SAFE_NETWORK_ERROR_CODES = new Set([
 	"HEVY_RETRY_EXHAUSTED",
 ]);
 
-const SENTRY_USER_ID_CONTEXT = "hevy-mcp:sentry-user-id:v1";
-
-function fingerprintApiKey(apiKey: string) {
-	// HMAC-SHA-256 gives Sentry and OTel a deterministic pseudonymous user
-	// hash without sending, logging, or storing the raw Hevy API key.
-	// Trimmed to 10 characters to keep it compact and readable in traces.
-	return createHmac("sha256", apiKey)
-		.update(SENTRY_USER_ID_CONTEXT)
-		.digest("hex")
-		.slice(0, 10);
-}
 const serverConfigSchema = z.object({
 	apiKey: z
 		.string()
@@ -217,9 +206,7 @@ export async function createNodeMcpServer(
 	transport: NodeTransport = "stdio",
 ) {
 	const { apiKey: validatedApiKey } = serverConfigSchema.parse({ apiKey });
-	const userHash = fingerprintApiKey(validatedApiKey);
-	setCurrentUserHash(userHash);
-	Sentry.setUser({ id: userHash });
+	setTelemetryUser(validatedApiKey);
 	await validateApiKey(validatedApiKey);
 	return buildServer(validatedApiKey, transport);
 }
@@ -243,12 +230,8 @@ export async function runStdioServer() {
 	// Seed the user context before config validation so startup failures for a
 	// supplied key retain the same trace correlation as normal tool calls.
 	const configuredApiKey = process.env.HEVY_API_KEY;
-	const initialUserHash = configuredApiKey
-		? fingerprintApiKey(configuredApiKey)
-		: undefined;
-	if (initialUserHash) {
-		setCurrentUserHash(initialUserHash);
-		Sentry.setUser({ id: initialUserHash });
+	if (configuredApiKey) {
+		setTelemetryUser(configuredApiKey);
 	}
 	let connectAttempted = false;
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -329,6 +329,7 @@ export async function runServer(): Promise<void> {
 			try {
 				const cfg = parseConfig(process.env);
 				assertApiKey(cfg.apiKey);
+				setTelemetryUser(cfg.apiKey);
 				await validateApiKey(cfg.apiKey);
 				const handle = await startStreamableHttpServer(
 					options,

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeSentryMcpSpan } from "./sentry-privacy.js";
 
 const originalEnv = { ...process.env };
@@ -7,30 +7,55 @@ const originalEnv = { ...process.env };
 // We mock the external dependencies so the test can verify initialization
 // without making real network calls.
 
-const testDoubles = vi.hoisted(() => ({
-	sentryInit: vi.fn(() => ({ _isSentryClient: true })),
-	validateOpenTelemetrySetup: vi.fn(),
-	register: vi.fn(),
-	setGlobalTracerProvider: vi.fn(),
-	setGlobalMeterProvider: vi.fn(),
-	otlpTraceExporter: vi.fn(),
-	otlpMetricExporter: vi.fn(),
-	batchSpanProcessor: vi.fn(),
-	meterProvider: vi.fn(),
-	periodicExportingMetricReader: vi.fn(),
-	nodeTracerProviderOptions: undefined as unknown,
-}));
+const testDoubles = vi.hoisted(() => {
+	const hmacUpdate = vi.fn().mockReturnThis();
+	const hmacDigest = vi.fn(() => "abcdef0123456789");
+
+	return {
+		sentryInit: vi.fn(() => ({ _isSentryClient: true })),
+		sentryFlush: vi.fn().mockResolvedValue(true),
+		sentrySetUser: vi.fn(),
+		validateOpenTelemetrySetup: vi.fn(),
+		sentrySpanProcessor: vi.fn(),
+		sentryPropagator: vi.fn(),
+		sentrySampler: vi.fn(),
+		sentryContextManager: vi.fn(),
+		register: vi.fn(),
+		setGlobalTracerProvider: vi.fn(),
+		setGlobalMeterProvider: vi.fn(),
+		otlpTraceExporter: vi.fn(),
+		otlpMetricExporter: vi.fn(),
+		batchSpanProcessor: vi.fn(),
+		meterProvider: vi.fn(),
+		meterProviderForceFlush: vi.fn().mockResolvedValue(undefined),
+		periodicExportingMetricReader: vi.fn(),
+		nodeTracerProvider: vi.fn(),
+		tracerProviderForceFlush: vi.fn().mockResolvedValue(undefined),
+		nodeTracerProviderOptions: undefined as unknown,
+		createHmac: vi.fn(() => ({
+			update: hmacUpdate,
+			digest: hmacDigest,
+		})),
+		hmacUpdate,
+		hmacDigest,
+	};
+});
 vi.mock("@sentry/node", () => ({
 	init: testDoubles.sentryInit,
-	flush: vi.fn().mockResolvedValue(true),
+	flush: testDoubles.sentryFlush,
+	setUser: testDoubles.sentrySetUser,
 	validateOpenTelemetrySetup: testDoubles.validateOpenTelemetrySetup,
-	SentryContextManager: vi.fn(),
+	SentryContextManager: testDoubles.sentryContextManager,
+}));
+
+vi.mock("node:crypto", () => ({
+	createHmac: testDoubles.createHmac,
 }));
 
 vi.mock("@sentry/opentelemetry", () => ({
-	SentrySpanProcessor: vi.fn(),
-	SentryPropagator: vi.fn(),
-	SentrySampler: vi.fn(),
+	SentrySpanProcessor: testDoubles.sentrySpanProcessor,
+	SentryPropagator: testDoubles.sentryPropagator,
+	SentrySampler: testDoubles.sentrySampler,
 }));
 
 vi.mock("@opentelemetry/api", () => ({
@@ -66,21 +91,55 @@ vi.mock("@opentelemetry/sdk-trace-base", () => ({
 vi.mock("@opentelemetry/sdk-trace-node", () => {
 	class MockNodeTracerProvider {
 		constructor(options: unknown) {
+			testDoubles.nodeTracerProvider(options);
 			testDoubles.nodeTracerProviderOptions = options;
 		}
 		register = testDoubles.register;
+		forceFlush() {
+			return testDoubles.tracerProviderForceFlush();
+		}
 	}
 	return { NodeTracerProvider: MockNodeTracerProvider };
 });
 
-vi.mock("@opentelemetry/sdk-metrics", () => ({
-	MeterProvider: testDoubles.meterProvider,
-	PeriodicExportingMetricReader: testDoubles.periodicExportingMetricReader,
-}));
+vi.mock("@opentelemetry/sdk-metrics", () => {
+	class MockMeterProvider {
+		constructor(options: unknown) {
+			testDoubles.meterProvider(options);
+		}
+		forceFlush() {
+			return testDoubles.meterProviderForceFlush();
+		}
+	}
+	return {
+		MeterProvider: MockMeterProvider,
+		PeriodicExportingMetricReader: testDoubles.periodicExportingMetricReader,
+	};
+});
+
+function setTelemetryEnvironment(
+	telemetrySetting?: string,
+	overrides: Record<string, string> = {},
+): void {
+	const env = { ...originalEnv };
+	delete env.HEVY_MCP_TELEMETRY;
+	delete env.SENTRY_DSN;
+	delete env.OTEL_COLLECTOR_TOKEN;
+	if (telemetrySetting !== undefined) {
+		env.HEVY_MCP_TELEMETRY = telemetrySetting;
+	}
+	Object.assign(env, overrides);
+	process.env = env;
+}
 
 describe("telemetry initialization", () => {
+	beforeEach(() => {
+		setTelemetryEnvironment();
+		testDoubles.nodeTracerProviderOptions = undefined;
+	});
 	afterEach(() => {
 		process.env = { ...originalEnv };
+		testDoubles.nodeTracerProviderOptions = undefined;
 		vi.clearAllMocks();
 	});
 
@@ -96,6 +155,26 @@ describe("telemetry initialization", () => {
 				ignoreErrors: ["EPIPE", "broken pipe"],
 			}),
 		);
+	});
+	it.each<[string, string | undefined]>([
+		["unset", undefined],
+		["empty", ""],
+		["one", "1"],
+		["false", "false"],
+	])("keeps telemetry enabled for $0", async (_label, setting) => {
+		setTelemetryEnvironment(setting);
+		vi.resetModules();
+
+		await import("./telemetry.js");
+
+		expect(testDoubles.sentryInit).toHaveBeenCalledOnce();
+		expect(testDoubles.nodeTracerProvider).toHaveBeenCalledOnce();
+		expect(testDoubles.sentrySpanProcessor).toHaveBeenCalledOnce();
+		expect(testDoubles.sentrySampler).toHaveBeenCalledOnce();
+		expect(testDoubles.sentryPropagator).toHaveBeenCalledOnce();
+		expect(testDoubles.sentryContextManager).toHaveBeenCalledOnce();
+		expect(testDoubles.setGlobalTracerProvider).toHaveBeenCalledOnce();
+		expect(testDoubles.validateOpenTelemetrySetup).toHaveBeenCalledOnce();
 	});
 
 	it("sanitizes Sentry MCP correlation and client metadata", async () => {
@@ -148,12 +227,11 @@ describe("telemetry initialization", () => {
 
 	it("configures collector exporters when a token is present", async () => {
 		vi.resetModules();
-		process.env = {
-			...originalEnv,
+		setTelemetryEnvironment(undefined, {
 			OTEL_COLLECTOR_TOKEN: "test-collector-token",
-		};
+		});
 
-		await import("./telemetry.js");
+		const mod = await import("./telemetry.js");
 
 		expect(testDoubles.otlpTraceExporter).toHaveBeenCalledWith({
 			url: "https://otel.chrisdoc.dev/v1/traces",
@@ -180,6 +258,83 @@ describe("telemetry initialization", () => {
 			}),
 		);
 		expect(testDoubles.setGlobalMeterProvider).toHaveBeenCalled();
+		expect(testDoubles.sentryInit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sendDefaultPii: false,
+				skipOpenTelemetrySetup: true,
+				registerEsmLoaderHooks: false,
+			}),
+		);
+		expect(testDoubles.nodeTracerProvider).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resource: expect.anything(),
+				sampler: expect.anything(),
+				spanProcessors: expect.any(Array),
+			}),
+		);
+		expect(testDoubles.setGlobalTracerProvider).toHaveBeenCalledOnce();
+		expect(testDoubles.validateOpenTelemetrySetup).toHaveBeenCalledOnce();
+
+		await mod.flushTelemetry();
+		expect(testDoubles.tracerProviderForceFlush).toHaveBeenCalledOnce();
+		expect(testDoubles.meterProviderForceFlush).toHaveBeenCalledOnce();
+		expect(testDoubles.sentryFlush).toHaveBeenCalledWith(1_000);
+	});
+
+	it("keeps collector exports when Sentry DSN is empty", async () => {
+		setTelemetryEnvironment(undefined, {
+			SENTRY_DSN: "",
+			OTEL_COLLECTOR_TOKEN: "test-collector-token",
+		});
+		vi.resetModules();
+
+		await import("./telemetry.js");
+
+		expect(testDoubles.sentryInit).toHaveBeenCalledWith(
+			expect.objectContaining({ dsn: undefined }),
+		);
+		expect(testDoubles.otlpTraceExporter).toHaveBeenCalledOnce();
+		expect(testDoubles.otlpMetricExporter).toHaveBeenCalledOnce();
+		expect(testDoubles.periodicExportingMetricReader).toHaveBeenCalledOnce();
+	});
+
+	it("disables the complete telemetry graph for the exact opt-out value", async () => {
+		setTelemetryEnvironment("0", {
+			SENTRY_DSN: "sentry-sentinel",
+			OTEL_COLLECTOR_TOKEN: "collector-sentinel",
+		});
+		vi.resetModules();
+
+		const mod = await import("./telemetry.js");
+
+		expect(testDoubles.sentryInit).not.toHaveBeenCalled();
+		expect(testDoubles.sentrySpanProcessor).not.toHaveBeenCalled();
+		expect(testDoubles.sentrySampler).not.toHaveBeenCalled();
+		expect(testDoubles.sentryPropagator).not.toHaveBeenCalled();
+		expect(testDoubles.sentryContextManager).not.toHaveBeenCalled();
+		expect(testDoubles.nodeTracerProvider).not.toHaveBeenCalled();
+		expect(testDoubles.otlpTraceExporter).not.toHaveBeenCalled();
+		expect(testDoubles.batchSpanProcessor).not.toHaveBeenCalled();
+		expect(testDoubles.otlpMetricExporter).not.toHaveBeenCalled();
+		expect(testDoubles.periodicExportingMetricReader).not.toHaveBeenCalled();
+		expect(testDoubles.meterProvider).not.toHaveBeenCalled();
+		expect(testDoubles.setGlobalTracerProvider).not.toHaveBeenCalled();
+		expect(testDoubles.setGlobalMeterProvider).not.toHaveBeenCalled();
+		expect(testDoubles.validateOpenTelemetrySetup).not.toHaveBeenCalled();
+		expect(testDoubles.nodeTracerProviderOptions).toBeUndefined();
+		expect(typeof mod.tracer).toBe("object");
+		expect(typeof mod.meter).toBe("object");
+		expect(typeof mod.flushTelemetry).toBe("function");
+		expect(typeof mod.setTelemetryUser).toBe("function");
+
+		mod.setTelemetryUser("raw-api-key-sentinel");
+		await mod.flushTelemetry();
+
+		expect(testDoubles.createHmac).not.toHaveBeenCalled();
+		expect(testDoubles.sentrySetUser).not.toHaveBeenCalled();
+		expect(testDoubles.tracerProviderForceFlush).not.toHaveBeenCalled();
+		expect(testDoubles.meterProviderForceFlush).not.toHaveBeenCalled();
+		expect(testDoubles.sentryFlush).not.toHaveBeenCalled();
 	});
 
 	it("exports tracer, meter, Sentry, serviceName, and serviceVersion", async () => {
@@ -191,9 +346,23 @@ describe("telemetry initialization", () => {
 		expect(mod.serviceName).toBe("hevy-mcp");
 		expect(mod.serviceVersion).toBe("dev");
 	});
-	it("adds the current user hash to every started span", async () => {
+	it("derives and attaches a truncated HMAC user pseudonym", async () => {
 		vi.resetModules();
 		const mod = await import("./telemetry.js");
+
+		mod.setTelemetryUser("raw-api-key-sentinel");
+
+		expect(testDoubles.createHmac).toHaveBeenCalledWith(
+			"sha256",
+			"raw-api-key-sentinel",
+		);
+		expect(testDoubles.hmacUpdate).toHaveBeenCalledWith(
+			"hevy-mcp:sentry-user-id:v1",
+		);
+		expect(testDoubles.hmacDigest).toHaveBeenCalledWith("hex");
+		expect(testDoubles.sentrySetUser).toHaveBeenCalledWith({
+			id: "abcdef0123",
+		});
 
 		const providerOptions = testDoubles.nodeTracerProviderOptions as {
 			spanProcessors: Array<{
@@ -205,15 +374,9 @@ describe("telemetry initialization", () => {
 			throw new Error("Expected user hash span processor");
 		}
 
-		const noUserHashSetAttribute = vi.fn();
-		processor.onStart({ setAttribute: noUserHashSetAttribute }, {});
-		expect(noUserHashSetAttribute).not.toHaveBeenCalled();
-
-		mod.setCurrentUserHash("hash-123");
-
 		const setAttribute = vi.fn();
 		processor.onStart({ setAttribute }, {});
 
-		expect(setAttribute).toHaveBeenCalledWith("user.hash", "hash-123");
+		expect(setAttribute).toHaveBeenCalledWith("user.hash", "abcdef0123");
 	});
 });

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -9,6 +9,7 @@
  * OTel Collector → Honeycomb: performance traces, metrics
  */
 
+import { createHmac } from "node:crypto";
 import * as Sentry from "@sentry/node";
 import { sanitizeSentryMcpSpan } from "./sentry-privacy.js";
 import {
@@ -42,6 +43,8 @@ const name =
 const version =
 	typeof __HEVY_MCP_VERSION__ === "string" ? __HEVY_MCP_VERSION__ : "dev";
 
+const telemetryEnabled = process.env.HEVY_MCP_TELEMETRY !== "0";
+
 // Collector token is injected at build time from the OTEL_COLLECTOR_TOKEN
 // GitHub secret via tsdown.config.ts define. The collector forwards
 // traces and metrics to Honeycomb, keeping the Honeycomb API key off the
@@ -58,24 +61,6 @@ const sentryRelease = process.env.SENTRY_RELEASE ?? `${name}@${version}`;
 const resource = resourceFromAttributes({
 	"service.name": name,
 	"service.version": version,
-});
-
-const bakedDsn =
-	"https://ce696d8333b507acbf5203eb877bce0f@o4508975499575296.ingest.de.sentry.io/4509049671647312";
-const rawDsn = process.env.SENTRY_DSN ?? bakedDsn;
-const isValidDsn =
-	typeof rawDsn === "string" && rawDsn.length > 0 && !rawDsn.startsWith("*");
-
-// --- Sentry (error monitoring + traces) ---
-const sentryClient = Sentry.init({
-	dsn: isValidDsn ? rawDsn : undefined,
-	beforeSendSpan: sanitizeSentryMcpSpan,
-	release: sentryRelease,
-	tracesSampleRate: 1.0,
-	sendDefaultPii: false,
-	skipOpenTelemetrySetup: true,
-	registerEsmLoaderHooks: false,
-	ignoreErrors: ["EPIPE", "broken pipe"],
 });
 
 // --- OpenTelemetry tracer provider (dual export) ---
@@ -95,64 +80,90 @@ class UserHashSpanProcessor implements SpanProcessor {
 	async shutdown(): Promise<void> {}
 }
 
-const spanProcessors: SpanProcessor[] = [
-	new UserHashSpanProcessor(),
-	new SentrySpanProcessor(),
-];
-
-// OTel Collector → Honeycomb traces — only if token is available
-if (collectorToken) {
-	spanProcessors.push(
-		new BatchSpanProcessor(
-			new OTLPTraceExporter({
-				url: `${COLLECTOR_ENDPOINT}/traces`,
-				headers: {
-					Authorization: `Bearer ${collectorToken}`,
-				},
-			}),
-		),
-	);
-}
-
-const tracerProvider = new NodeTracerProvider({
-	resource,
-	sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
-	spanProcessors,
-});
-
-tracerProvider.register({
-	propagator: new SentryPropagator(),
-	contextManager: new Sentry.SentryContextManager(),
-});
-
+let tracerProvider: NodeTracerProvider | undefined;
 let meterProvider: MeterProvider | undefined;
-// --- OpenTelemetry meter provider (→ Collector → Honeycomb metrics) ---
-if (collectorToken) {
-	meterProvider = new MeterProvider({
-		resource,
-		readers: [
-			new PeriodicExportingMetricReader({
-				exporter: new OTLPMetricExporter({
-					url: `${COLLECTOR_ENDPOINT}/metrics`,
+
+if (telemetryEnabled) {
+	const bakedDsn =
+		"https://ce696d8333b507acbf5203eb877bce0f@o4508975499575296.ingest.de.sentry.io/4509049671647312";
+	const rawDsn = process.env.SENTRY_DSN ?? bakedDsn;
+	const isValidDsn =
+		typeof rawDsn === "string" && rawDsn.length > 0 && !rawDsn.startsWith("*");
+
+	// --- Sentry (error monitoring + traces) ---
+	const sentryClient = Sentry.init({
+		dsn: isValidDsn ? rawDsn : undefined,
+		beforeSendSpan: sanitizeSentryMcpSpan,
+		release: sentryRelease,
+		tracesSampleRate: 1.0,
+		sendDefaultPii: false,
+		skipOpenTelemetrySetup: true,
+		registerEsmLoaderHooks: false,
+		ignoreErrors: ["EPIPE", "broken pipe"],
+	});
+
+	const spanProcessors: SpanProcessor[] = [
+		new UserHashSpanProcessor(),
+		new SentrySpanProcessor(),
+	];
+
+	// OTel Collector → Honeycomb traces — only if token is available
+	if (collectorToken) {
+		spanProcessors.push(
+			new BatchSpanProcessor(
+				new OTLPTraceExporter({
+					url: `${COLLECTOR_ENDPOINT}/traces`,
 					headers: {
 						Authorization: `Bearer ${collectorToken}`,
 					},
 				}),
-				exportIntervalMillis: 10_000,
-			}),
-		],
+			),
+		);
+	}
+
+	tracerProvider = new NodeTracerProvider({
+		resource,
+		sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
+		spanProcessors,
 	});
-	metrics.setGlobalMeterProvider(meterProvider);
+
+	tracerProvider.register({
+		propagator: new SentryPropagator(),
+		contextManager: new Sentry.SentryContextManager(),
+	});
+
+	// --- OpenTelemetry meter provider (→ Collector → Honeycomb metrics) ---
+	if (collectorToken) {
+		meterProvider = new MeterProvider({
+			resource,
+			readers: [
+				new PeriodicExportingMetricReader({
+					exporter: new OTLPMetricExporter({
+						url: `${COLLECTOR_ENDPOINT}/metrics`,
+						headers: {
+							Authorization: `Bearer ${collectorToken}`,
+						},
+					}),
+					exportIntervalMillis: 10_000,
+				}),
+			],
+		});
+		metrics.setGlobalMeterProvider(meterProvider);
+	}
+
+	trace.setGlobalTracerProvider(tracerProvider);
+
+	// Validate that Sentry + OpenTelemetry are wired correctly
+	Sentry.validateOpenTelemetrySetup();
 }
 
-trace.setGlobalTracerProvider(tracerProvider);
-
-// Validate that Sentry + OpenTelemetry are wired correctly
-Sentry.validateOpenTelemetrySetup();
-
 export async function flushTelemetry(timeoutMs = 1_000): Promise<void> {
+	if (!telemetryEnabled) {
+		return;
+	}
+
 	const flushPromise = Promise.allSettled([
-		tracerProvider.forceFlush(),
+		...(tracerProvider ? [tracerProvider.forceFlush()] : []),
 		...(meterProvider ? [meterProvider.forceFlush()] : []),
 		Sentry.flush(timeoutMs),
 	]);
@@ -187,6 +198,17 @@ export const serviceInfo: ServiceInfo = { name, version } as const;
 export { name as serviceName, version as serviceVersion };
 
 // --- User context for span attributes ---
-export function setCurrentUserHash(hash: string): void {
-	currentUserHash = hash;
+const SENTRY_USER_ID_CONTEXT = "hevy-mcp:sentry-user-id:v1";
+
+export function setTelemetryUser(apiKey: string): void {
+	if (!telemetryEnabled) {
+		return;
+	}
+
+	const userHash = createHmac("sha256", apiKey)
+		.update(SENTRY_USER_ID_CONTEXT)
+		.digest("hex")
+		.slice(0, 10);
+	currentUserHash = userHash;
+	Sentry.setUser({ id: userHash });
 }


### PR DESCRIPTION
## Summary

- Add `HEVY_MCP_TELEMETRY=0` as an exact-string, import-time opt-out for all Node project telemetry.
- Gate Sentry, OTLP exporters/readers, provider registration, identity derivation, and flushing while preserving enabled-by-default behavior.
- Initialize the telemetry user pseudonym for both stdio and HTTP startup paths.
- Add regression coverage, CLI/help and README disclosures, `.env.sample` guidance, and a patch changeset.

Closes #749

## Validation

- `npm run test:pr`
- `npm run test:performance`
- `npx vitest run packages/node/src/utils/telemetry.test.ts packages/node/src/index.test.ts`
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- `HEVY_MCP_TELEMETRY=0 node packages/node/dist/cli.mjs --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-out for all local project telemetry using the exact value `HEVY_MCP_TELEMETRY=0`; telemetry remains enabled by default and honors this setting consistently.
  - Updated CLI help to document `HEVY_MCP_TELEMETRY=0`.

- **Documentation**
  - Expanded advanced configuration with clearer telemetry, debugging, and Sentry behavior notes.
  - Added a new “Local Node telemetry and privacy” section covering what’s exported, privacy-preserving user correlation, and what’s not collected.
  - Updated `.env.sample` and Node package README formatting.

- **Tests**
  - Strengthened telemetry tests to verify opt-out behavior, initialization, and flush/export wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->