### PR TITLE
fix: bound Hevy response body timeouts (#790)

### DIFF
--- a/.changeset/fuzzy-routines-timeout.md
+++ b/.changeset/fuzzy-routines-timeout.md
@@ -1,5 +1,6 @@
 ---
 "@hevy-mcp/hevy-client": patch
+"@hevy-mcp/core": patch
 ---
 
 Bound Hevy response fetching and body consumption with per-attempt timeouts.

--- a/.changeset/fuzzy-routines-timeout.md
+++ b/.changeset/fuzzy-routines-timeout.md
@@ -1,0 +1,6 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/core": patch
+---
+
+Bound Hevy response fetching and body consumption with per-attempt timeouts.

--- a/.changeset/fuzzy-routines-timeout.md
+++ b/.changeset/fuzzy-routines-timeout.md
@@ -1,6 +1,5 @@
 ---
 "@hevy-mcp/hevy-client": patch
-"@hevy-mcp/core": patch
 ---
 
 Bound Hevy response fetching and body consumption with per-attempt timeouts.

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -80,6 +80,24 @@ describe("routine tools", () => {
 		expect(client.getRoutineById).toHaveBeenCalledWith("r1");
 	});
 
+	it("returns a standard error response for a bounded timeout", async () => {
+		const client = {
+			getRoutineById: vi.fn().mockRejectedValue(
+				new HevyHttpError("request timed out", {
+					method: "GET",
+					endpoint: "/v1/routines/:routineId",
+					code: "ETIMEDOUT",
+				}),
+			),
+		} as unknown as HevyClient;
+		const tool = register(client);
+		const response = await handler(tool, "get-routine")({
+			routine_id: "routine-1",
+		});
+
+		expect(response).toMatchObject({ isError: true });
+	});
+
 	it("passes nested snake_case routine payloads to create and update", async () => {
 		const client = {
 			createRoutine: vi.fn().mockResolvedValue(routineInput.routine),

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -91,7 +91,10 @@ describe("routine tools", () => {
 			),
 		} as unknown as HevyClient;
 		const tool = register(client);
-		const response = await handler(tool, "get-routine")({
+		const response = await handler(
+			tool,
+			"get-routine",
+		)({
 			routine_id: "routine-1",
 		});
 

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -116,31 +116,32 @@ function withTimeout<T>(
 	timeoutMs: number,
 	onTimeout: () => void,
 ): Promise<T> {
-	const { promise, resolve, reject } = Promise.withResolvers<T>();
-	let settled = false;
-	const timer = setTimeout(
-		() => {
-			if (settled) return;
-			settled = true;
-			onTimeout();
-			reject(new DOMException("Operation timed out", "AbortError"));
-		},
-		Math.max(0, timeoutMs),
-	);
-	operation.then(
-		(value) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timer);
-			resolve(value);
-		},
-		(error: unknown) => {
-			if (settled) return;
-			settled = true;
-			clearTimeout(timer);
-			reject(error);
-		},
-	);
+	const promise = new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const timer = setTimeout(
+			() => {
+				if (settled) return;
+				settled = true;
+				onTimeout();
+				reject(new DOMException("Operation timed out", "AbortError"));
+			},
+			Math.max(0, timeoutMs),
+		);
+		operation.then(
+			(value) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
 	return promise;
 }
 

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -111,6 +111,36 @@ function defaultSleep(milliseconds: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+function withTimeout<T>(
+	operation: Promise<T>,
+	timeoutMs: number,
+	onTimeout: () => void,
+): Promise<T> {
+	const { promise, resolve, reject } = Promise.withResolvers<T>();
+	let settled = false;
+	const timer = setTimeout(() => {
+		if (settled) return;
+		settled = true;
+		onTimeout();
+		reject(new DOMException("Operation timed out", "AbortError"));
+	}, Math.max(0, timeoutMs));
+	operation.then(
+		(value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(value);
+		},
+		(error: unknown) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			reject(error);
+		},
+	);
+	return promise;
+}
+
 function getRequestContext(config: { method?: string; url?: string }) {
 	const method = (config.method ?? "GET").toUpperCase();
 	const rawEndpoint = (config.url ?? "").split("?")[0] ?? "";
@@ -264,19 +294,28 @@ function createNativeClient(
 				) {
 					headers.set("content-type", "application/json");
 				}
-				const response = await fetchImplementation(url, {
-					method,
-					headers,
-					redirect: "manual",
-					body:
-						normalized.data instanceof FormData
-							? normalized.data
-							: normalized.data === undefined
-								? undefined
-								: JSON.stringify(normalized.data),
-					signal: controller.signal,
-				});
-				const data = await parseResponseData(response);
+				const attemptDeadline = Date.now() + timeoutMs;
+				const response = await withTimeout(
+					fetchImplementation(url, {
+						method,
+						headers,
+						redirect: "manual",
+						body:
+							normalized.data instanceof FormData
+								? normalized.data
+								: normalized.data === undefined
+									? undefined
+									: JSON.stringify(normalized.data),
+						signal: controller.signal,
+					}),
+					Math.max(0, attemptDeadline - Date.now()),
+					() => controller.abort(),
+				);
+				const data = await withTimeout(
+					parseResponseData(response),
+					Math.max(0, attemptDeadline - Date.now()),
+					() => controller.abort(),
+				);
 				if (!response.ok) {
 					throw new HevyHttpError(
 						`Hevy API request failed (HTTP ${response.status})`,

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -118,12 +118,15 @@ function withTimeout<T>(
 ): Promise<T> {
 	const { promise, resolve, reject } = Promise.withResolvers<T>();
 	let settled = false;
-	const timer = setTimeout(() => {
-		if (settled) return;
-		settled = true;
-		onTimeout();
-		reject(new DOMException("Operation timed out", "AbortError"));
-	}, Math.max(0, timeoutMs));
+	const timer = setTimeout(
+		() => {
+			if (settled) return;
+			settled = true;
+			onTimeout();
+			reject(new DOMException("Operation timed out", "AbortError"));
+		},
+		Math.max(0, timeoutMs),
+	);
 	operation.then(
 		(value) => {
 			if (settled) return;

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -15,7 +15,7 @@ function hangingResponse(): Response {
 	return new Response(
 		new ReadableStream({
 			start(controller) {
-				controller.enqueue(new TextEncoder().encode('{"routine":'));
+				controller.enqueue(new TextEncoder().encode("{\"routine\":"));
 			},
 		}),
 		{ status: 200, headers: { "content-type": "application/json" } },

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -15,7 +15,7 @@ function hangingResponse(): Response {
 	return new Response(
 		new ReadableStream({
 			start(controller) {
-				controller.enqueue(new TextEncoder().encode("{\"routine\":"));
+				controller.enqueue(new TextEncoder().encode('{"routine":'));
 			},
 		}),
 		{ status: 200, headers: { "content-type": "application/json" } },

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHevyClient } from "./hevy-client.js";
-import { HevyHttpError } from "./hevy-http-error.js";
-
+import {
+	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+	HevyHttpError,
+} from "./hevy-http-error.js";
 function response(data: unknown, status = 200): Response {
 	return new Response(JSON.stringify(data), {
 		status,
 		headers: { "content-type": "application/json" },
 	});
+}
+
+function hangingResponse(): Response {
+	return new Response(
+		new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('{"routine":'));
+			},
+		}),
+		{ status: 200, headers: { "content-type": "application/json" } },
+	);
 }
 
 describe("@hevy-mcp/hevy-client", () => {
@@ -65,5 +78,48 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(eventText).not.toContain("body");
 		expect(eventText).not.toContain("observer-secret");
 		expect(onLog).toHaveBeenCalled();
+	});
+	it("times out while consuming a response body", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			timeoutMs: 20,
+			maxGetRetries: 0,
+		});
+
+		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
+			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		});
+	});
+
+	it("times out when fetch never settles", async () => {
+		const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			timeoutMs: 20,
+			maxGetRetries: 0,
+		});
+
+		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
+			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		});
+	});
+
+	it("bounds retries for hanging response bodies", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			timeoutMs: 20,
+			maxGetRetries: 1,
+			sleep: async () => {},
+		});
+
+		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
+			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 });


