### PR TITLE
feat: add hevy cli write actions

### DIFF
--- a/.changeset/silly-cameras-dig.md
+++ b/.changeset/silly-cameras-dig.md
@@ -1,0 +1,5 @@
+---
+"@chrisdoc/hevy-cli": minor
+---
+
+Add create and update commands for Hevy resources.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.chrisdoc%2Fhevy-mcp.svg)](https://mcptoplist.com/server/io.github.chrisdoc%2Fhevy-mcp)
 
-[Connect to the hosted MCP](#connect-to-the-hosted-endpoint) · [Use the read-only CLI](#read-only-cli) · [Watch the 18-second demo](https://raw.githubusercontent.com/chrisdoc/hevy-mcp/main/docs/assets/hevy-mcp-demo.mp4) · [Explore all 25 tools](#tools)
+[Connect to the hosted MCP](#connect-to-the-hosted-endpoint) · [Use the Hevy CLI](#hevy-cli) · [Watch the 18-second demo](https://raw.githubusercontent.com/chrisdoc/hevy-mcp/main/docs/assets/hevy-mcp-demo.mp4) · [Explore all 25 tools](#tools)
 
 </div>
 
-## Read-only CLI
+## Hevy CLI
 
 Prefer the terminal? The separate
 [`@chrisdoc/hevy-cli`](https://www.npmjs.com/package/@chrisdoc/hevy-cli)
 package reads workouts, routines, exercises, and body measurements directly
-from the Hevy API. It never creates, updates, or deletes Hevy data.
+from the Hevy API, and can create or update those resources with explicit
+confirmation. Deletion is not supported.
 
 ```sh
 npm install -g @chrisdoc/hevy-cli

--- a/hk.pkl
+++ b/hk.pkl
@@ -13,7 +13,7 @@ local linters = new Mapping<String, Step> {
             "**/*.jsx",
             "**/*.tsx",
         )
-        check = "npx oxlint --type-aware --type-check {{files}}"
+        check = "npx oxlint --type-aware --type-check ."
     }
     ["oxfmt"] {
         glob = List(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13232,6 +13232,7 @@
 				"hevy": "dist/cli.mjs"
 			},
 			"devDependencies": {
+				"@hevy-mcp/core": "file:../core",
 				"@hevy-mcp/hevy-client": "file:../hevy-client",
 				"@stricli/core": "^1.3.0",
 				"zod": "^4.4.3"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,10 +1,9 @@
 # @chrisdoc/hevy-cli
 
-A read-only command-line client for the Hevy API. Use it to inspect workouts,
-routines, exercises, and body measurements from your terminal, or add `--json`
-to pipe the results into another tool.
-
-The CLI does not create, update, or delete Hevy data.
+The `@chrisdoc/hevy-cli` package is a terminal client for the Hevy API. It
+supports read commands plus create and update commands for workouts, routines,
+custom exercise templates, routine folders, and body measurements. Deletion is
+not supported.
 
 ## Requirements
 
@@ -20,9 +19,11 @@ hevy --help
 ```
 
 The CLI reads credentials only from `HEVY_API_KEY`. It does not accept API keys
-in command arguments or URLs.
+in command arguments, JSON payloads, or URLs.
 
 ## Examples
+
+Read commands do not require confirmation:
 
 ```sh
 # List 10 workouts
@@ -31,60 +32,106 @@ hevy workouts list --page-size 10
 # Search the exercise catalog
 hevy exercises search "bench press"
 
-# Review an exercise over a date range
-hevy exercises history <exercise-template-id> \
-  --start-date 2026-07-01T00:00:00Z \
-  --end-date 2026-07-31T23:59:59Z
-
-# Summarize the last four weeks
-hevy summary --weeks 4
-
 # Pipe one JSON value to jq
 hevy routines list --json | jq
 ```
 
-Run `hevy <command> --help` for the flags and arguments accepted by a command.
+Mutation commands require both `--data` and an explicit `--yes`:
+
+```sh
+# Create a folder from inline camelCase JSON
+hevy folders create --data '{"name":"Strength"}' --yes
+
+# Create a workout from a UTF-8 JSON file
+hevy workouts create --data @workout.json --yes --json
+
+# Replace a routine from JSON piped on stdin
+cat routine.json | hevy routines update routine-123 --data @- --yes --json
+
+# Patch one measurement field
+hevy measurements update 2026-07-27 \
+  --data '{"weightKg":80.5}' --yes --json
+
+# Clear a measurement field explicitly
+hevy measurements update 2026-07-27 \
+  --data '{"fatPercent":null}' --yes --json
+```
+
+`--data` accepts inline JSON, `@path` for a UTF-8 file, or `@-` for stdin.
+Payload keys are camelCase and are supplied without a resource wrapper. The
+CLI validates the complete payload before making an API request.
 
 ## Commands
 
-| Command                                                                                             | What it returns                                   |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `hevy user`                                                                                         | Your Hevy user profile                            |
-| `hevy workouts list [--page N] [--page-size N]`                                                     | A page of workouts                                |
-| `hevy workouts get <workout-id>`                                                                    | One workout                                       |
-| `hevy workouts count`                                                                               | Your workout count                                |
-| `hevy workouts events --since <timestamp> [--page N] [--page-size N]`                               | Workout events since an ISO timestamp             |
-| `hevy routines list [--page N] [--page-size N]`                                                     | A page of routines                                |
-| `hevy routines get <routine-id>`                                                                    | One routine                                       |
-| `hevy exercises search <query> [--max-pages N]`                                                     | Exercise templates whose titles contain the query |
-| `hevy exercises get <exercise-template-id>`                                                         | One exercise template                             |
-| `hevy exercises history <exercise-template-id> [--start-date <timestamp>] [--end-date <timestamp>]` | History for one exercise                          |
-| `hevy measurements list [--page N] [--page-size N]`                                                 | A page of body measurements                       |
-| `hevy measurements get <YYYY-MM-DD>`                                                                | Body measurements for one date                    |
-| `hevy summary [--weeks N]`                                                                          | Workout totals for a recent period                |
+### Read
 
-Add `--json` to any command for machine-readable output.
+| Command                                                                                             | What it returns                       |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `hevy user`                                                                                         | Your Hevy user profile                |
+| `hevy workouts list [--page N] [--page-size N]`                                                     | A page of workouts                    |
+| `hevy workouts get <workout-id>`                                                                    | One workout                           |
+| `hevy workouts count`                                                                               | Your workout count                    |
+| `hevy workouts events --since <timestamp> [--page N] [--page-size N]`                               | Workout events since an ISO timestamp |
+| `hevy routines list [--page N] [--page-size N]`                                                     | A page of routines                    |
+| `hevy routines get <routine-id>`                                                                    | One routine                           |
+| `hevy exercises search <query> [--max-pages N]`                                                     | Exercise templates matching the query |
+| `hevy exercises get <exercise-template-id>`                                                         | One exercise template                 |
+| `hevy exercises history <exercise-template-id> [--start-date <timestamp>] [--end-date <timestamp>]` | History for one exercise              |
+| `hevy measurements list [--page N] [--page-size N]`                                                 | A page of body measurements           |
+| `hevy measurements get <YYYY-MM-DD>`                                                                | Measurements for one date             |
+| `hevy summary [--weeks N]`                                                                          | Workout totals for a recent period    |
 
-## Pagination and scans
+### Create and update
+
+| Command                                                      | Payload                                      |
+| ------------------------------------------------------------ | -------------------------------------------- |
+| `hevy workouts create --data <value> --yes`                  | Complete workout                             |
+| `hevy workouts update <workout-id> --data <value> --yes`     | Complete replacement workout                 |
+| `hevy routines create --data <value> --yes`                  | Complete routine, optionally with `folderId` |
+| `hevy routines update <routine-id> --data <value> --yes`     | Complete replacement routine                 |
+| `hevy exercises create --data <value> --yes`                 | Custom exercise template                     |
+| `hevy folders create --data <value> --yes`                   | Routine folder                               |
+| `hevy measurements create <YYYY-MM-DD> --data <value> --yes` | New body measurement                         |
+| `hevy measurements update <YYYY-MM-DD> --data <value> --yes` | Measurement patch                            |
+
+There is no delete command, update-template command, or update-folder command.
+
+## Payloads and safety
+
+Workout and routine updates are full replacements. Include every exercise and
+set that should remain; omitted content is not preserved. A workout update
+requires the same complete workout payload as creation. A routine update cannot
+move a routine between folders because Hevy's update endpoint does not accept
+`folderId`.
+
+Measurement updates are patches over Hevy's replacement PUT endpoint. The CLI
+reads the existing date first, preserves omitted fields, replaces supplied
+numbers, and treats explicit `null` as a clear operation. The date is always
+the positional `YYYY-MM-DD` argument and cannot appear in `--data`. Measurement
+creation needs at least one numeric field; update needs at least one supplied
+field.
+
+Writes are never retried automatically. Creates are not idempotent, and an
+uncertain network result can still have committed. Verify an uncertain write
+with a read before deciding whether to retry. A duplicate measurement date is
+reported by Hevy as HTTP 409. HTTP 403 is reported as a generic API failure
+because Hevy uses it for permissions and routine/custom-exercise quotas.
+
+## Pagination, output, and exit codes
 
 List commands default to page 1 with 5 results per page. `--page-size` accepts
-up to 10. Summary defaults to one week and accepts up to 520.
+up to 10. Summary defaults to one week and accepts up to 520. Exercise search
+checks up to 10 API pages, with 100 templates per page; `--max-pages` accepts
+up to 100.
 
-Exercise search checks up to 10 API pages, with 100 templates per page. Use
-`--max-pages N` to change the limit, up to 100. Search and summary results
-include `pagesScanned` and `complete` so scripts can tell whether a scan reached
-the end of the available data.
+Add `--json` to any command for machine-readable output. Successful commands
+write one JSON value followed by a newline to stdout. Errors write one
+sanitized line to stderr.
 
-## Output and exit codes
-
-Human-readable output is the default. With `--json`, successful commands write
-one JSON value followed by a newline to stdout. Errors write one sanitized line
-to stderr.
-
-| Exit code | Meaning                          |
-| --------- | -------------------------------- |
-| `0`       | Success                          |
-| `1`       | Missing or invalid configuration |
-| `2`       | Invalid command, flag, or value  |
-| `3`       | Hevy API failure                 |
-| `4`       | Network or timeout failure       |
+| Exit code | Meaning                                  |
+| --------- | ---------------------------------------- |
+| `0`       | Success                                  |
+| `1`       | Missing or invalid configuration         |
+| `2`       | Invalid command, flag, payload, or value |
+| `3`       | Hevy API failure                         |
+| `4`       | Network or timeout failure               |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
 		"test": "vitest run"
 	},
 	"devDependencies": {
+		"@hevy-mcp/core": "file:../core",
 		"@hevy-mcp/hevy-client": "file:../hevy-client",
 		"@stricli/core": "^1.3.0",
 		"zod": "^4.4.3"

--- a/packages/cli/src/arguments.test.ts
+++ b/packages/cli/src/arguments.test.ts
@@ -10,6 +10,7 @@ import {
 	parseWorkoutEventsOptions,
 	parseWorkoutId,
 	UsageError,
+	requireMutationConfirmation,
 	type CliArgs,
 } from "./arguments.js";
 
@@ -132,5 +133,17 @@ describe("CLI argument validation", () => {
 				() => parseWeeks(args({ weeks })),
 				"--weeks must be a positive integer no greater than 520",
 			);
+	});
+});
+
+describe("mutation confirmation", () => {
+	it("requires an explicit true --yes flag", () => {
+		expect(() =>
+			requireMutationConfirmation(args({ yes: true })),
+		).not.toThrow();
+		for (const yes of [undefined, false])
+			expect(() =>
+				requireMutationConfirmation(args(yes === undefined ? {} : { yes })),
+			).toThrow("Mutation requires --yes");
 	});
 });

--- a/packages/cli/src/arguments.ts
+++ b/packages/cli/src/arguments.ts
@@ -255,3 +255,8 @@ export function parseWeeks(args: CliArgs): number {
 		_: "must be a positive integer no greater than 520",
 	});
 }
