### PR TITLE
fix: correct nightly workout pagination checks

### DIFF
--- a/tests/nightly/test_hevy_mcp.mjs
+++ b/tests/nightly/test_hevy_mcp.mjs
@@ -25,8 +25,8 @@ import {
 const SEARCH_QUERY = "bench";
 const UNKNOWN_WORKOUT_ID = "00000000-0000-0000-0000-000000000000";
 
-export function buildWorkoutPageArgs(pageSize) {
-	return { page: 1, page_size: pageSize };
+export function buildWorkoutPageArgs(page, pageSize) {
+	return { page, page_size: pageSize };
 }
 
 function assertCondition(condition, schemaPath, kind = "schema") {
@@ -302,7 +302,7 @@ async function main() {
 				const { empty, parsed } = await callOrIgnoreEmpty(
 					client,
 					"get-workouts",
-					{ page: 1, page_size },
+					buildWorkoutPageArgs(1, pageSize),
 				);
 				if (empty) return;
 				assertCondition(Array.isArray(parsed), "$");
@@ -334,7 +334,7 @@ async function main() {
 				const { empty, parsed } = await callOrIgnoreEmpty(
 					client,
 					"get-workouts",
-					buildWorkoutPageArgs(10),
+					buildWorkoutPageArgs(page, 10),
 				);
 				if (empty || !Array.isArray(parsed) || parsed.length === 0) break;
 				fetchedCount += parsed.length;

--- a/tests/nightly/test_hevy_mcp.test.mjs
+++ b/tests/nightly/test_hevy_mcp.test.mjs
@@ -4,5 +4,5 @@ import test from "node:test";
 import { buildWorkoutPageArgs } from "./test_hevy_mcp.mjs";
 
 void test("builds snake_case workout pagination arguments", () => {
-	assert.deepEqual(buildWorkoutPageArgs(5), { page: 1, page_size: 5 });
+	assert.deepEqual(buildWorkoutPageArgs(3, 5), { page: 3, page_size: 5 });
 });


### PR DESCRIPTION
## Summary

- fix the nightly pagination checks to pass `page_size` from the loop variable
- make the pagination helper accept and preserve the requested page number
- add regression coverage for non-first-page arguments

## Root cause

The compact tool catalog migration left the nightly test using the undefined
`page_size` shorthand in the page-size checks. Its count-consistency loop also
called a helper that always returned page 1, so it repeatedly counted the same
page.

## Validation

- `node --test tests/nightly/test_hevy_mcp.test.mjs`
- `npm run test:unit` (646 passed)
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`

The full non-integration command still exposes an unrelated existing
performance/mock contract failure from the compact-catalog merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated pagination test coverage to verify requests use the specified page number and page size.
  - Improved validation that workout counts remain consistent across paginated results.
  - Updated helper tests for the revised pagination input format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->