### PR DESCRIPTION
## Primary changes
- add abort-independent deadlines around fetch and response-body parsing
- preserve per-attempt timeout budgets, cleanup, and bounded GET retries
- add hanging-fetch, hanging-body, retry, and MCP get-routine regression coverage

## Reviewer walkthrough

- `packages/hevy-client/src/hevy-client-kubb.ts`: review the timeout wrapper around both fetch and response-body parsing, including the shared per-attempt deadline and abort cleanup.
- `packages/hevy-client/src/hevy-client.test.ts`: review coverage for a never-settling fetch, a hanging response body, and bounded retries.
- `packages/core/src/tools/routines.test.ts`: review the standard MCP error response assertion for a bounded timeout.
- `.changeset/fuzzy-routines-timeout.md`: review the patch changesets for `@hevy-mcp/hevy-client` and `@hevy-mcp/core`.

## Correctness and invariants

- Fetch and response-body parsing share one per-attempt deadline, so a response that never finishes consuming cannot outlive the configured timeout.
- Each timeout wrapper settles once, clears its timer after normal completion, and aborts the request controller when the deadline expires.
- Existing bounded GET retry behavior is preserved; hanging attempts exhaust according to `maxGetRetries` instead of waiting indefinitely.

## Testing and QA
- 
 RUN  v4.1.10 /root/hevy-mcp


 Test Files  2 passed (2)
      Tests  10 passed (10)
   Start at  09:10:30
   Duration  562ms (transform 337ms, setup 0ms, import 541ms, tests 134ms, environment 0ms) — passed (10 tests)