+
+export function requireMutationConfirmation(args: CliArgs): void {
+	if (args.options.yes !== true)
+		throw new UsageError("Mutation requires --yes");
+}

--- a/packages/cli/src/commands/index.test.ts
+++ b/packages/cli/src/commands/index.test.ts
@@ -2,6 +2,7 @@
 import type { HevyClient } from "@hevy-mcp/hevy-client";
 import { describe, expect, it, vi } from "vitest";
 import type { CliArgs } from "../arguments.js";
+import { ApiResponseError } from "../errors.js";
 import { execute } from "./index.js";
 
 const args = (
@@ -165,4 +166,263 @@ describe("execute command/API mappings", () => {
 		);
 		expect(result).toMatchObject({ pagesScanned: 1, complete: true });
 	});
+
+	it("dispatches every create/update route with normalized envelopes", async () => {
+		const api = client();
+		const workout = {
+			title: "Push",
+			startTime: "2024-01-01T10:00:00Z",
+			endTime: "2024-01-01T11:00:00Z",
+			exercises: [
+				{
+					exerciseTemplateId: "exercise-1",
+					sets: [{ type: "normal", weightKg: 50, reps: 5 }],
+				},
+			],
+		};
+		const routine = {
+			title: "Strength",
+			exercises: [
+				{
+					exerciseTemplateId: "exercise-1",
+					sets: [{ type: "normal", reps: 5 }],
+				},
+			],
+		};
+		const options = (data: unknown): CliArgs["options"] => ({
+			data: JSON.stringify(data),
+			yes: true,
+		});
+
+		vi.mocked(api.createWorkout).mockResolvedValue({ id: "workout-1" });
+		vi.mocked(api.updateWorkout).mockResolvedValue({ id: "workout-1" });
+		vi.mocked(api.createRoutine).mockResolvedValue({ id: "routine-1" });
+		vi.mocked(api.updateRoutine).mockResolvedValue({ id: "routine-1" });
+		vi.mocked(api.createExerciseTemplate).mockResolvedValue({
+			id: 2,
+		});
+		vi.mocked(api.createRoutineFolder).mockResolvedValue({ id: 3 });
+		vi.mocked(api.createBodyMeasurement).mockResolvedValue({
+			date: "2024-01-02",
+			weight_kg: 80,
+		});
+		vi.mocked(api.updateBodyMeasurement).mockResolvedValue({
+			date: "2024-01-02",
+			weight_kg: 81,
+		});
+		vi.mocked(api.getBodyMeasurement).mockResolvedValue({
+			date: "2024-01-02",
+			weight_kg: 80,
+			fat_percent: 20,
+			neck_cm: 40,
+		});
+
+		expect(
+			await execute(args("workouts", "create", [], options(workout)), api),
+		).toEqual({ workout: { id: "workout-1" } });
+		expect(
+			await execute(
+				args("workouts", "update", ["workout-1"], options(workout)),
+				api,
+			),
+		).toEqual({ workoutId: "workout-1", workout: { id: "workout-1" } });
+		expect(
+			await execute(args("routines", "create", [], options(routine)), api),
+		).toEqual({
+			routine: { id: "routine-1" },
+			usesRepRanges: false,
+		});
+		expect(
+			await execute(
+				args("routines", "update", ["routine-1"], options(routine)),
+				api,
+			),
+		).toEqual({
+			routineId: "routine-1",
+			routine: { id: "routine-1" },
+			usesRepRanges: false,
+		});
+		expect(
+			await execute(
+				args(
+					"exercises",
+					"create",
+					[],
+					options({
+						title: "Cable Row",
+						exerciseType: "weight_reps",
+						equipmentCategory: "machine",
+						muscleGroup: "upper_back",
+					}),
+				),
+				api,
+			),
+		).toEqual({ exerciseTemplate: { id: 2 } });
+		expect(
+			await execute(
+				args("folders", "create", [], options({ name: "Strength" })),
+				api,
+			),
+		).toEqual({ folder: { id: 3 } });
+		expect(
+			await execute(
+				args(
+					"measurements",
+					"create",
+					["2024-01-02"],
+					options({ weightKg: 80 }),
+				),
+				api,
+			),
+		).toEqual({ measurement: { date: "2024-01-02", weightKg: 80 } });
+		expect(
+			await execute(
+				args(
+					"measurements",
+					"update",
+					["2024-01-02"],
+					options({ weightKg: 81, fatPercent: null }),
+				),
+				api,
+			),
+		).toEqual({
+			measurement: {
+				date: "2024-01-02",
+				weightKg: 81,
+				fatPercent: null,
+				neckCm: 40,
+			},
+		});
+
+		expect(api.createWorkout).toHaveBeenCalledWith({
+			workout: {
+				title: "Push",
+				description: null,
+				start_time: "2024-01-01T10:00:00Z",
+				end_time: "2024-01-01T11:00:00Z",
+				is_private: false,
+				exercises: [
+					{
+						exercise_template_id: "exercise-1",
+						superset_id: null,
+						notes: null,
+						sets: [
+							{
+								type: "normal",
+								weight_kg: 50,
+								reps: 5,
+								distance_meters: null,
+								duration_seconds: null,
+								rpe: null,
+								custom_metric: null,
+							},
+						],
+					},
+				],
+			},
+		});
+		expect(api.createRoutine).toHaveBeenCalledWith({
+			routine: {
+				title: "Strength",
+				folder_id: null,
+				notes: "",
+				exercises: [
+					{
+						exercise_template_id: "exercise-1",
+						superset_id: null,
+						rest_seconds: null,
+						notes: null,
+						sets: [
+							{
+								type: "normal",
+								weight_kg: null,
+								reps: 5,
+								distance_meters: null,
+								duration_seconds: null,
+								custom_metric: null,
+								rep_range: null,
+							},
+						],
+					},
+				],
+			},
+		});
+		expect(api.updateRoutine).toHaveBeenCalledWith("routine-1", {
+			routine: {
+				title: "Strength",
+				notes: null,
+				exercises: [
+					{
+						exercise_template_id: "exercise-1",
+						superset_id: null,
+						rest_seconds: null,
+						notes: null,
+						sets: [
+							{
+								type: "normal",
+								weight_kg: null,
+								reps: 5,
+								distance_meters: null,
+								duration_seconds: null,
+								custom_metric: null,
+							},
+						],
+					},
+				],
+			},
+		});
+		expect(api.createExerciseTemplate).toHaveBeenCalledWith({
+			exercise: {
+				title: "Cable Row",
+				exercise_type: "weight_reps",
+				equipment_category: "machine",
+				muscle_group: "upper_back",
+				other_muscles: [],
+			},
+		});
+		expect(api.createRoutineFolder).toHaveBeenCalledWith({
+			routine_folder: { title: "Strength" },
+		});
+		expect(api.createBodyMeasurement).toHaveBeenCalledWith({
+			date: "2024-01-02",
+			weight_kg: 80,
+		});
+		expect(api.getBodyMeasurement).toHaveBeenCalledWith("2024-01-02");
+		expect(api.updateBodyMeasurement).toHaveBeenCalledWith("2024-01-02", {
+			weight_kg: 81,
+			neck_cm: 40,
+		});
+		expect(vi.mocked(api.createWorkout)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.updateWorkout)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.createRoutine)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.updateRoutine)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.createExerciseTemplate)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.createRoutineFolder)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.createBodyMeasurement)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.updateBodyMeasurement)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(api.getBodyMeasurement)).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		{ response: { date: "2024-01-02", unexpected: true } },
+		{ response: { date: "2024-01-03", weight_kg: 80 } },
+	])(
+		"rejects invalid existing measurements without PUT",
+		async ({ response }) => {
+			const api = client();
+			vi.mocked(api.getBodyMeasurement).mockResolvedValue(response);
+			await expect(
+				execute(
+					args("measurements", "update", ["2024-01-02"], {
+						data: JSON.stringify({ weightKg: 81 }),
+						yes: true,
+					}),
+					api,
+				),
+			).rejects.toThrow(
+				new ApiResponseError("The API returned an invalid body measurement"),
+			);
+			expect(vi.mocked(api.updateBodyMeasurement)).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -4,6 +4,21 @@ import {
 	getV1RoutinesQueryParamsSchema,
 } from "@hevy-mcp/hevy-client/schemas";
 import {
+	bodyMeasurementFieldsInputSchema,
+	buildExerciseTemplateRequest,
+	buildMeasurementPayload,
+	buildRoutineFolderRequest,
+	buildRoutinePayload,
+	buildWorkoutPayload,
+	createRoutineInputSchema,
+	exerciseTemplateInputSchema,
+	existingBodyMeasurementSchema,
+	mergeMeasurementPayload,
+	routineFolderInputSchema,
+	updateRoutineInputSchema,
+	workoutInputSchema,
+} from "@hevy-mcp/core/mutations";
+import {
 	parseExerciseHistoryId,
 	parseExerciseHistoryOptions,
 	parseExerciseId,
@@ -15,10 +30,16 @@ import {
 	parseWeeks,
 	parseWorkoutEventsOptions,
 	parseWorkoutId,
+	requireMutationConfirmation,
 	UsageError,
 	type CliArgs,
 } from "../arguments.js";
 import { ApiResponseError } from "../errors.js";
+import {
+	loadMutationInput,
+	readDataSource as defaultDataSourceReader,
+	type DataSourceReader,
+} from "../input.js";
 import { normalize, pageEnvelope } from "../output/normalize.js";
 
 type Body = Record<string, unknown>;
@@ -50,11 +71,26 @@ function list(data: Body, source: string, output: string, page: number): Body {
 		Array.isArray(data[source]) ? data[source] : [],
 	);
 }
+const createBodyMeasurementDataSchema = bodyMeasurementFieldsInputSchema.refine(
+	(fields) => Object.values(fields).some((value) => typeof value === "number"),
+	"Include at least one numeric measurement field",
+);
+const updateBodyMeasurementDataSchema = bodyMeasurementFieldsInputSchema.refine(
+	(fields) => Object.keys(fields).length > 0,
+	"Include at least one measurement field",
+);
+
+function mutationData(args: CliArgs): string {
+	const value = args.options.data;
+	if (typeof value !== "string") throw new UsageError("--data is required");
+	return value;
+}
 
 export async function execute(
 	args: CliArgs,
 	client: HevyClient,
 	now = () => new Date(),
+	readDataSource: DataSourceReader = defaultDataSourceReader,
 ): Promise<unknown> {
 	const command = args.command;
 	const sub = args.subcommand;
@@ -75,6 +111,31 @@ export async function execute(
 			return {
 				workout: normalize(await client.getWorkout(workoutId)),
 			};
+		}
+		if (sub === "create") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				workoutInputSchema,
+				readDataSource,
+			);
+			const response = await client.createWorkout({
+				workout: buildWorkoutPayload(input),
+			});
+			return { workout: normalize(response) };
+		}
+		if (sub === "update") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				workoutInputSchema,
+				readDataSource,
+			);
+			const workoutId = parseWorkoutId(args.positionals[0]);
+			const response = await client.updateWorkout(workoutId, {
+				workout: buildWorkoutPayload(input),
+			});
+			return { workoutId, workout: normalize(response) };
 		}
 		if (sub === "count")
 			return { count: body(await client.getWorkoutCount()).workout_count ?? 0 };
