### PR TITLE
chore: pin all github actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,16 +40,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,10 +29,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dependabot PR branch
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -24,6 +24,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create changeset
-        uses: mscharley/dependency-changesets-action@v1.2.5
+        uses: mscharley/dependency-changesets-action@874dac2372a085cb94f750e8bdf5b1173a838a75 # v1.2.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -40,7 +40,7 @@ jobs:
     name: gitStream workflow automation
     steps:
       - name: Evaluate Rules
-        uses: linear-b/gitstream-github-action@v2
+        uses: linear-b/gitstream-github-action@b1a284aa7219a6248c2e5ef3bc73f494814bc189 # 2.0.250
         id: rules-engine
         with:
           full_repository: ${{ github.event.inputs.full_repository }}

--- a/.github/workflows/nightly-mcp-test.yml
+++ b/.github/workflows/nightly-mcp-test.yml
@@ -39,11 +39,11 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
         id: setup_node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up Bun
         if: matrix.launcher.command == 'bunx'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Run MCP integration test
         id: run_mcp_integration_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       released: ${{ steps.release.outputs.released }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create Release PR or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: npm run version:changesets
           publish: npm run release

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v10
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           # Issues
           stale-issue-message: >-

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# min_age:
+#   value: 7      # threshold in days
+#   always: true  # also run the passive audit on every `pinact run` (extra GitHub API calls)
+# separator: "  # "
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+# rules:
+#   - ignore: true
+#     conditions:
+#       - expr: |
+#           ActionName == "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml" && ActionVersion matches "v\\d+\\.\\d+\\.\\d+"
+#       - expr: |
+#           ActionRepoOwner == "suzuki-shunsuke" && ActionVersion == "main"
+#   - min_age: 0
+#     conditions:
+#       - expr: |
+#           ActionName matches "actions/.*"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 hk = "1.51.0"
 kiota = "latest"
+pinact = "latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved security and reliability of automated workflows by pinning GitHub Actions to specific commit SHAs across code analysis, copilot setup, changesets, CI streaming, nightly MCP tests, releases, and staleness cleanup.
  * Applied consistent fixed-version references for common setup steps (checkout, Node setup, Bun setup) to avoid floating action tags.
  * Added `pinact` configuration support and included `pinact` as a managed tool dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Primary changes

- Replaced mutable GitHub Actions version tags with immutable commit SHA pins across the repository workflows.
- Hardened the release workflow checkout by disabling persisted credentials.
- Added pinact configuration and registered the tool in `mise.toml` for action maintenance.

## Reviewer walkthrough

- Review the updated action references in `.github/workflows/` and confirm each retains a version comment for auditability.
- Review the release workflow checkout hardening, including `persist-credentials: false` alongside the existing fetch-depth and ref settings.
- Review `.pinact.yaml` and `mise.toml` for the pinact defaults used to maintain the pins.

## Correctness and invariants

- Workflow behavior is unchanged apart from resolving action references to immutable commits and disabling credential persistence in the release checkout.
- The release workflow checkout no longer persists credentials for subsequent steps.
- All updated action references retain their upstream version information in comments.

## Testing and QA

- No application tests were run; this change is limited to workflow and pinact configuration.