- 
> build
> npm run build --workspace hevy-mcp


> hevy-mcp@5.0.0 build
> tsdown -c tsdown.config.ts

ℹ tsdown v0.22.14 powered by rolldown v1.2.0
ℹ config file: /root/hevy-mcp/packages/node/tsdown.config.ts 
ℹ entry: src/index.ts, src/cli.ts
ℹ target: esnext
ℹ tsconfig: tsconfig.json
ℹ Build start
ℹ Cleaning 5 files
ℹ Emit types with typescript@7.0.2
ℹ Granting execute permission to dist/cli.mjs
ℹ Granting execute permission to dist/index.mjs
ℹ dist/cli.mjs             1.00 kB │ gzip:  0.56 kB
ℹ dist/index.mjs           0.72 kB │ gzip:  0.41 kB
ℹ dist/src-CMa-Ij-S.mjs  208.14 kB │ gzip: 46.56 kB
ℹ dist/index.d.mts         0.40 kB │ gzip:  0.22 kB
ℹ dist/cli.d.mts           0.01 kB │ gzip:  0.03 kB
ℹ 5 files, total: 210.28 kB
✔ Build complete in 308ms — passed
- 
 RUN  v4.1.10 /root/hevy-mcp

 ❯ tests/integration/mocked/hevy-mcp.mocked.integration.test.ts (0 test)
 ❯ tests/integration/worker-http.integration.test.ts (0 test)
 ❯ tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts (0 test)
 ❯ tests/integration/worker-http.live.integration.test.ts (0 test)

 Test Files  4 failed (4)
      Tests  no tests
   Start at  09:10:32
   Duration  273ms (transform 239ms, setup 0ms, import 0ms, tests 0ms, environment 0ms) — blocked by missing MCP client/server packages in the environment
- 
> check:types
> tsc --noEmit && npm run check:types --workspaces --if-present

