### PR TITLE
fix: type routine exercise rest_seconds as integer (fixes get-routine)

### DIFF
--- a/.changeset/routine-rest-seconds-integer.md
+++ b/.changeset/routine-rest-seconds-integer.md
@@ -1,0 +1,6 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/core": patch
+---
+
+Fix get-routine failing for every routine: the Routine read schema typed each exercise's `rest_seconds` as a string, but the Hevy API returns an integer. Correct the OpenAPI spec (and regenerated client) to type it as an integer and align the get-routine output contract, matching the Post/Put routine request schemas. get-routines was unaffected because its compact projection omits `rest_seconds`.

--- a/openapi-spec.json
+++ b/openapi-spec.json
@@ -2270,9 +2270,9 @@
 									"example": "Bench Press (Barbell)"
 								},
 								"rest_seconds": {
-									"type": "string",
+									"type": "integer",
 									"description": "The rest time in seconds between sets of the exercise",
-									"example": "60"
+									"example": 60
 								},
 								"notes": {
 									"type": "string",

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -80,6 +80,39 @@ describe("routine tools", () => {
 		expect(client.getRoutineById).toHaveBeenCalledWith("r1");
 	});
 
+	it("parses a routine whose exercise rest_seconds is an integer", async () => {
+		// Regression: the Hevy API returns rest_seconds as an integer, but the
+		// Routine read schema (and the get-routine output contract) previously
+		// typed it as a string, so output validation rejected every routine.
+		const client = {
+			getRoutineById: vi.fn().mockResolvedValue({
+				routine: {
+					id: "r1",
+					title: "Legs A",
+					exercises: [
+						{
+							index: 0,
+							title: "Hip Thrust (Barbell)",
+							exercise_template_id: "D57C2EC7",
+							rest_seconds: 120,
+							sets: [{ type: "normal", weight_kg: 22.68, reps: 12 }],
+						},
+					],
+				},
+			}),
+		} as unknown as HevyClient;
+		const tool = register(client);
+
+		const response = await handler(tool, "get-routine")({ routine_id: "r1" });
+
+		expect(response).not.toMatchObject({ isError: true });
+		expect(response).toMatchObject({
+			structuredContent: {
+				routine: { exercises: [{ rest_seconds: 120 }] },
+			},
+		});
+	});
+
 	it("returns a standard error response for a bounded timeout", async () => {
 		const client = {
 			getRoutineById: vi.fn().mockRejectedValue(

--- a/packages/core/src/utils/formatters.test.ts
+++ b/packages/core/src/utils/formatters.test.ts
@@ -50,7 +50,7 @@ describe("snake_case response projections", () => {
 			exercises: [
 				{
 					exercise_template_id: "bench",
-					rest_seconds: "60",
+					rest_seconds: 60,
 					sets: [{ rep_range: { start: 8, end: 12 } }],
 				},
 			],
@@ -62,7 +62,7 @@ describe("snake_case response projections", () => {
 			exercises: [
 				{
 					exercise_template_id: "bench",
-					rest_seconds: "60",
+					rest_seconds: 60,
 					sets: [{ rep_range: { start: 8, end: 12 } }],
 				},
 			],

--- a/packages/core/src/utils/output-schemas.test.ts
+++ b/packages/core/src/utils/output-schemas.test.ts
@@ -23,9 +23,9 @@ describe("snake_case formatted output schemas", () => {
 			formattedRoutineSchema.parse({
 				id: "routine-1",
 				folder_id: 2,
-				exercises: [{ rest_seconds: "60" }],
+				exercises: [{ rest_seconds: 60 }],
 			}),
-		).toMatchObject({ folder_id: 2, exercises: [{ rest_seconds: "60" }] });
+		).toMatchObject({ folder_id: 2, exercises: [{ rest_seconds: 60 }] });
 	});
 
 	it("accepts snake_case template, history, measurement, and folder DTOs", () => {

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -184,7 +184,7 @@ export const formattedRoutineExerciseSchema = z.object({
 	exercise_template_id: z.string().optional(),
 	notes: z.string().optional(),
 	supersets_id: optionalNumber,
-	rest_seconds: optionalNumber,
+	rest_seconds: z.number().int().optional(),
 	sets: z.array(formattedRoutineSetSchema).optional(),
 });
 

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -184,7 +184,7 @@ export const formattedRoutineExerciseSchema = z.object({
 	exercise_template_id: z.string().optional(),
 	notes: z.string().optional(),
 	supersets_id: optionalNumber,
-	rest_seconds: z.string().optional(),
+	rest_seconds: optionalNumber,
 	sets: z.array(formattedRoutineSetSchema).optional(),
 });
 

--- a/packages/hevy-client/src/generated/client/routine.json
+++ b/packages/hevy-client/src/generated/client/routine.json
@@ -43,9 +43,9 @@
             "example": "Bench Press (Barbell)"
           },
           "rest_seconds": {
-            "type": "string",
+            "type": "integer",
             "description": "The rest time in seconds between sets of the exercise",
-            "example": "60"
+            "example": 60
           },
           "notes": {
             "type": "string",

--- a/packages/hevy-client/src/generated/client/schemas/routineSchema.ts
+++ b/packages/hevy-client/src/generated/client/schemas/routineSchema.ts
@@ -30,7 +30,7 @@ export const routineSchema = z.object({
         title: z.optional(z.string().describe("Title of the exercise")),
         rest_seconds: z.optional(
           z
-            .string()
+            .int()
             .describe("The rest time in seconds between sets of the exercise")
         ),
         notes: z.optional(z.string().describe("Routine notes on the exercise")),

--- a/packages/hevy-client/src/generated/client/types/Routine.ts
+++ b/packages/hevy-client/src/generated/client/types/Routine.ts
@@ -45,9 +45,9 @@ export type Routine = {
     title?: string;
     /**
      * @description The rest time in seconds between sets of the exercise
-     * @type string | undefined
+     * @type integer | undefined
      */
-    rest_seconds?: string;
+    rest_seconds?: number;
     /**
      * @description Routine notes on the exercise
      * @type string | undefined


### PR DESCRIPTION
## Primary changes

- Type `Routine.exercises[].rest_seconds` as `integer` in `openapi-spec.json` (it was `string`), matching the Hevy API and the existing `PostRoutinesRequestExercise` / `PutRoutinesRequestExercise` request schemas.
- Regenerate the Kubb client so the routine read type/schema use a number.
- Align the `get-routine` output contract (`formattedRoutineExerciseSchema`) to a number so a numeric `rest_seconds` passes structured-output validation.
- Add a regression test driving an integer `rest_seconds` through the `get-routine` handler.

## Root cause

`get-routine` (fetch a single routine by id) failed for **every** routine, while `get-routines` (list) worked.

The Hevy API returns `rest_seconds` as an integer:

```
GET /v1/routines/{id} -> 200
{ "routine": { "exercises": [ { "rest_seconds": 120, ... } ] } }
```

But `components/schemas/Routine` in `openapi-spec.json` typed `exercises[].rest_seconds` as `string`. That flows two ways:

1. The regenerated Zod/type for the routine read disagreed with the real payload.
2. More importantly, the `get-routine` tool declares an `outputSchema`, and its output contract (`formattedRoutineExerciseSchema` in `response-contracts.ts`) validated `rest_seconds` as `z.string()`. `projectRoutine` passes the raw integer straight through, so structured-output validation rejected `120` and the by-id read surfaced as a generic "request failed unexpectedly."

`get-routines` was unaffected because its compact projection (id, title, counts) never surfaces per-exercise `rest_seconds`. The `Post`/`Put` routine request schemas already type the field as `integer`, so this also removes a read/write inconsistency.

## Relationship to this morning's fixes (they do not fix this)

Two related robustness PRs merged earlier today, and it's worth being explicit that **neither addresses this bug**:

- #795 — *fix: bound Hevy response body timeouts (#790)*: added per-attempt deadlines around fetch and body parsing. That fixes a hang, not a schema mismatch — a routine that returns promptly with an integer `rest_seconds` still fails validation.
- #796 — *fix: ignore malformed MCP stdin lines (#792)*: hardened stdin parsing on the transport layer, unrelated to Hevy response typing.

This PR targets the actual cause of the remaining `get-routine` failures: the mistyped `rest_seconds` field.

## Reviewer walkthrough

- `openapi-spec.json`: `components/schemas/Routine` -> `exercises.items.properties.rest_seconds` changed `string` -> `integer` (example `"60"` -> `60`). The `Post`/`Put` request schemas are intentionally left as-is (already `integer`).
- `packages/hevy-client/src/generated/**`: regenerated via `npm run build:client` (not hand-edited) — routine read type is now `number` and the Zod schema uses `z.int()`.
- `packages/core/src/utils/response-contracts.ts`: `formattedRoutineExerciseSchema.rest_seconds` `z.string().optional()` -> `optionalNumber` (the runtime validation that was rejecting real payloads).
- `packages/core/src/tools/routines.test.ts`: new regression test — an integer `rest_seconds` now flows through `get-routine` without an error and is preserved in `structuredContent`.
- `packages/core/src/utils/{formatters,output-schemas}.test.ts`: existing `"60"` assertions updated to numeric `60`.
- `.changeset/routine-rest-seconds-integer.md`: patch changeset for `@hevy-mcp/hevy-client` and `@hevy-mcp/core`.

## Testing and QA

- `npm run build:client` — regen matches the committed generated files.
- `npm run check:types` — passes across all workspaces.
- `npm run test:unit` — 658 passed (incl. the new regression test).
- `npm run check:changeset` — patch bump for both packages.
- `npm run check` — oxlint + format clean.
- Integration tests require a real `HEVY_API_KEY` and are not run here by design.

## Follow-ups (out of scope, not included here)

- The `Routine` read schema names the superset field `supersets_id` (plural), but the API returns `superset_id` (singular), so superset membership is silently dropped on read. Non-fatal (optional/nullish, unknown keys stripped); worth a separate small PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Routine retrieval now correctly accepts and returns rest periods as numeric seconds.
  - Improved compatibility with routine requests and API responses using integer `rest_seconds` values.
  - Updated routine validation and formatting to consistently handle numeric rest periods.

- **Documentation**
  - Updated the routine schema example to show rest periods as numbers, such as `60`.

- **Tests**
  - Added regression coverage to verify successful routine retrieval with integer rest periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->