@@ -110,8 +171,45 @@ export async function execute(
 				routine: normalize(await client.getRoutineById(routineId)),
 			};
 		}
+		if (sub === "create") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				createRoutineInputSchema,
+				readDataSource,
+			);
+			const { payload, usesRepRanges } = buildRoutinePayload(input, "create");
+			const response = await client.createRoutine({ routine: payload });
+			return { routine: normalize(response), usesRepRanges };
+		}
+		if (sub === "update") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				updateRoutineInputSchema,
+				readDataSource,
+			);
+			const routineId = parseRoutineId(args.positionals[0]);
+			const { payload, usesRepRanges } = buildRoutinePayload(input, "update");
+			const response = await client.updateRoutine(routineId, {
+				routine: payload,
+			});
+			return { routineId, routine: normalize(response), usesRepRanges };
+		}
 	}
 	if (command === "exercises") {
+		if (sub === "create") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				exerciseTemplateInputSchema,
+				readDataSource,
+			);
+			const response = await client.createExerciseTemplate(
+				buildExerciseTemplateRequest(input),
+			);
+			return { exerciseTemplate: normalize(response) };
+		}
 		if (sub === "get") {
 			const exerciseId = parseExerciseId(args.positionals[0]);
 			return {
@@ -186,6 +284,52 @@ export async function execute(
 			const date = parseMeasurementDate(args.positionals[0]);
 			return { measurement: normalize(await client.getBodyMeasurement(date)) };
 		}
+		if (sub === "create") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				createBodyMeasurementDataSchema,
+				readDataSource,
+			);
+			const date = parseMeasurementDate(args.positionals[0]);
+			const wireFields = buildMeasurementPayload(input);
+			await client.createBodyMeasurement({ date, ...wireFields });
+			return { measurement: normalize({ date, ...wireFields }) };
+		}
+		if (sub === "update") {
+			requireMutationConfirmation(args);
+			const input = await loadMutationInput(
+				mutationData(args),
+				updateBodyMeasurementDataSchema,
+				readDataSource,
+			);
+			const date = parseMeasurementDate(args.positionals[0]);
+			const parsed = existingBodyMeasurementSchema.safeParse(
+				await client.getBodyMeasurement(date),
+			);
+			if (!parsed.success || parsed.data.date !== date)
+				throw new ApiResponseError(
+					"The API returned an invalid body measurement",
+				);
+			const { payload, measurement } = mergeMeasurementPayload(
+				parsed.data,
+				input,
+			);
+			await client.updateBodyMeasurement(date, payload);
+			return { measurement: normalize(measurement) };
+		}
+	}
+	if (command === "folders" && sub === "create") {
+		requireMutationConfirmation(args);
+		const input = await loadMutationInput(
+			mutationData(args),
+			routineFolderInputSchema,
+			readDataSource,
+		);
+		const response = await client.createRoutineFolder(
+			buildRoutineFolderRequest(input),
+		);
+		return { folder: normalize(response) };
 	}
 	if (command === "summary") {
 		const weeks = parseWeeks(args);

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -14,7 +14,7 @@ export function diagnostic(error: unknown): { code: number; message: string } {
 			message: error.message.replace(/https?:\/\/\S+/gi, "[redacted]"),
 		};
 	if (error instanceof HevyHttpError || isHevyHttpError(error)) {
-		if (error.status === 401 || error.status === 403)
+		if (error.status === 401)
 			return {
 				code: EXIT.api,
 				message: "Authentication failed; check HEVY_API_KEY",

--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	loadMutationInput,
+	readDataSource,
+	type DataSourceReader,
+} from "./input.js";
+import { UsageError } from "./arguments.js";
+import {
+	createRoutineInputSchema,
+	routineFolderInputSchema,
+	workoutInputSchema,
+} from "@hevy-mcp/core/mutations";
+
+const workout = {
+	title: "Push",
+	startTime: "2024-01-01T10:00:00Z",
+	endTime: "2024-01-01T11:00:00Z",
+	exercises: [
+		{
+			exerciseTemplateId: "exercise-1",
+			sets: [{ type: "normal", weightKg: 50, reps: 5 }],
+		},
+	],
+};
+
+describe("mutation input sources", () => {
+	it("loads equivalent inline, file, and stdin JSON", async () => {
+		const inline = await loadMutationInput(
+			JSON.stringify(workout),
+			workoutInputSchema,
+		);
+		const directory = await mkdtemp(join(tmpdir(), "hevy-cli-"));
+		const path = join(directory, "workout.json");
+		try {
+			await writeFile(path, JSON.stringify(workout), "utf8");
+			const file = await loadMutationInput(
+				`@${path}`,
+				workoutInputSchema,
+				readDataSource,
+			);
+			const stdin = await loadMutationInput(
+				"@-",
+				workoutInputSchema,
+				async (source) => {
+					expect(source).toBe("-");
+					return JSON.stringify(workout);
+				},
+			);
+			expect(file).toEqual(inline);
+			expect(stdin).toEqual(inline);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("reports source, JSON, and schema failures as usage errors", async () => {
+		const reader: DataSourceReader = async () => {
+			throw new Error("missing");
+		};
+		await expect(
+			loadMutationInput("@", workoutInputSchema, reader),
+		).rejects.toThrow(new UsageError("--data source is required after @"));
+		await expect(
+			loadMutationInput("@missing", workoutInputSchema, reader),
+		).rejects.toThrow(new UsageError('Unable to read --data source "missing"'));
+		await expect(loadMutationInput("{", workoutInputSchema)).rejects.toThrow(
+			new UsageError("--data must contain valid JSON"),
+		);
+		await expect(
+			loadMutationInput(
+				JSON.stringify({ outer: { inner: 1 } }),
+				z.object({ outer: z.object({ inner: z.string() }).strict() }).strict(),
+			),
+		).rejects.toThrow(/--data\.outer\.inner/);
+	});
+
+	it.each([
+		["top-level", { ...workout, extra: true }],
+		[
+			"exercise",
+			{
+				...workout,
+				exercises: [{ ...workout.exercises[0], extra: true }],
+			},
+		],
+		[
+			"set",
+			{
+				...workout,
+				exercises: [
+					{ ...workout.exercises[0], sets: [{ type: "normal", extra: true }] },
+				],
+			},
+		],
+		[
+			"repRange",
+			{
+				title: "Routine",
+				exercises: [
+					{
+						exerciseTemplateId: "exercise-1",
+						sets: [{ type: "normal", repRange: { start: 5, extra: true } }],
+					},
+				],
+			},
+		],
+	] as const)("rejects unknown %s keys", async (name, value) => {
+		if (name === "repRange") {
+			await expect(
+				loadMutationInput(JSON.stringify(value), createRoutineInputSchema),
+			).rejects.toThrow(/--data.*extra/);
+			return;
+		}
+		await expect(
+			loadMutationInput(JSON.stringify(value), workoutInputSchema),
+		).rejects.toThrow(/--data.*extra/);
+	});
+
+	it("uses strict simple-resource schemas", async () => {
+		await expect(
+			loadMutationInput(
+				JSON.stringify({ name: "Strength", extra: true }),
+				routineFolderInputSchema,
+			),
+		).rejects.toThrow(/--data.*extra/);
+	});
+});

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+import { UsageError } from "./arguments.js";
+
+export type DataSourceReader = (source: string) => Promise<string>;
+
+async function readStdin(): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+export const readDataSource: DataSourceReader = (source) =>
+	source === "-" ? readStdin() : readFile(source, "utf8");
+
+function schemaDiagnostic(error: z.ZodError): string {
+	const issue = error.issues[0];
+	const path = issue?.path.join(".");
+	return path
+		? `--data.${path} ${issue.message}`
+		: `--data ${issue?.message ?? "is invalid"}`;
+}
+
+export async function loadMutationInput<T>(
+	value: string,
+	schema: z.ZodType<T>,
+	reader: DataSourceReader = readDataSource,
+): Promise<T> {
+	let sourceValue = value;
+	if (value.startsWith("@")) {
+		const source = value.slice(1);
+		if (source.length === 0)
+			throw new UsageError("--data source is required after @");
+		try {
+			sourceValue = await reader(source);
+		} catch {
+			throw new UsageError(`Unable to read --data source "${source}"`);
+		}
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(sourceValue);
+	} catch {
+		throw new UsageError("--data must contain valid JSON");
+	}
+
+	try {
+		return schema.parse(parsed);
+	} catch (error) {
+		if (error instanceof z.ZodError)
+			throw new UsageError(schemaDiagnostic(error));
+		throw error;
+	}
+}

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -1,4 +1,5 @@
-import type { HevyClient } from "@hevy-mcp/hevy-client";
+/* oxlint-disable typescript/unbound-method */
+import { HevyHttpError, type HevyClient } from "@hevy-mcp/hevy-client";
 import { describe, expect, it, vi } from "vitest";
 import { runCli } from "./main.js";
 
@@ -101,5 +102,176 @@ describe("CLI process contract", () => {
 		expect(code).toBe(0);
 		expect(getWorkouts).toHaveBeenCalledWith({ page: 2, pageSize: 10 });
 		expect(io.err).toBe("");
+	});
+});
+
+function mutationClient(): HevyClient {
+	const client = Object.create(null) as HevyClient;
+	client.createWorkout = vi.fn().mockResolvedValue({ id: "workout-1" });
+	client.updateWorkout = vi.fn().mockResolvedValue({ id: "workout-1" });
+	client.createRoutine = vi.fn().mockResolvedValue({ id: "routine-1" });
+	client.updateRoutine = vi.fn().mockResolvedValue({ id: "routine-1" });
+	client.createExerciseTemplate = vi.fn().mockResolvedValue({ id: 2 });
+	client.createRoutineFolder = vi.fn().mockResolvedValue({ id: 3 });
+	client.createBodyMeasurement = vi.fn().mockResolvedValue({
+		date: "2024-01-02",
+		weight_kg: 80,
+	});
+	client.getBodyMeasurement = vi.fn().mockResolvedValue({
+		date: "2024-01-02",
+		weight_kg: 80,
+	});
+	client.updateBodyMeasurement = vi.fn().mockResolvedValue({
+		date: "2024-01-02",
+		weight_kg: 81,
+	});
+	return client;
+}
+
+describe("CLI mutation process contract", () => {
+	it("requires --yes before reading data or invoking a mutation", async () => {
+		for (const confirmation of [undefined, "--noYes"]) {
+			const io = streams();
+			const readDataSource = vi.fn().mockResolvedValue("{}");
+			const clientFactory = vi.fn(() => mutationClient());
+			const argv = [
+				"folders",
+				"create",
+				"--data",
+				'{"name":"Strength"}',
+				...(confirmation ? [confirmation] : []),
+			];
+			const code = await runCli({
+				argv,
+				env: { HEVY_API_KEY: "key" },
+				clientFactory,
+				readDataSource,
+				streams: io.streams,
+			});
+			expect(code).toBe(2);
+			expect(io.out).toBe("");
+			expect(io.err).toBe("Mutation requires --yes\n");
+			expect(readDataSource).not.toHaveBeenCalled();
+		}
+	});
+
+	it("routes all eight mutations through runCli", async () => {
+		const workout = {
+			title: "Push",
+			startTime: "2024-01-01T10:00:00Z",
+			endTime: "2024-01-01T11:00:00Z",
+			exercises: [],
+		};
+		const routine = { title: "Strength", exercises: [] };
+		const json = (value: unknown) => JSON.stringify(value);
+		const commands = [
+			["workouts", "create", "--data", json(workout), "--yes", "--json"],
+			[
+				"workouts",
+				"update",
+				"workout-1",
+				"--data",
+				json(workout),
+				"--yes",
+				"--json",
+			],
+			["routines", "create", "--data", json(routine), "--yes", "--json"],
+			[
+				"routines",
+				"update",
+				"routine-1",
+				"--data",
+				json(routine),
+				"--yes",
+				"--json",
+			],
+			[
+				"exercises",
+				"create",
+				"--data",
+				json({
+					title: "Cable Row",
+					exerciseType: "weight_reps",
+					equipmentCategory: "machine",
+					muscleGroup: "upper_back",
+				}),
+				"--yes",
+				"--json",
+			],
+			[
+				"folders",
+				"create",
+				"--data",
+				json({ name: "Strength" }),
+				"--yes",
+				"--json",
+			],
+			[
+				"measurements",
+				"create",
+				"2024-01-02",
+				"--data",
+				json({ weightKg: 80 }),
+				"--yes",
+				"--json",
+			],
+			[
+				"measurements",
+				"update",
+				"2024-01-02",
+				"--data",
+				json({ weightKg: 81 }),
+				"--yes",
+				"--json",
+			],
+		] as const;
+		const output: string[] = [];
+		const client = mutationClient();
+		for (const argv of commands) {
+			const io = streams();
+			const code = await runCli({
+				argv: [...argv],
+				env: { HEVY_API_KEY: "key" },
+				clientFactory: () => client,
+				streams: io.streams,
+			});
+			expect(code).toBe(0);
+			expect(io.err).toBe("");
+			output.push(io.out);
+		}
+		expect(output).toHaveLength(8);
+		expect(output.every((value) => value.endsWith("\n"))).toBe(true);
+		expect(client.createWorkout).toHaveBeenCalledTimes(1);
+		expect(client.updateWorkout).toHaveBeenCalledTimes(1);
+		expect(client.createRoutine).toHaveBeenCalledTimes(1);
+		expect(client.updateRoutine).toHaveBeenCalledTimes(1);
+		expect(client.createExerciseTemplate).toHaveBeenCalledTimes(1);
+		expect(client.createRoutineFolder).toHaveBeenCalledTimes(1);
+		expect(client.createBodyMeasurement).toHaveBeenCalledTimes(1);
+		expect(client.getBodyMeasurement).toHaveBeenCalledTimes(1);
+		expect(client.updateBodyMeasurement).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		[401, "Authentication failed; check HEVY_API_KEY"],
+		[403, "Hevy API request failed (HTTP 403)"],
+	] as const)("uses safe HTTP diagnostics for %s", async (status, message) => {
+		const io = streams();
+		const getWorkouts = vi.fn().mockRejectedValue(
+			new HevyHttpError("request failed", {
+				status,
+				method: "GET",
+				endpoint: "/v1/workouts",
+			}),
+		);
+		const code = await runCli({
+			argv: ["workouts", "list"],
+			env: { HEVY_API_KEY: "key" },
+			clientFactory: () => mockClient(getWorkouts),
+			streams: io.streams,
+		});
+		expect(code).toBe(3);
+		expect(io.out).toBe("");
+		expect(io.err).toBe(`${message}\n`);
 	});
 });

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,14 +1,15 @@
 import { createHevyClient, type HevyClient } from "@hevy-mcp/hevy-client";
 import { getApiKey } from "./auth.js";
 import { diagnostic, EXIT } from "./errors.js";
+import { readDataSource, type DataSourceReader } from "./input.js";
 import { runRoutes } from "./routes.js";
 import { writeResult, type Streams } from "./output/write.js";
-
 export interface RunCliOptions {
 	argv: string[];
 	env?: Record<string, string | undefined>;
 	clientFactory?: (key: string) => HevyClient;
 	now?: () => Date;
+	readDataSource?: DataSourceReader;
 	streams?: Streams;
 }
 
@@ -27,6 +28,7 @@ export async function runCli(options: RunCliOptions): Promise<number> {
 		process: stricliProcess,
 		state,
 		now: options.now ?? (() => new Date()),
+		readDataSource: options.readDataSource ?? readDataSource,
 		client: undefined as HevyClient | undefined,
 	};
 	const metaCommand = options.argv.some((value) =>

--- a/packages/cli/src/routes.ts
+++ b/packages/cli/src/routes.ts
@@ -13,6 +13,7 @@ import {
 import type { HevyClient } from "@hevy-mcp/hevy-client";
 import { execute } from "./commands/index.js";
 import type { CliArgs } from "./arguments.js";
+import type { DataSourceReader } from "./input.js";
 
 declare const __HEVY_CLI_VERSION__: string;
 const cliVersion =
@@ -22,6 +23,7 @@ export interface CliRuntimeContext extends CommandContext {
 	readonly process: StricliProcess;
 	client?: HevyClient;
 	now: () => Date;
+	readDataSource: DataSourceReader;
 	state: {
 		result?: unknown;
 		error?: unknown;
@@ -35,12 +37,20 @@ type PageFlags = JsonFlags & { page?: string; "page-size"?: string };
 type EventFlags = PageFlags & { since?: string };
 type HistoryFlags = JsonFlags & { "start-date"?: string; "end-date"?: string };
 type SummaryFlags = JsonFlags & { weeks?: string };
+type MutationFlags = JsonFlags & { data: string; yes?: boolean };
 
 const flag = (brief: string) => ({
 	brief,
 	kind: "parsed" as const,
 	parse: String,
 	optional: true as const,
+});
+
+const requiredFlag = (brief: string) => ({
+	brief,
+	kind: "parsed" as const,
+	parse: String,
+	optional: false as const,
 });
 const booleanFlag = (brief: string) => ({
 	brief,
@@ -49,6 +59,11 @@ const booleanFlag = (brief: string) => ({
 });
 
 const jsonFlag = { json: booleanFlag("Print machine-readable JSON") };
+const mutationFlags = {
+	...jsonFlag,
+	data: requiredFlag("JSON mutation data, inline or @path or @-"),
+	yes: booleanFlag("Confirm this mutation"),
+};
 const searchFlags = {
 	...jsonFlag,
 	"max-pages": flag("Maximum API pages to scan (default: 10)"),
@@ -101,6 +116,7 @@ async function invoke(
 			toArgs(command, subcommand, flags, positionals),
 			context.client,
 			context.now,
+			context.readDataSource,
 		);
 	} catch (error) {
 		context.state.error = error;
@@ -127,6 +143,7 @@ function idCommand<FLAGS extends object>(
 	subcommand: string,
 	brief: string,
 	flags: FlagParametersForType<FLAGS, CliRuntimeContext>,
+	positionalBrief = "Resource identifier",
 ): Command<CliRuntimeContext> {
 	return buildCommand<FLAGS, [string], CliRuntimeContext>({
 		func: function (this: CliRuntimeContext, values: FLAGS, id: string) {
@@ -136,7 +153,7 @@ function idCommand<FLAGS extends object>(
 			flags,
 			positional: {
 				kind: "tuple",
-				parameters: [{ brief: "Resource identifier", parse: String }],
+				parameters: [{ brief: positionalBrief, parse: String }],
 			},
 		},
 		docs: { brief },
@@ -150,6 +167,18 @@ const workouts = buildRouteMap({
 			"list",
 			"List workouts",
 			pageFlags,
+		),
+		create: noArgsCommand<MutationFlags>(
+			"workouts",
+			"create",
+			"Create a workout",
+			mutationFlags,
+		),
+		update: idCommand<MutationFlags>(
+			"workouts",
+			"update",
+			"Replace a workout",
+			mutationFlags,
 		),
 		get: idCommand<JsonFlags>("workouts", "get", "Get a workout", jsonFlag),
 		count: noArgsCommand<JsonFlags>(
@@ -176,6 +205,18 @@ const routines = buildRouteMap({
 			"List routines",
 			pageFlags,
 		),
+		create: noArgsCommand<MutationFlags>(
+			"routines",
+			"create",
+			"Create a routine",
+			mutationFlags,
+		),
+		update: idCommand<MutationFlags>(
+			"routines",
+			"update",
+			"Replace a routine",
+			mutationFlags,
+		),
 		get: idCommand<JsonFlags>("routines", "get", "Get a routine", jsonFlag),
 	},
 	docs: { brief: "Read routine data" },
@@ -183,6 +224,12 @@ const routines = buildRouteMap({
 
 const exercises = buildRouteMap({
 	routes: {
+		create: noArgsCommand<MutationFlags>(
+			"exercises",
+			"create",
+			"Create an exercise template",
+			mutationFlags,
+		),
 		search: idCommand<SearchFlags>(
 			"exercises",
 			"search",
@@ -219,8 +266,34 @@ const measurements = buildRouteMap({
 			"Get a body measurement",
 			jsonFlag,
 		),
+		create: idCommand<MutationFlags>(
+			"measurements",
+			"create",
+			"Create a body measurement",
+			mutationFlags,
+			"Measurement date (YYYY-MM-DD)",
+		),
+		update: idCommand<MutationFlags>(
+			"measurements",
+			"update",
+			"Update a body measurement",
+			mutationFlags,
+			"Measurement date (YYYY-MM-DD)",
+		),
 	},
 	docs: { brief: "Read body measurements" },
+});
+
+const folders = buildRouteMap({
+	routes: {
+		create: noArgsCommand<MutationFlags>(
+			"folders",
+			"create",
+			"Create a routine folder",
+			mutationFlags,
+		),
+	},
+	docs: { brief: "Create routine folders" },
 });
 
 const root = buildRouteMap({
@@ -235,6 +308,7 @@ const root = buildRouteMap({
 		routines,
 		exercises,
 		measurements,
+		folders,
 		summary: noArgsCommand<SummaryFlags>(
 			"summary",
 			undefined,
@@ -243,7 +317,7 @@ const root = buildRouteMap({
 		),
 	},
 	docs: {
-		brief: "Run read-only commands against the Hevy API",
+		brief: "Run read, create, and update Hevy data commands",
 	},
 });
 

--- a/packages/cli/tests/npm-pack-smoke.mjs
+++ b/packages/cli/tests/npm-pack-smoke.mjs
@@ -1,7 +1,17 @@
-import { access, mkdtemp, mkdir, readdir, rename, rm } from "node:fs/promises";
+import {
+	access,
+	mkdtemp,
+	mkdir,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawn } from "node:child_process";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -12,6 +22,24 @@ const dir = await mkdtemp(join(tmpdir(), "hevy-cli-pack-"));
 const backupDir = await mkdtemp(join(tmpdir(), "hevy-cli-dist-"));
 const backupDist = join(backupDir, "dist");
 let hadDist = false;
+
+function runWithInput(command, args, options, input) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			...options,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => (stdout += chunk));
+		child.stderr.on("data", (chunk) => (stderr += chunk));
+		child.on("error", reject);
+		child.on("close", (code) => resolve({ code, stdout, stderr }));
+		child.stdin.end(input);
+	});
+}
 
 try {
 	try {
@@ -57,13 +85,139 @@ try {
 		],
 		{ cwd: repositoryRoot },
 	);
-	const version = await exec(
-		join(consumer, "node_modules/.bin/hevy"),
-		["--version"],
-		{ env: { ...process.env, HEVY_API_KEY: "" } },
+	const binary = join(consumer, "node_modules/.bin/hevy");
+	const key = "00000000-0000-0000-0000-000000000000";
+	const fakeFetch = join(dir, "fake-fetch.mjs");
+	const requestLog = join(dir, "requests.jsonl");
+	await writeFile(
+		fakeFetch,
+		`import { appendFile } from "node:fs/promises";
+const log = process.env.HEVY_SMOKE_LOG;
+globalThis.fetch = async (input, init = {}) => {
+	const headers = Object.fromEntries(new Headers(init.headers).entries());
+	const request = {
+		method: init.method ?? "GET",
+		url: String(input),
+		headers,
+		body: typeof init.body === "string" ? init.body : "",
+	};
+	await appendFile(log, JSON.stringify(request) + "\\n");
+	const pathname = new URL(request.url).pathname;
+	const response =
+		request.method === "POST" && pathname === "/v1/routine_folders"
+			? { status: 201, body: { id: 3 } }
+			: request.method === "PUT" && pathname === "/v1/workouts/workout-1"
+				? { status: 200, body: { id: "workout-1" } }
+				: { status: 404, body: { error: "unexpected request" } };
+	return new Response(JSON.stringify(response.body), {
+		status: response.status,
+		headers: { "content-type": "application/json" },
+	});
+};
+`,
+		"utf8",
 	);
+	const env = {
+		...process.env,
+		HEVY_API_KEY: key,
+		HEVY_SMOKE_LOG: requestLog,
+		NODE_OPTIONS: `--import=${fakeFetch}`,
+	};
+	const version = await exec(binary, ["--version"], { env });
 	if (version.stdout !== `${manifest.version}\n` || version.stderr !== "")
 		throw new Error("Packed CLI executable did not report its version");
+
+	const help = await exec(binary, ["--help"], { env });
+	if (
+		help.stderr !== "" ||
+		!help.stdout.includes("workouts list|create|update") ||
+		!help.stdout.includes("routines list|create|update") ||
+		!help.stdout.includes("exercises create") ||
+		!help.stdout.includes("measurements list|get|create|update") ||
+		!help.stdout.includes("folders create") ||
+		help.stdout.toLowerCase().includes("delete")
+	)
+		throw new Error("Packed CLI help mutation matrix is incorrect");
+
+	const folder = await exec(
+		binary,
+		["folders", "create", "--data", '{"name":"Strength"}', "--yes", "--json"],
+		{ env },
+	);
+	if (folder.stderr !== "") throw new Error("Packed folder create failed");
+	if (JSON.parse(folder.stdout).folder.id !== 3)
+		throw new Error("Packed folder response was not normalized");
+
+	const workout = {
+		title: "Push",
+		startTime: "2024-01-01T10:00:00Z",
+		endTime: "2024-01-01T11:00:00Z",
+		exercises: [
+			{
+				exerciseTemplateId: "exercise-1",
+				sets: [{ type: "normal", weightKg: 50, reps: 5 }],
+			},
+		],
+	};
+	const update = await runWithInput(
+		binary,
+		["workouts", "update", "workout-1", "--data", "@-", "--yes", "--json"],
+		{ env },
+		JSON.stringify(workout),
+	);
+	if (update.code !== 0 || update.stderr !== "")
+		throw new Error("Packed workout update failed");
+	if (JSON.parse(update.stdout).workoutId !== "workout-1")
+		throw new Error("Packed workout response was not normalized");
+
+	const requests = (await readFile(requestLog, "utf8"))
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line));
+	if (requests.length !== 2) throw new Error("Unexpected packed request count");
+	const [folderRequest, workoutRequest] = requests;
+	if (
+		folderRequest.method !== "POST" ||
+		new URL(folderRequest.url).pathname !== "/v1/routine_folders" ||
+		folderRequest.headers["api-key"] !== key ||
+		JSON.stringify(JSON.parse(folderRequest.body)) !==
+			JSON.stringify({ routine_folder: { title: "Strength" } })
+	)
+		throw new Error("Packed folder request contract is incorrect");
+	if (
+		workoutRequest.method !== "PUT" ||
+		new URL(workoutRequest.url).pathname !== "/v1/workouts/workout-1" ||
+		workoutRequest.headers["api-key"] !== key ||
+		JSON.stringify(JSON.parse(workoutRequest.body)) !==
+			JSON.stringify({
+				workout: {
+					title: "Push",
+					description: null,
+					start_time: "2024-01-01T10:00:00Z",
+					end_time: "2024-01-01T11:00:00Z",
+					is_private: false,
+					exercises: [
+						{
+							exercise_template_id: "exercise-1",
+							superset_id: null,
+							notes: null,
+							sets: [
+								{
+									type: "normal",
+									weight_kg: 50,
+									reps: 5,
+									distance_meters: null,
+									duration_seconds: null,
+									rpe: null,
+									custom_metric: null,
+								},
+							],
+						},
+					],
+				},
+			})
+	)
+		throw new Error("Packed workout request contract is incorrect");
 } finally {
 	await rm(packageDist, { recursive: true, force: true });
 	if (hadDist) await rename(backupDist, packageDist);

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -14,7 +14,12 @@ export default defineConfig({
 	clean: true,
 	outDir: "dist",
 	deps: {
-		alwaysBundle: ["@hevy-mcp/hevy-client", "@stricli/core", "zod"],
+		alwaysBundle: [
+			"@hevy-mcp/hevy-client",
+			"@hevy-mcp/core",
+			"@stricli/core",
+			"zod",
+		],
 		onlyBundle: false,
 	},
 	define: { __HEVY_CLI_VERSION__: JSON.stringify(version) },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
 		".": {
 			"types": "./src/index.ts",
 			"import": "./src/index.ts"
+		},
+		"./mutations": {
+			"types": "./src/mutations.ts",
+			"import": "./src/mutations.ts"
 		}
 	},
 	"scripts": {

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -1,0 +1,104 @@
+import { bodyMeasurementSchema } from "@hevy-mcp/hevy-client/schemas";
+import { z } from "zod";
+import {
+	bodyMeasurementFieldsSchema,
+	exerciseTemplateInputShape,
+	routineFolderInputShape,
+	routinePayloadShape,
+	routineExerciseShape,
+	routineSetShape,
+	workoutExerciseShape,
+	workoutPayloadShape,
+	workoutSetShape,
+} from "./tools/input-schemas.js";
+import {
+	buildExerciseTemplateRequest,
+	buildMeasurementPayload,
+	buildRoutineFolderRequest,
+	buildRoutinePayload,
+	buildWorkoutPayload,
+	mergeMeasurementPayload,
+} from "./tools/payload-mappers.js";
+import { parseJsonArray } from "./utils/json-parser.js";
+import { zStrictOptionalRepRange } from "./utils/schemas.js";
+
+const strictWorkoutSetSchema = z.object(workoutSetShape).strict();
+const strictWorkoutExerciseSchema = z
+	.object({
+		...workoutExerciseShape,
+		sets: z.array(strictWorkoutSetSchema),
+	})
+	.strict();
+const strictWorkoutExercisesSchema = z.preprocess(
+	parseJsonArray,
+	z.array(strictWorkoutExerciseSchema),
+);
+
+export const workoutInputSchema = z
+	.object({
+		...workoutPayloadShape,
+		exercises: strictWorkoutExercisesSchema,
+	})
+	.strict();
+
+const strictRoutineSetSchema = z
+	.object({
+		...routineSetShape,
+		repRange: zStrictOptionalRepRange,
+	})
+	.strict();
+const strictRoutineExerciseSchema = z
+	.object({
+		...routineExerciseShape,
+		sets: z.array(strictRoutineSetSchema),
+	})
+	.strict();
+const strictRoutineExercisesSchema = z.preprocess(
+	parseJsonArray,
+	z.array(strictRoutineExerciseSchema),
+);
+
+export const createRoutineInputSchema = z
+	.object({
+		...routinePayloadShape,
+		exercises: strictRoutineExercisesSchema,
+	})
+	.strict();
+
+export const updateRoutineInputSchema = z
+	.object({
+		title: routinePayloadShape.title,
+		notes: routinePayloadShape.notes,
+		exercises: strictRoutineExercisesSchema,
+	})
+	.strict();
+
+export const exerciseTemplateInputSchema = z
+	.object(exerciseTemplateInputShape)
+	.strict();
+
+export const routineFolderInputSchema = z
+	.object(routineFolderInputShape)
+	.strict();
+
+export const bodyMeasurementFieldsInputSchema = z
+	.object(bodyMeasurementFieldsSchema)
+	.strict();
+
+export const existingBodyMeasurementSchema = bodyMeasurementSchema.strict();
+
+export {
+	buildExerciseTemplateRequest,
+	buildMeasurementPayload,
+	buildRoutineFolderRequest,
+	buildRoutinePayload,
+	buildWorkoutPayload,
+	mergeMeasurementPayload,
+};
+export type {
+	ExerciseTemplateInput,
+	MeasurementFields,
+	RoutineFolderInput,
+	RoutinePayloadInput,
+	WorkoutPayloadInput,
+} from "./tools/input-schemas.js";

--- a/packages/core/src/tools/folders.ts
+++ b/packages/core/src/tools/folders.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 // Import types from generated client
 import type {
 	GetV1RoutineFolders200,
@@ -20,7 +19,12 @@ import {
 } from "../utils/tool-annotations.js";
 import { describeTool } from "../utils/tool-descriptions.js";
 import type { InferToolParams } from "../utils/tool-helpers.js";
-import { nonEmptyId, paginationShape } from "./input-schemas.js";
+import {
+	nonEmptyId,
+	paginationShape,
+	routineFolderInputShape,
+} from "./input-schemas.js";
+import { buildRoutineFolderRequest } from "./payload-mappers.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
@@ -35,9 +39,7 @@ type GetRoutineFoldersParams = InferToolParams<typeof getRoutineFoldersSchema>;
 const getRoutineFolderSchema = { folderId: nonEmptyId } as const;
 type GetRoutineFolderParams = InferToolParams<typeof getRoutineFolderSchema>;
 
-const createRoutineFolderSchema = {
-	name: z.string().min(1),
-} as const;
+const createRoutineFolderSchema = routineFolderInputShape;
 type CreateRoutineFolderParams = InferToolParams<
 	typeof createRoutineFolderSchema
 >;
@@ -156,12 +158,9 @@ const createRoutineFolderDefinition = {
 		runtime: ToolRuntime,
 		args: CreateRoutineFolderParams,
 	): Promise<PostV1RoutineFolders201 | null | undefined> => {
-		const { name } = args;
-		return runtime.getClient().createRoutineFolder({
-			routine_folder: {
-				title: name,
-			},
-		});
+		return runtime
+			.getClient()
+			.createRoutineFolder(buildRoutineFolderRequest(args));
 	},
 } satisfies ToolDefinition<
 	typeof createRoutineFolderSchema,

--- a/packages/core/src/tools/input-schemas.ts
+++ b/packages/core/src/tools/input-schemas.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 import type { BodyMeasurement } from "@hevy-mcp/hevy-client/types";
 import { parseJsonArray } from "../utils/json-parser.js";
 import {
+	equipmentCategoryEnum,
+	exerciseTypeEnum,
+	muscleGroupEnum,
 	setTypeEnum,
 	utcSecondTimestamp,
 	zNullableInt,
@@ -34,6 +37,17 @@ export function paginationShape({
 }
 
 export const nonEmptyId = z.string().min(1);
+export const exerciseTemplateInputShape = {
+	title: z.string().min(1),
+	exerciseType: exerciseTypeEnum,
+	equipmentCategory: equipmentCategoryEnum,
+	muscleGroup: muscleGroupEnum,
+	otherMuscles: z.array(muscleGroupEnum).default([]),
+} as const;
+
+export const routineFolderInputShape = {
+	name: z.string().min(1),
+} as const;
 
 const CALENDAR_DATE_MESSAGE = "Date must be in YYYY-MM-DD format";
 export const calendarDate = z
@@ -182,4 +196,10 @@ export type RoutinePayloadInput = z.infer<
 >;
 export type MeasurementFields = z.infer<
 	z.ZodObject<typeof bodyMeasurementFieldsSchema>
+>;
+export type ExerciseTemplateInput = z.infer<
+	z.ZodObject<typeof exerciseTemplateInputShape>
+>;
+export type RoutineFolderInput = z.infer<
+	z.ZodObject<typeof routineFolderInputShape>
 >;

--- a/packages/core/src/tools/payload-mappers.test.ts
+++ b/packages/core/src/tools/payload-mappers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildExerciseTemplateRequest,
 	buildMeasurementPayload,
+	buildRoutineFolderRequest,
 	buildRoutinePayload,
 	buildWorkoutPayload,
+	mergeMeasurementPayload,
 } from "./payload-mappers.js";
 import type {
 	RoutinePayloadInput,
@@ -301,5 +304,48 @@ describe("payload mappers", () => {
 				fatPercent: undefined,
 			}),
 		).toEqual({ weight_kg: 80 });
+	});
+
+	it("builds simple-resource requests and merges measurement changes", () => {
+		expect(
+			buildExerciseTemplateRequest({
+				title: "Cable Row",
+				exerciseType: "weight_reps",
+				equipmentCategory: "machine",
+				muscleGroup: "upper_back",
+				otherMuscles: [],
+			}),
+		).toEqual({
+			exercise: {
+				title: "Cable Row",
+				exercise_type: "weight_reps",
+				equipment_category: "machine",
+				muscle_group: "upper_back",
+				other_muscles: [],
+			},
+		});
+		expect(buildRoutineFolderRequest({ name: "Strength" })).toEqual({
+			routine_folder: { title: "Strength" },
+		});
+
+		expect(
+			mergeMeasurementPayload(
+				{
+					date: "2024-01-02",
+					weight_kg: 80,
+					fat_percent: 20,
+					neck_cm: 40,
+				},
+				{ weightKg: 81, fatPercent: null },
+			),
+		).toEqual({
+			payload: { weight_kg: 81, neck_cm: 40 },
+			measurement: {
+				date: "2024-01-02",
+				weight_kg: 81,
+				fat_percent: null,
+				neck_cm: 40,
+			},
+		});
 	});
 });

--- a/packages/core/src/tools/payload-mappers.ts
+++ b/packages/core/src/tools/payload-mappers.ts
@@ -1,3 +1,4 @@
+import type { HevyClient } from "@hevy-mcp/hevy-client";
 import type {
 	BodyMeasurement,
 	PostRoutinesRequestBody,
@@ -12,7 +13,9 @@ import type {
 } from "@hevy-mcp/hevy-client/types";
 import {
 	measurementFieldToApiKey,
+	type ExerciseTemplateInput,
 	type MeasurementFields,
+	type RoutineFolderInput,
 	type RoutinePayloadInput,
 	type WorkoutPayloadInput,
 } from "./input-schemas.js";
@@ -198,4 +201,51 @@ export function buildMeasurementPayload(
 		}
 	}
 	return payload;
+}
+export function buildExerciseTemplateRequest(
+	input: ExerciseTemplateInput,
+): Parameters<HevyClient["createExerciseTemplate"]>[0] {
+	return {
+		exercise: {
+			title: input.title,
+			exercise_type: input.exerciseType,
+			equipment_category: input.equipmentCategory,
+			muscle_group: input.muscleGroup,
+			other_muscles: input.otherMuscles,
+		},
+	};
+}
+
+export function buildRoutineFolderRequest(
+	input: RoutineFolderInput,
+): Parameters<HevyClient["createRoutineFolder"]>[0] {
+	return {
+		routine_folder: {
+			title: input.name,
+		},
+	};
+}
+
+export function mergeMeasurementPayload(
+	existing: BodyMeasurement,
+	changes: MeasurementFields,
+): { payload: MeasurementPayload; measurement: BodyMeasurement } {
+	const payload: MeasurementPayload = {};
+	const measurement = { ...existing };
+
+	for (const [camelKey, apiKey] of Object.entries(measurementFieldToApiKey) as [
+		keyof MeasurementFields,
+		keyof MeasurementPayload,
+	][]) {
+		const changed = changes[camelKey];
+		if (changed !== undefined) {
+			measurement[apiKey] = changed;
+			if (changed !== null) payload[apiKey] = changed;
+			continue;
+		}
+		const existingValue = existing[apiKey];
+		if (existingValue != null) payload[apiKey] = existingValue;
+	}
+
+	return { payload, measurement };
 }

--- a/packages/core/src/tools/templates.ts
+++ b/packages/core/src/tools/templates.ts
@@ -4,7 +4,6 @@ import type {
 	GetV1ExerciseHistoryExercisetemplateid200,
 	GetV1ExerciseTemplates200,
 	GetV1ExerciseTemplatesExercisetemplateid200,
-	PostV1ExerciseTemplates200,
 } from "@hevy-mcp/hevy-client/types";
 import type { ToolRuntime } from "./tool-runtime.js";
 import {
@@ -21,12 +20,13 @@ import {
 } from "../utils/tool-annotations.js";
 import { describeTool } from "../utils/tool-descriptions.js";
 import { type InferToolParams } from "../utils/tool-helpers.js";
-import { nonEmptyId, paginationShape } from "./input-schemas.js";
 import {
-	equipmentCategoryEnum,
-	exerciseTypeEnum,
-	muscleGroupEnum,
-} from "../utils/schemas.js";
+	exerciseTemplateInputShape,
+	nonEmptyId,
+	paginationShape,
+} from "./input-schemas.js";
+import { buildExerciseTemplateRequest } from "./payload-mappers.js";
+import { muscleGroupEnum } from "../utils/schemas.js";
 import {
 	isExpectedListPageNotFound,
 	isExpectedReadNotFound,
@@ -55,13 +55,7 @@ const getExerciseHistorySchema = {
 		.optional(),
 } as const;
 
-const createExerciseTemplateSchema = {
-	title: z.string().min(1),
-	exerciseType: exerciseTypeEnum,
-	equipmentCategory: equipmentCategoryEnum,
-	muscleGroup: muscleGroupEnum,
-	otherMuscles: z.array(muscleGroupEnum).default([]),
-} as const;
+const createExerciseTemplateSchema = exerciseTemplateInputShape;
 
 const searchExerciseTemplatesSchema = {
 	query: z
@@ -227,25 +221,9 @@ const createExerciseTemplateDefinition = {
 		runtime: ToolRuntime,
 		args: InferToolParams<typeof createExerciseTemplateSchema>,
 	) => {
-		const {
-			title,
-			exerciseType,
-			equipmentCategory,
-			muscleGroup,
-			otherMuscles,
-		} = args;
-		const response: PostV1ExerciseTemplates200 = await runtime
+		return runtime
 			.getClient()
-			.createExerciseTemplate({
-				exercise: {
-					title,
-					exercise_type: exerciseType,
-					equipment_category: equipmentCategory,
-					muscle_group: muscleGroup,
-					other_muscles: otherMuscles,
-				},
-			});
-		return response;
+			.createExerciseTemplate(buildExerciseTemplateRequest(args));
 	},
 };
 

--- a/packages/core/src/utils/schemas.test.ts
+++ b/packages/core/src/utils/schemas.test.ts
@@ -9,6 +9,7 @@ import {
 	zNullableInt,
 	zNullableNumber,
 	zOptionalRepRange,
+	zStrictOptionalRepRange,
 } from "./schemas.js";
 
 describe("shared tool schemas", () => {
@@ -35,6 +36,13 @@ describe("shared tool schemas", () => {
 			start: 5,
 			end: 8,
 		});
+	});
+
+	it("rejects unknown keys in strict repetition ranges", () => {
+		expect(
+			zStrictOptionalRepRange.safeParse({ start: 5, end: 8, extra: true })
+				.success,
+		).toBe(false);
 	});
 
 	it("validates shared enum values and defaults", () => {

--- a/packages/core/src/utils/schemas.ts
+++ b/packages/core/src/utils/schemas.ts
@@ -40,14 +40,21 @@ export const zNullableNumber = z.preprocess(
 	z.coerce.number().nullable().optional(),
 );
 
-export const zOptionalRepRange = z.preprocess(
-	(value) => (value === null ? undefined : value),
-	z
-		.object({
-			start: zNullableInt,
-			end: zNullableInt,
-		})
-		.optional(),
+const repRangeShape = {
+	start: zNullableInt,
+	end: zNullableInt,
+} as const;
+
+function optionalRepRangeSchema<T extends z.ZodType>(schema: T) {
+	return z.preprocess((value) => (value === null ? undefined : value), schema);
+}
+
+export const zOptionalRepRange = optionalRepRangeSchema(
+	z.object(repRangeShape).optional(),
+);
+
+export const zStrictOptionalRepRange = optionalRepRangeSchema(
+	z.object(repRangeShape).strict().optional(),
 );
 
 const setTypeValues = ["warmup", "normal", "failure", "dropset"] as const;

--- a/packages/hevy-client/src/schemas.test.ts
+++ b/packages/hevy-client/src/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	bodyMeasurementSchema,
 	getV1BodyMeasurementsDatePathParamsSchema,
 	getV1BodyMeasurementsQueryParamsSchema,
 	getV1ExerciseHistoryExercisetemplateidPathParamsSchema,
@@ -51,5 +52,8 @@ describe("curated client schema exports", () => {
 		expect(
 			getV1BodyMeasurementsDatePathParamsSchema.parse({ date: "2024-02-29" }),
 		).toEqual({ date: "2024-02-29" });
+		expect(
+			bodyMeasurementSchema.parse({ date: "2024-02-29", weight_kg: 80 }),
+		).toMatchObject({ date: "2024-02-29", weight_kg: 80 });
 	});
 });

--- a/packages/hevy-client/src/schemas.ts
+++ b/packages/hevy-client/src/schemas.ts
@@ -11,3 +11,4 @@ export { getV1RoutinesRoutineidPathParamsSchema } from "./generated/client/schem
 export { getV1WorkoutsEventsQueryParamsSchema } from "./generated/client/schemas/getV1WorkoutsEventsSchema.js";
 export { getV1WorkoutsQueryParamsSchema } from "./generated/client/schemas/getV1WorkoutsSchema.js";
 export { getV1WorkoutsWorkoutidPathParamsSchema } from "./generated/client/schemas/getV1WorkoutsWorkoutidSchema.js";
+export { bodyMeasurementSchema } from "./generated/client/schemas/bodyMeasurementSchema.js";

--- a/scripts/check-package-exports.mjs
+++ b/scripts/check-package-exports.mjs
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 const root = resolve(import.meta.dirname, "..");
 const expected = new Map([
 	["packages/hevy-client", [".", "./types", "./schemas"]],
-	["packages/core", ["."]],
+	["packages/core", [".", "./mutations"]],
 	["packages/node", ["."]],
 	["packages/worker", ["."]],
 ]);

--- a/skills/hevy-cli/SKILL.md
+++ b/skills/hevy-cli/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: hevy-cli
+description: Manage Hevy workouts from the terminal: read and summarize training data, search exercise templates, and create or update workouts, routines, exercises, folders, or body measurements.
+---
+
+# Hevy CLI
+
+Use this skill to manage workouts in the Hevy app.
+The CLI supports reads, creates, and updates. Deletion is unsupported.
+
+## 1. Install or run the published package
+
+```sh
+# One-off use; npm downloads the published package when needed.
+npx @chrisdoc/hevy-cli --help
+
+# Local project install.
+npm i @chrisdoc/hevy-cli
+npx hevy --help
+
+# Persistent global install.
+npm i -g @chrisdoc/hevy-cli
+hevy --help
+```
+
+The package requires Node.js 24 or newer. Use `npx --yes
+@chrisdoc/hevy-cli ...` in non-interactive scripts. Installation is verified
+when `npx @chrisdoc/hevy-cli --version` or `hevy --version` prints a version.
+
+## 2. Configure the API key
+
+The CLI reads credentials only from `HEVY_API_KEY`:
+
+```sh
+export HEVY_API_KEY='<your-hevy-api-key>'
+```
+
+Keep the key out of command arguments, JSON payloads, URLs, shell history,
+screenshots, logs, and responses. `--help` and `--version` work without it.
+
+## 3. Choose a route
+
+Read routes:
+
+- `user`
+- `workouts list`, `workouts get`, `workouts count`, `workouts events`
+- `routines list`, `routines get`
+- `exercises search`, `exercises get`, `exercises history`
+- `measurements list`, `measurements get`
+- `summary`
+
+Create/update routes:
+
+- `workouts create`, `workouts update <workout-id>`
+- `routines create`, `routines update <routine-id>`
+- `exercises create`
+- `folders create`
+- `measurements create <YYYY-MM-DD>`, `measurements update <YYYY-MM-DD>`
+
+The CLI exposes no delete, update-exercise-template, or update-folder routes.
+If a user requests deletion of any resource, explain that deletion is not
+supported by the CLI or the Hevy API integration. Suggest a supported
+alternative, such as archiving the resource in Hevy if available or replacing
+it.
+
+Run route help whenever a flag or argument is uncertain:
+
+```sh
+npx @chrisdoc/hevy-cli <command> --help
+```
+
+Use the narrowest read route and date/page range that answers the question.
+Use `--json` when output will be searched, filtered, or piped.
+
+For exercise work, search first and use the exact returned template ID. Create
+a custom exercise only when the required movement is absent:
+
+```sh
+npx @chrisdoc/hevy-cli exercises search "bench press" --json
+npx @chrisdoc/hevy-cli exercises history <exercise-template-id> \
+  --start-date 2026-07-01T00:00:00Z \
+  --end-date 2026-07-31T23:59:59Z \
+  --json
+```
+
+## 4. Supply mutation data safely
+
+Every create/update requires `--data <value>` and an explicit `--yes`.
+`--noYes`, omission, or any value other than `true` is rejected before the
+CLI reads a file/stdin or calls Hevy. `--data` accepts inline JSON, `@path`
+for a UTF-8 JSON file, or `@-` for JSON from stdin. Keys are camelCase and
+payloads are wrapperless; do not submit `{ "workout": ... }` or snake_case.
+
+```sh
+# Inline folder creation
+npx @chrisdoc/hevy-cli folders create \
+  --data '{"name":"Strength"}' --yes
+
+# Workout creation from a file
+npx @chrisdoc/hevy-cli workouts create \
+  --data @workout.json --yes --json
+
+# Piped full routine replacement
+cat routine.json | npx @chrisdoc/hevy-cli routines update routine-123 \
+  --data @- --yes --json
+
+# Numeric measurement update
+npx @chrisdoc/hevy-cli measurements update 2026-07-27 \
+  --data '{"weightKg":80.5}' --yes --json
+
+# Explicit-null measurement clearing
+npx @chrisdoc/hevy-cli measurements update 2026-07-27 \
+  --data '{"fatPercent":null}' --yes --json
+```
+
+Workout and routine updates are full replacements. Include every exercise and
+set that should remain; omitted content is not preserved. A routine update
+cannot move a routine to another folder because Hevy's PUT endpoint has no
+`folderId`.
+
+Measurement updates are patches over Hevy's replacement PUT. The CLI reads the
+existing date first, preserves omitted fields, replaces supplied numbers, and
+uses explicit `null` to clear a field. Measurement create needs at least one
+numeric field; update needs at least one supplied field. The date is the
+positional argument and cannot appear in `--data`.
+
+## 5. Handle writes and errors
+
+Writes are never retried automatically. Creates are not idempotent, and an
+uncertain network result may already have committed. Verify an uncertain write
+with a read before deciding whether to retry. A duplicate measurement date is
+an API conflict (HTTP 409). HTTP 403 is a generic API failure because Hevy also
+uses it for routine and custom-exercise quotas.
+
+When HTTP 403 occurs, tell the user it may indicate either an invalid API key
+or an exceeded routine/custom-exercise quota. Advise them to check both before
+deciding what to do next.
+
+Successful `--json` commands write one JSON value plus newline to stdout.
+Errors write one sanitized line to stderr. Exit codes:
+
+- `0` — success
+- `1` — missing or invalid configuration
+- `2` — invalid command, flag, payload, or value
+- `3` — Hevy API failure
+- `4` — network or timeout failure
+
+Use `YYYY-MM-DD` for measurement dates and ISO timestamps with timezone
+offsets for history/event filters. Quote user-provided queries and IDs.


### PR DESCRIPTION
## Summary

- add strict shared mutation schemas and payload mappers
- add safe `--data` sources and mandatory `--yes` confirmation
- add workout, routine, exercise, folder, and measurement create/update routes
- document mutation safety, unsupported deletion, and HTTP 403 ambiguity

## Verification

- `npm run test:cli`
- core regression suite: 87 tests passed
- `npm run check`
- `npm run check:types`
- `npm run check:exports`
- `npm run check:boundaries`
- `npm run check:workspaces`
- `npm run check:changeset`
- `npm run test:pack:cli` with fake fetch and no live Hevy writes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added create and update commands for workouts, routines, and body measurements.
  * Added create commands for exercises and routine folders.
  * Supports mutation data as inline JSON, files, or standard input.
  * Requires explicit `--yes` confirmation for all changes; deletion remains unsupported.

* **Documentation**
  * Updated CLI guidance with examples, validation rules, update behavior, output handling, and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->