packages/core/src/prompts/workouts.ts(1,32): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/resources/hevy.ts(4,8): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/resources/hevy.ts(52,10): error TS7006: Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts(65,10): error TS7006: Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts(82,10): error TS7006: Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts(95,10): error TS7006: Parameter 'uri' implicitly has an 'any' type.
packages/core/src/server.ts(1,27): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/define-tool.ts(1,49): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/register.ts(1,32): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/mcp-client-logger.ts(1,49): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/response-contracts.ts(1,50): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/tool-annotations.ts(8,38): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/worker/src/worker.ts(1,58): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/worker/src/worker.ts(2,32): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/worker/src/worker.ts(300,24): error TS7006: Parameter 'error' implicitly has an 'any' type.
scripts/measure-token-cost.test.ts(1,27): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
scripts/measure-token-cost.ts(1,46): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
scripts/measure-token-cost.ts(2,27): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
scripts/measure-token-cost.ts(3,24): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/fixtures/graceful-shutdown-child.ts(1,38): error TS2307: Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
tests/integration/hevy-mcp.integration.test.ts(1,46): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/hevy-mcp.integration.test.ts(2,24): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts(1,46): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts(2,24): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(1,46): error TS2307: Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(2,24): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(141,48): error TS7031: Binding element 'name' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(634,28): error TS7031: Binding element 'name' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(634,34): error TS7031: Binding element 'uri' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts(634,39): error TS7031: Binding element 'mimeType' implicitly has an 'any' type.
tests/integration/worker-http.integration.test.ts(10,8): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/worker-http.integration.test.ts(567,28): error TS7006: Parameter 'tool' implicitly has an 'any' type.
tests/integration/worker-http.live.integration.test.ts(8,8): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/worker-http.live.integration.test.ts(347,49): error TS7006: Parameter 'tool' implicitly has an 'any' type.
tests/performance/harness.ts(5,38): error TS2307: Cannot find module '@modelcontextprotocol/client/stdio' or its corresponding type declarations.
tests/performance/harness.ts(6,24): error TS2307: Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/performance/performance.test.ts(131,32): error TS7031: Binding element 'name' implicitly has an 'any' type. — blocked by missing MCP client/server packages in the environment
- 
> check
> oxlint . --type-aware --type-check && node scripts/check-worker-import-boundary.mjs && oxfmt . --check

