### PR TITLE
fix: ignore malformed MCP stdin lines (#792)

### DIFF
--- a/.changeset/steady-stdin-guards.md
+++ b/.changeset/steady-stdin-guards.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Ignore malformed MCP stdin lines after recording bounded diagnostics so valid subsequent messages continue processing.

--- a/packages/node/src/utils/stdio-observability.test.ts
+++ b/packages/node/src/utils/stdio-observability.test.ts
@@ -285,6 +285,20 @@ describe("package-local stdio observability", () => {
 		}
 	});
 
+	it("rethrows unexpected parser failures from the transport adapter", () => {
+		const { readBuffer, transport } = createTransportDouble();
+		const unexpected = new Error("instrumentation failure");
+		sdkSharedTestDoubles.deserializeMessage.mockImplementationOnce(() => {
+			throw unexpected;
+		});
+		createInstrumentedStdioTransport(
+			transport as unknown as StdioServerTransport,
+		);
+		transport._ondata?.(Buffer.from('{"jsonrpc":"2.0"}\n', "utf8"));
+
+		expect(() => readBuffer.readMessage()).toThrow(unexpected);
+	});
+
 	it("rethrows the original parser error when diagnostics fail", () => {
 		const parserError = new Error("private parser failure at position 3");
 		sdkSharedTestDoubles.deserializeMessage.mockImplementationOnce(() => {

--- a/packages/node/src/utils/stdio-observability.test.ts
+++ b/packages/node/src/utils/stdio-observability.test.ts
@@ -270,7 +270,7 @@ describe("package-local stdio observability", () => {
 			);
 			await processed;
 
-			expect(onError).toHaveBeenCalledOnce();
+			expect(onError).not.toHaveBeenCalled();
 			expect(onMessage).toHaveBeenCalledWith({
 				jsonrpc: "2.0",
 				method: "notifications/initialized",

--- a/packages/node/src/utils/stdio-observability.test.ts
+++ b/packages/node/src/utils/stdio-observability.test.ts
@@ -288,6 +288,7 @@ describe("package-local stdio observability", () => {
 	it("rethrows unexpected parser failures from the transport adapter", () => {
 		const { readBuffer, transport } = createTransportDouble();
 		const unexpected = new Error("instrumentation failure");
+		unexpected.name = "ZodError";
 		sdkSharedTestDoubles.deserializeMessage.mockImplementationOnce(() => {
 			throw unexpected;
 		});
@@ -297,6 +298,25 @@ describe("package-local stdio observability", () => {
 		transport._ondata?.(Buffer.from('{"jsonrpc":"2.0"}\n', "utf8"));
 
 		expect(() => readBuffer.readMessage()).toThrow(unexpected);
+	});
+	it("defers the message after the malformed-line drain cap", async () => {
+		const { readBuffer, transport } = createTransportDouble();
+		createInstrumentedStdioTransport(
+			transport as unknown as StdioServerTransport,
+		);
+		const malformedLines = Array.from({ length: 100 }, () => "{bad}").join(
+			"\n",
+		);
+		transport._ondata?.(
+			Buffer.from(
+				`${malformedLines}\n{"jsonrpc":"2.0","id":1,"method":"ping"}\n`,
+				"utf8",
+			),
+		);
+
+		expect(readBuffer.readMessage()).toBeNull();
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(readBuffer.readMessage()).toMatchObject({ id: 1, method: "ping" });
 	});
 
 	it("rethrows the original parser error when diagnostics fail", () => {

--- a/packages/node/src/utils/stdio-observability.ts
+++ b/packages/node/src/utils/stdio-observability.ts
@@ -24,6 +24,15 @@ const SAFE_MCP_METHODS: Record<string, true> = {
 };
 const REDACTED_CONTENT_MARKER = "[REDACTED]";
 
+const MAX_MALFORMED_LINES_PER_READ = 100;
+
+function isMalformedMessageError(error: unknown): boolean {
+	return (
+		error instanceof SyntaxError ||
+		(error instanceof Error && error.name === "ZodError")
+	);
+}
+
 export interface StdioChunkSnapshot {
 	lastChunkByteLength: number;
 	lastChunkStartsWithUtf8Bom: boolean;
@@ -81,6 +90,7 @@ function createSdkPrivateStdioAdapter(
 			}
 
 			readBuffer.readMessage = () => {
+				let skippedMalformedLines = 0;
 				while (true) {
 					const buffer = readBuffer._buffer;
 					if (!buffer) {
@@ -97,8 +107,14 @@ function createSdkPrivateStdioAdapter(
 					const line = lineBuffer.toString("utf8").replace(/\r$/, "");
 					try {
 						return onReadLine(line);
-					} catch {
-						// Malformed stdin lines are consumed and ignored.
+					} catch (error) {
+						if (!isMalformedMessageError(error)) {
+							throw error;
+						}
+						skippedMalformedLines += 1;
+						if (skippedMalformedLines >= MAX_MALFORMED_LINES_PER_READ) {
+							return null;
+						}
 					}
 				}
 			};

--- a/packages/node/src/utils/stdio-observability.ts
+++ b/packages/node/src/utils/stdio-observability.ts
@@ -1,3 +1,4 @@
+import { ZodError } from "zod";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { deserializeMessage } from "@modelcontextprotocol/server";
 import type { JSONRPCMessage } from "@modelcontextprotocol/server";
@@ -27,10 +28,7 @@ const REDACTED_CONTENT_MARKER = "[REDACTED]";
 const MAX_MALFORMED_LINES_PER_READ = 100;
 
 function isMalformedMessageError(error: unknown): boolean {
-	return (
-		error instanceof SyntaxError ||
-		(error instanceof Error && error.name === "ZodError")
-	);
+	return error instanceof SyntaxError || error instanceof ZodError;
 }
 
 export interface StdioChunkSnapshot {
@@ -88,8 +86,14 @@ function createSdkPrivateStdioAdapter(
 			if (!readBuffer || typeof readBuffer.readMessage !== "function") {
 				return false;
 			}
+			let deferredMessage: JSONRPCMessage | null = null;
 
 			readBuffer.readMessage = () => {
+				if (deferredMessage) {
+					const message = deferredMessage;
+					deferredMessage = null;
+					return message;
+				}
 				let skippedMalformedLines = 0;
 				while (true) {
 					const buffer = readBuffer._buffer;
@@ -113,6 +117,10 @@ function createSdkPrivateStdioAdapter(
 						}
 						skippedMalformedLines += 1;
 						if (skippedMalformedLines >= MAX_MALFORMED_LINES_PER_READ) {
+							setImmediate(() => {
+								const message = readBuffer.readMessage();
+								if (message) deferredMessage = message;
+							});
 							return null;
 						}
 					}

--- a/packages/node/src/utils/stdio-observability.ts
+++ b/packages/node/src/utils/stdio-observability.ts
@@ -81,22 +81,27 @@ function createSdkPrivateStdioAdapter(
 			}
 
 			readBuffer.readMessage = () => {
-				const buffer = readBuffer._buffer;
-				if (!buffer) {
-					return null;
-				}
+				while (true) {
+					const buffer = readBuffer._buffer;
+					if (!buffer) {
+						return null;
+					}
 
-				const index = buffer.indexOf("\n");
-				if (index === -1) {
-					return null;
-				}
+					const index = buffer.indexOf("\n");
+					if (index === -1) {
+						return null;
+					}
 
-				const lineBuffer = buffer.subarray(0, index);
-				readBuffer._buffer = buffer.subarray(index + 1);
-				const line = lineBuffer.toString("utf8").replace(/\r$/, "");
-				return onReadLine(line);
+					const lineBuffer = buffer.subarray(0, index);
+					readBuffer._buffer = buffer.subarray(index + 1);
+					const line = lineBuffer.toString("utf8").replace(/\r$/, "");
+					try {
+						return onReadLine(line);
+					} catch {
+						// Malformed stdin lines are consumed and ignored.
+					}
+				}
 			};
-
 			return true;
 		},
 	};


### PR DESCRIPTION
## Primary changes

- Consume malformed or empty newline-delimited stdin records without terminating transport processing.
- Preserve bounded diagnostics and continue to the next valid MCP message.
- Cover malformed input followed by a valid message.

## Reviewer walkthrough

1. `packages/node/src/utils/stdio-observability.ts`: inspect the read-buffer loop and per-line error handling.
2. `packages/node/src/utils/stdio-observability.test.ts`: inspect coverage for malformed input followed by a valid message.
3. `.changeset/steady-stdin-guards.md`: inspect the patch release note.

## Correctness and invariants

- Each complete newline-delimited record is consumed before the next buffered record is parsed.
- A malformed record is ignored after bounded diagnostics; subsequent valid MCP messages remain deliverable.
- A malformed record does not invoke the transport error callback or terminate processing.

## Testing and QA

- Targeted stdio test attempted: blocked because `@modelcontextprotocol/server` is not installed in the current environment.

Resolves #792
Resolves #793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed standard-input messages are now ignored after limited diagnostics, allowing subsequent valid messages to continue processing.
  * Unexpected transport errors continue to surface instead of being silently suppressed.
* **Tests**
  * Added coverage for continued processing after malformed input and propagation of unexpected parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->