packages/node/src/utils/streamable-http.ts:8:51: error typescript(TS2307): Cannot find module '@modelcontextprotocol/node' or its corresponding type declarations.
packages/node/src/utils/streamable-http.ts:336:28: error typescript(TS7006): Parameter 'id' implicitly has an 'any' type.
packages/node/src/utils/stdio-observability.ts:2:36: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.ts:3:37: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.ts:4:43: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
packages/node/src/index.ts:11:38: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.test.ts:3:43: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.test.ts:254:18: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
packages/node/src/utils/streamable-http.test.ts:2:27: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/node/src/utils/stdio-observability.ts:34:21: error typescript(no-redundant-type-constituents): 'JSONRPCMessage' is an 'error' type that acts as 'any' and overrides all other types in this union type.
packages/core/src/prompts/workouts.ts:1:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/mcp-client-logger.ts:1:49: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/response-contracts.ts:1:50: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/resources/hevy.ts:4:8: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/resources/hevy.ts:52:10: error typescript(TS7006): Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts:65:10: error typescript(TS7006): Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts:82:10: error typescript(TS7006): Parameter 'uri' implicitly has an 'any' type.
packages/core/src/resources/hevy.ts:95:10: error typescript(TS7006): Parameter 'uri' implicitly has an 'any' type.
packages/core/src/tools/define-tool.ts:1:49: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/utils/tool-annotations.ts:8:38: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/register.ts:1:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/server.ts:1:27: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/prompts/workouts.ts:97:54: error typescript(restrict-template-expressions): Invalid type used in template literal expression.
packages/core/src/prompts/workouts.ts:138:45: error typescript(no-base-to-string): 'routine_id' will use Object's default stringification format ('[object Object]') when stringified. help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSON.stringify`), or implementing a custom `toString()`/`toLocaleString()` on the type.
packages/core/src/prompts/workouts.ts:138:72: error typescript(no-base-to-string): 'start_time' will use Object's default stringification format ('[object Object]') when stringified. help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSON.stringify`), or implementing a custom `toString()`/`toLocaleString()` on the type.
packages/core/src/prompts/workouts.ts:138:45: error typescript(restrict-template-expressions): Invalid type used in template literal expression.
packages/core/src/prompts/workouts.ts:138:72: error typescript(restrict-template-expressions): Invalid type used in template literal expression.
scripts/measure-token-cost.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
scripts/measure-token-cost.ts:2:27: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
scripts/measure-token-cost.ts:3:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
scripts/measure-token-cost.test.ts:1:27: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/fixtures/graceful-shutdown-child.ts:1:38: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server/stdio' or its corresponding type declarations.
tests/integration/hevy-mcp.integration.test.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/hevy-mcp.integration.test.ts:2:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/worker-http.integration.test.ts:10:8: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/worker-http.integration.test.ts:567:28: error typescript(TS7006): Parameter 'tool' implicitly has an 'any' type.
tests/integration/worker-http.live.integration.test.ts:8:8: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/worker-http.live.integration.test.ts:347:49: error typescript(TS7006): Parameter 'tool' implicitly has an 'any' type.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts:2:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:2:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:141:48: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:634:28: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:634:34: error typescript(TS7031): Binding element 'uri' implicitly has an 'any' type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:634:39: error typescript(TS7031): Binding element 'mimeType' implicitly has an 'any' type.
tests/performance/harness.ts:5:38: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client/stdio' or its corresponding type declarations.
tests/performance/harness.ts:6:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
tests/performance/performance.test.ts:131:32: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
tests/integration/hevy-mcp.integration.test.ts:100:14: error typescript(no-redundant-type-constituents): 'McpServer' is an 'error' type that acts as 'any' and overrides all other types in this union type.
tests/integration/hevy-mcp.integration.test.ts:101:14: error typescript(no-redundant-type-constituents): 'Client' is an 'error' type that acts as 'any' and overrides all other types in this union type.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts:56:14: error typescript(no-redundant-type-constituents): 'McpServer' is an 'error' type that acts as 'any' and overrides all other types in this union type.
tests/integration/mocked/get-workout-count-events-mocked.integration.test.ts:57:14: error typescript(no-redundant-type-constituents): 'Client' is an 'error' type that acts as 'any' and overrides all other types in this union type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:64:14: error typescript(no-redundant-type-constituents): 'McpServer' is an 'error' type that acts as 'any' and overrides all other types in this union type.
tests/integration/mocked/hevy-mcp.mocked.integration.test.ts:65:14: error typescript(no-redundant-type-constituents): 'Client' is an 'error' type that acts as 'any' and overrides all other types in this union type.
packages/worker/src/worker.ts:1:58: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/worker/src/worker.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/worker/src/worker.ts:300:24: error typescript(TS7006): Parameter 'error' implicitly has an 'any' type.
packages/core/src/prompts/workouts.test.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/prompts/workouts.test.ts:2:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
packages/worker/src/worker.test.ts:2:58: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/templates.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/body-measurements.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/workouts.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/register.test.ts:1:46: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/register.test.ts:2:24: error typescript(TS2307): Cannot find module '@modelcontextprotocol/client' or its corresponding type declarations.
packages/core/src/tools/register.test.ts:72:23: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
packages/core/src/tools/register.test.ts:77:39: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
packages/core/src/tools/register.test.ts:121:33: error typescript(TS7031): Binding element 'name' implicitly has an 'any' type.
packages/core/src/tools/annotations.test.ts:1:49: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/user.test.ts:1:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/resources/hevy.test.ts:4:8: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/folders.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations.
packages/core/src/tools/routines.test.ts:2:32: error typescript(TS2307): Cannot find module '@modelcontextprotocol/server' or its corresponding type declarations. — blocked by missing MCP client/server packages in the environment

Resolves #790


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-attempt timeouts for workout routine requests, including stalled response downloads.
  * Requests that exceed the timeout now stop promptly instead of hanging indefinitely.
  * Retry attempts are now bounded when responses remain incomplete.
  * Timed-out routine requests return a standard error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->