### PR TITLE
fix: harden OpenTelemetry SDK span correlation and privacy

### DIFF
--- a/.changeset/wise-cloths-jump.md
+++ b/.changeset/wise-cloths-jump.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Enrich SDK protocol spans and export privacy-safe failure events.

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -228,34 +228,16 @@ describe("Node package entrypoint", () => {
 		);
 		expect(testDoubles.server.connect).not.toHaveBeenCalled();
 	});
-	it("tracks SDK tool, discovery, validation, and protocol failures", async () => {
+	it("enriches initialize and tool SDK spans", async () => {
 		const initializeHandler = vi
 			.fn()
 			.mockResolvedValue({ protocolVersion: "1" });
-		const toolHandler = vi
-			.fn()
-			.mockResolvedValueOnce({ isError: true })
-			.mockResolvedValueOnce({})
-			.mockRejectedValueOnce(new Error("tool failure"));
-		const discoveryHandler = vi
-			.fn()
-			.mockResolvedValueOnce({ capabilities: [] })
-			.mockRejectedValueOnce(new Error("discovery failure"));
-		const previousOnError = vi.fn(() => {
-			throw new Error("previous SDK handler failure");
-		});
-		const createToolError = vi.fn((message: string) => ({ message }));
-		testDoubles.sdkProtocol.onerror = previousOnError;
+		const toolHandler = vi.fn().mockResolvedValue({});
 		testDoubles.sdkProtocol._requestHandlers.set(
 			"initialize",
 			initializeHandler,
 		);
 		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
-		testDoubles.sdkProtocol._requestHandlers.set(
-			"server/discover",
-			discoveryHandler,
-		);
-		testDoubles.server.createToolError = createToolError;
 
 		await expect(createNodeMcpServer({ apiKey: "valid-key" })).resolves.toBe(
 			testDoubles.server,
@@ -265,17 +247,9 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
 		const wrappedInitializeHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("initialize");
-		const wrappedDiscoveryHandler =
-			testDoubles.sdkProtocol._requestHandlers.get("server/discover");
 		expect(wrappedToolHandler).toBeDefined();
 		expect(wrappedInitializeHandler).toBeDefined();
-		expect(wrappedDiscoveryHandler).toBeDefined();
-		if (
-			!wrappedToolHandler ||
-			!wrappedInitializeHandler ||
-			!wrappedDiscoveryHandler
-		)
-			return;
+		if (!wrappedToolHandler || !wrappedInitializeHandler) return;
 
 		const activeSpanSpy = vi
 			.spyOn(trace, "getActiveSpan")
@@ -294,7 +268,7 @@ describe("Node package entrypoint", () => {
 
 		await expect(
 			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
-		).resolves.toEqual({ isError: true });
+		).resolves.toEqual({});
 		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
 			"mcp.span.category": "protocol",
 			"mcp.transport": "stdio",
@@ -302,9 +276,33 @@ describe("Node package entrypoint", () => {
 			"mcp.tool.name": "get-workouts",
 			"mcp.session.id": "test-session",
 		});
+		activeSpanSpy.mockRestore();
+	});
+
+	it("tracks SDK tool and discovery outcomes", async () => {
+		const toolHandler = vi
+			.fn()
+			.mockResolvedValueOnce({ isError: true })
+			.mockRejectedValueOnce(new Error("tool failure"));
+		const discoveryHandler = vi
+			.fn()
+			.mockResolvedValueOnce({ capabilities: [] })
+			.mockRejectedValueOnce(new Error("discovery failure"));
+		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
+		testDoubles.sdkProtocol._requestHandlers.set(
+			"server/discover",
+			discoveryHandler,
+		);
+		await createNodeMcpServer({ apiKey: "valid-key" });
+		const wrappedToolHandler =
+			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
+		const wrappedDiscoveryHandler =
+			testDoubles.sdkProtocol._requestHandlers.get("server/discover");
+		if (!wrappedToolHandler || !wrappedDiscoveryHandler) return;
+
 		await expect(
 			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
-		).resolves.toEqual({});
+		).resolves.toEqual({ isError: true });
 		await expect(
 			wrappedToolHandler({ params: { name: "bad name" } }, {}),
 		).rejects.toThrow("tool failure");
@@ -315,7 +313,22 @@ describe("Node package entrypoint", () => {
 			"discovery failure",
 		);
 
+		expect(testDoubles.recordTelemetryException).toHaveBeenCalled();
+	});
+
+	it("tracks SDK validation and protocol failures", async () => {
+		const previousOnError = vi.fn(() => {
+			throw new Error("previous SDK handler failure");
+		});
+		const createToolError = vi.fn((message: string) => ({ message }));
+		testDoubles.sdkProtocol.onerror = previousOnError;
+		testDoubles.server.createToolError = createToolError;
+		await createNodeMcpServer({ apiKey: "valid-key" });
+
 		testDoubles.sdkProtocol.onerror?.(new Error("protocol failure"));
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
 		testDoubles.server.createToolError?.("invalid tool");
 		testDoubles.sdkProtocol.onerror?.(new Error("active protocol failure"));
 
@@ -330,6 +343,7 @@ describe("Node package entrypoint", () => {
 		);
 		expect(testDoubles.recordTelemetryException).toHaveBeenCalled();
 		expect(createToolError).toHaveBeenCalledWith("invalid tool");
+		expect(previousOnError).toHaveBeenCalledTimes(2);
 		activeSpanSpy.mockRestore();
 	});
 

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -5,6 +5,7 @@ const testDoubles = vi.hoisted(() => {
 	const span = {
 		addEvent: vi.fn(),
 		setAttribute: vi.fn(),
+		setAttributes: vi.fn(),
 		setStatus: vi.fn(),
 		end: vi.fn(),
 	};
@@ -94,6 +95,10 @@ vi.mock("@hevy-mcp/hevy-client", () => ({
 vi.mock("@hevy-mcp/core", () => ({
 	createHevyMcpServer: testDoubles.createHevyMcpServer,
 	createSafeErrorDiagnostic: vi.fn(() => ({ category: "Error" })),
+	ErrorType: {
+		UNKNOWN_ERROR: "UNKNOWN_ERROR",
+		VALIDATION_ERROR: "VALIDATION_ERROR",
+	},
 }));
 
 vi.mock("@modelcontextprotocol/server/stdio", () => ({
@@ -224,6 +229,9 @@ describe("Node package entrypoint", () => {
 		expect(testDoubles.server.connect).not.toHaveBeenCalled();
 	});
 	it("tracks SDK tool, discovery, validation, and protocol failures", async () => {
+		const initializeHandler = vi
+			.fn()
+			.mockResolvedValue({ protocolVersion: "1" });
 		const toolHandler = vi
 			.fn()
 			.mockResolvedValueOnce({ isError: true })
@@ -238,6 +246,10 @@ describe("Node package entrypoint", () => {
 		});
 		const createToolError = vi.fn((message: string) => ({ message }));
 		testDoubles.sdkProtocol.onerror = previousOnError;
+		testDoubles.sdkProtocol._requestHandlers.set(
+			"initialize",
+			initializeHandler,
+		);
 		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
 		testDoubles.sdkProtocol._requestHandlers.set(
 			"server/discover",
@@ -251,15 +263,45 @@ describe("Node package entrypoint", () => {
 
 		const wrappedToolHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
+		const wrappedInitializeHandler =
+			testDoubles.sdkProtocol._requestHandlers.get("initialize");
 		const wrappedDiscoveryHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("server/discover");
 		expect(wrappedToolHandler).toBeDefined();
+		expect(wrappedInitializeHandler).toBeDefined();
 		expect(wrappedDiscoveryHandler).toBeDefined();
-		if (!wrappedToolHandler || !wrappedDiscoveryHandler) return;
+		if (
+			!wrappedToolHandler ||
+			!wrappedInitializeHandler ||
+			!wrappedDiscoveryHandler
+		)
+			return;
+
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
+		await expect(wrappedInitializeHandler({}, {})).resolves.toEqual({
+			protocolVersion: "1",
+		});
+		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
+			"mcp.span.category": "protocol",
+			"mcp.transport": "stdio",
+		});
+		expect(testDoubles.span.setAttributes).not.toHaveBeenCalledWith(
+			expect.objectContaining({ "mcp.session.id": expect.anything() }),
+		);
+		testDoubles.span.setAttributes.mockClear();
 
 		await expect(
 			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({ isError: true });
+		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
+			"mcp.span.category": "protocol",
+			"mcp.transport": "stdio",
+			"mcp.operation.kind": "tool",
+			"mcp.tool.name": "get-workouts",
+			"mcp.session.id": "test-session",
+		});
 		await expect(
 			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({});
@@ -274,18 +316,60 @@ describe("Node package entrypoint", () => {
 		);
 
 		testDoubles.sdkProtocol.onerror?.(new Error("protocol failure"));
-		const activeSpanSpy = vi
-			.spyOn(trace, "getActiveSpan")
-			.mockReturnValue(testDoubles.span as never);
 		testDoubles.server.createToolError?.("invalid tool");
 		testDoubles.sdkProtocol.onerror?.(new Error("active protocol failure"));
 
 		expect(testDoubles.span.addEvent).toHaveBeenCalledWith(
 			"mcp.tool.failure",
-			expect.objectContaining({ "mcp.tool.name": "unknown" }),
+			expect.objectContaining({
+				"mcp.tool.name": "unknown",
+				"mcp.failure.phase": "sdk",
+				"error.type": "VALIDATION_ERROR",
+				"error.category": "McpSdkValidationFailure",
+			}),
 		);
 		expect(testDoubles.recordTelemetryException).toHaveBeenCalled();
 		expect(createToolError).toHaveBeenCalledWith("invalid tool");
+		activeSpanSpy.mockRestore();
+	});
+
+	it("keeps SDK span enrichment best-effort and transport-aware", async () => {
+		const initializeHandler = vi.fn().mockResolvedValue({});
+		const toolHandler = vi.fn().mockResolvedValue({});
+		testDoubles.sdkProtocol._requestHandlers.set(
+			"initialize",
+			initializeHandler,
+		);
+		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
+		testDoubles.span.setAttributes.mockImplementationOnce(() => {
+			throw new Error("telemetry unavailable");
+		});
+
+		await expect(
+			createNodeMcpServer({ apiKey: "valid-key" }, "http"),
+		).resolves.toBe(testDoubles.server);
+		const wrappedInitialize =
+			testDoubles.sdkProtocol._requestHandlers.get("initialize");
+		const wrappedTool =
+			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
+		if (!wrappedInitialize || !wrappedTool) return;
+
+		await expect(wrappedInitialize({}, {})).resolves.toEqual({});
+		await expect(
+			wrappedTool({ params: { name: "get-workouts" } }, {}),
+		).resolves.toEqual({});
+		expect(initializeHandler).toHaveBeenCalledOnce();
+		expect(toolHandler).toHaveBeenCalledOnce();
+		expect(testDoubles.span.setAttributes).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				"mcp.span.category": "protocol",
+				"mcp.transport": "http",
+				"mcp.session.id": "test-session",
+			}),
+		);
 		activeSpanSpy.mockRestore();
 	});
 
@@ -380,8 +464,19 @@ describe("Node package entrypoint", () => {
 		);
 		expect(testDoubles.recordTelemetryException).toHaveBeenCalledWith(
 			expect.any(Error),
-			expect.objectContaining({ "error.category": "Error" }),
+			expect.objectContaining({
+				"error.type": "MCP_SERVER_BUILD_ERROR",
+				"error.category": "McpServerBuildFailure",
+			}),
 			testDoubles.span,
+		);
+		expect(testDoubles.span.addEvent).toHaveBeenCalledWith(
+			"mcp.lifecycle.failure",
+			expect.objectContaining({
+				"mcp.failure.phase": "build",
+				"error.type": "MCP_SERVER_BUILD_ERROR",
+				"error.category": "McpServerBuildFailure",
+			}),
 		);
 	});
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -13,14 +13,9 @@ import {
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { serverStartups } from "./utils/metrics.js";
 
-import { AsyncLocalStorage } from "node:async_hooks";
-import { SpanStatusCode, trace, type Span } from "@opentelemetry/api";
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
 import { z } from "zod";
-import {
-	createHevyMcpServer,
-	createSafeErrorDiagnostic,
-	ErrorType,
-} from "@hevy-mcp/core";
+import { createHevyMcpServer, createSafeErrorDiagnostic } from "@hevy-mcp/core";
 import { createHevyClient, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { assertApiKey, parseConfig } from "./utils/config.js";
 import { parseNodeCliOptions, type NodeTransport } from "./utils/arguments.js";
@@ -33,11 +28,10 @@ import {
 import { createNodeToolObserver } from "./utils/tool-observer.js";
 import { createInstrumentedStdioTransport } from "./utils/stdio-observability.js";
 import {
-	getCurrentMcpSessionId,
-	getCurrentMcpTransport,
 	recordMcpSessionTermination,
 	resolveSessionTerminationCategory,
 } from "./utils/mcp-session-observability.js";
+import { installSdkErrorTracking } from "./utils/sdk-observability.js";
 import { scheduleUpdateCheck } from "./utils/version-check.js";
 
 const name = serviceName;
@@ -142,123 +136,47 @@ function getSafeValidationDiagnostic(error: unknown): string | undefined {
 		? code
 		: undefined;
 }
-function recordLifecycleFailure(
-	span: Span,
-	error: unknown,
-	phase: "config" | "api_key_validation" | "build" | "connect" | "run",
-): void {
-	const diagnostic = createSafeErrorDiagnostic(error);
-	const taxonomy = {
-		config: {
-			errorType: "MCP_SERVER_CONFIG_ERROR",
-			errorCategory: "McpServerConfigFailure",
-		},
-		api_key_validation: {
-			errorType: "MCP_API_KEY_VALIDATION_ERROR",
-			errorCategory: "McpApiKeyValidationFailure",
-		},
-		build: {
-			errorType: "MCP_SERVER_BUILD_ERROR",
-			errorCategory: "McpServerBuildFailure",
-		},
-		connect: {
-			errorType: "MCP_TRANSPORT_CONNECT_ERROR",
-			errorCategory: "McpTransportConnectFailure",
-		},
-		run: {
-			errorType: "MCP_SERVER_RUN_ERROR",
-			errorCategory: "McpServerRunFailure",
-		},
-	}[phase];
-	const attributes = {
-		"mcp.failure.phase": phase,
-		"error.type": taxonomy.errorType,
-		"error.category": taxonomy.errorCategory,
-		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-		...(diagnostic.status !== undefined
-			? { "http.response.status_code": diagnostic.status }
-			: {}),
-		...(diagnostic.method ? { "http.request.method": diagnostic.method } : {}),
-		...(diagnostic.endpoint
-			? { "hevy.api.endpoint": diagnostic.endpoint }
-			: {}),
-	};
-	span.addEvent("mcp.lifecycle.failure", {
-		"mcp.failure.phase": phase,
-		"error.type": taxonomy.errorType,
-		"error.category": taxonomy.errorCategory,
-		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-	});
-	recordTelemetryException(error, attributes, span);
-}
-type SdkRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
+type LifecycleFailurePhase =
+	| "config"
+	| "api_key_validation"
+	| "build"
+	| "connect"
+	| "run";
 
-interface SdkProtocolInternals {
-	_requestHandlers?: Map<string, SdkRequestHandler>;
-}
-interface ToolRequestLike {
-	params?: { name?: unknown };
-}
-interface SdkToolErrorHost {
-	createToolError?: (message: string) => unknown;
-}
-
-interface ToolResultLike {
-	isError?: unknown;
-}
-
-const sdkToolNameStorage = new AsyncLocalStorage<string>();
-const SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
-
-type SdkFailureKind = "protocol" | "tool_call" | "validation";
-
-const SDK_FAILURE_TAXONOMY: Record<
-	SdkFailureKind,
-	{ errorType: ErrorType; errorCategory: string }
+const LIFECYCLE_FAILURE_TAXONOMY: Record<
+	LifecycleFailurePhase,
+	{ errorType: string; errorCategory: string }
 > = {
-	protocol: {
-		errorType: ErrorType.UNKNOWN_ERROR,
-		errorCategory: "McpSdkProtocolFailure",
+	config: {
+		errorType: "MCP_SERVER_CONFIG_ERROR",
+		errorCategory: "McpServerConfigFailure",
 	},
-	tool_call: {
-		errorType: ErrorType.UNKNOWN_ERROR,
-		errorCategory: "McpSdkToolCallFailure",
+	api_key_validation: {
+		errorType: "MCP_API_KEY_VALIDATION_ERROR",
+		errorCategory: "McpApiKeyValidationFailure",
 	},
-	validation: {
-		errorType: ErrorType.VALIDATION_ERROR,
-		errorCategory: "McpSdkValidationFailure",
+	build: {
+		errorType: "MCP_SERVER_BUILD_ERROR",
+		errorCategory: "McpServerBuildFailure",
+	},
+	connect: {
+		errorType: "MCP_TRANSPORT_CONNECT_ERROR",
+		errorCategory: "McpTransportConnectFailure",
+	},
+	run: {
+		errorType: "MCP_SERVER_RUN_ERROR",
+		errorCategory: "McpServerRunFailure",
 	},
 };
 
-function enrichActiveSdkSpan(
-	attributes: Record<string, string | number | boolean>,
-): void {
-	try {
-		trace.getActiveSpan()?.setAttributes(attributes);
-	} catch {
-		// SDK span enrichment is best-effort and cannot affect protocol handling.
-	}
-}
-
-function getSdkToolName(request: unknown): string {
-	if (!request || typeof request !== "object") return "unknown";
-	const candidate = (request as ToolRequestLike).params?.name;
-	return typeof candidate === "string" && SAFE_TOOL_NAME_PATTERN.test(candidate)
-		? candidate
-		: "unknown";
-}
-
-function markSdkToolFailure(
-	span: Span,
+function createLifecycleFailureAttributes(
 	error: unknown,
-	toolName = sdkToolNameStorage.getStore() ?? "unknown",
-	kind: SdkFailureKind = "tool_call",
-): void {
+	phase: LifecycleFailurePhase,
+): Record<string, string | number | boolean> {
 	const diagnostic = createSafeErrorDiagnostic(error);
-	const taxonomy = SDK_FAILURE_TAXONOMY[kind];
-	span.addEvent("mcp.tool.failure", {
-		"mcp.tool.name": toolName,
-		"mcp.failure.phase": "sdk",
+	const taxonomy = LIFECYCLE_FAILURE_TAXONOMY[phase];
+	return {
+		"mcp.failure.phase": phase,
 		"error.type": taxonomy.errorType,
 		"error.category": taxonomy.errorCategory,
 		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
@@ -269,209 +187,18 @@ function markSdkToolFailure(
 		...(diagnostic.endpoint
 			? { "hevy.api.endpoint": diagnostic.endpoint }
 			: {}),
-	});
-	span.setAttribute("error.type", taxonomy.errorType);
-	recordTelemetryException(
-		error,
-		{
-			"mcp.failure.phase": "sdk",
-			"error.type": taxonomy.errorType,
-			"error.category": taxonomy.errorCategory,
-			...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-			...(diagnostic.status !== undefined
-				? { "http.response.status_code": diagnostic.status }
-				: {}),
-		},
-		span,
-	);
-	span.setStatus({ code: SpanStatusCode.ERROR });
-}
-
-function installSdkErrorTracking(
-	server: {
-		server?: { onerror?: (error: Error) => void };
-	},
-	transport: NodeTransport,
-): void {
-	const protocol = server.server;
-	if (!protocol) return;
-	const previous = protocol.onerror;
-	protocol.onerror = (error) => {
-		const diagnostic = createSafeErrorDiagnostic(error);
-		const taxonomy = SDK_FAILURE_TAXONOMY.protocol;
-		const attributes = {
-			"mcp.failure.phase": "sdk",
-			"error.type": taxonomy.errorType,
-			"error.category": taxonomy.errorCategory,
-			...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-			...(diagnostic.status !== undefined
-				? { "http.response.status_code": diagnostic.status }
-				: {}),
-		};
-		const activeSpan = trace.getActiveSpan();
-		const sessionId = getCurrentMcpSessionId();
-		if (activeSpan) {
-			activeSpan.addEvent("mcp.tool.failure", {
-				"mcp.tool.name": sdkToolNameStorage.getStore() ?? "unknown",
-				"mcp.failure.phase": "sdk",
-				"error.type": taxonomy.errorType,
-				"error.category": taxonomy.errorCategory,
-				...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-			});
-			recordTelemetryException(error, attributes, activeSpan);
-		} else {
-			tracer.startActiveSpan(
-				"mcp.sdk.failure",
-				{
-					attributes: {
-						"mcp.span.category": "protocol",
-						"mcp.transport": transport,
-						...(sessionId ? { "mcp.session.id": sessionId } : {}),
-					},
-				},
-				(span) => {
-					span.addEvent("mcp.tool.failure", {
-						"mcp.tool.name": "unknown",
-						"mcp.failure.phase": "sdk",
-						"error.type": taxonomy.errorType,
-						"error.category": taxonomy.errorCategory,
-						...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-					});
-					recordTelemetryException(error, attributes, span);
-					span.end();
-				},
-			);
-		}
-		try {
-			previous?.(error);
-		} catch {
-			// Existing SDK/Sentry handlers must not affect protocol behavior.
-		}
 	};
-	const toolErrorHost = server as unknown as SdkToolErrorHost;
-	const previousCreateToolError = toolErrorHost.createToolError;
-	if (previousCreateToolError) {
-		const createToolError = previousCreateToolError.bind(server);
-		toolErrorHost.createToolError = (message) => {
-			const result = createToolError(message);
-			const activeSpan = trace.getActiveSpan();
-			if (activeSpan) {
-				markSdkToolFailure(
-					activeSpan,
-					new Error("MCP tool validation failed"),
-					undefined,
-					"validation",
-				);
-			}
-			return result;
-		};
-	}
-
-	const handlers = (protocol as unknown as SdkProtocolInternals)
-		._requestHandlers;
-	if (!(handlers instanceof Map)) return;
-
-	const initializeHandler = handlers.get("initialize");
-	if (initializeHandler) {
-		handlers.set("initialize", (request, extra) => {
-			enrichActiveSdkSpan({
-				"mcp.span.category": "protocol",
-				"mcp.transport": transport,
-			});
-			return initializeHandler(request, extra);
-		});
-	}
-
-	const toolHandler = handlers.get("tools/call");
-	if (toolHandler) {
-		handlers.set("tools/call", (request, extra) => {
-			const sessionId = getCurrentMcpSessionId();
-			const toolName = getSdkToolName(request);
-			const attributes = {
-				"mcp.span.category": "protocol",
-				"mcp.transport": transport,
-				"mcp.operation.kind": "tool",
-				"mcp.tool.name": toolName,
-				...(sessionId ? { "mcp.session.id": sessionId } : {}),
-			};
-			enrichActiveSdkSpan(attributes);
-			return sdkToolNameStorage.run(toolName, () =>
-				tracer.startActiveSpan(
-					"mcp.sdk.tools.call",
-					{
-						attributes,
-					},
-					async (span) => {
-						try {
-							const result = (await toolHandler(
-								request,
-								extra,
-							)) as ToolResultLike;
-							if (result?.isError === true) {
-								span.setAttribute("mcp.tool.outcome", "returned_error");
-								span.setStatus({ code: SpanStatusCode.ERROR });
-							} else {
-								span.setStatus({ code: SpanStatusCode.OK });
-							}
-							return result;
-						} catch (error) {
-							markSdkToolFailure(span, error, toolName);
-							throw error;
-						} finally {
-							span.end();
-						}
-					},
-				),
-			);
-		});
-	}
-
-	const discoveryHandler = handlers.get("server/discover");
-	if (discoveryHandler) {
-		handlers.set("server/discover", (request, extra) => {
-			const sessionId = getCurrentMcpSessionId();
-			return tracer.startActiveSpan(
-				"mcp.server.discover",
-				{
-					attributes: {
-						"mcp.span.category": "discovery",
-						"mcp.transport": getCurrentMcpTransport(),
-						...(sessionId ? { "mcp.session.id": sessionId } : {}),
-					},
-				},
-				async (span) => {
-					try {
-						const result = await discoveryHandler(request, extra);
-						span.setStatus({ code: SpanStatusCode.OK });
-						return result;
-					} catch (error) {
-						const diagnostic = createSafeErrorDiagnostic(error);
-						span.addEvent("mcp.discovery.failure", {
-							"mcp.failure.phase": "discovery",
-							"error.type": diagnostic.category,
-							"error.category": diagnostic.category,
-							...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-						});
-						recordTelemetryException(
-							error,
-							{
-								"mcp.failure.phase": "discovery",
-								"error.type": diagnostic.category,
-								"error.category": diagnostic.category,
-								...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
-							},
-							span,
-						);
-						throw error;
-					} finally {
-						span.end();
-					}
-				},
-			);
-		});
-	}
 }
 
+function recordLifecycleFailure(
+	span: Span,
+	error: unknown,
+	phase: LifecycleFailurePhase,
+): void {
+	const attributes = createLifecycleFailureAttributes(error, phase);
+	span.addEvent("mcp.lifecycle.failure", attributes);
+	recordTelemetryException(error, attributes, span);
+}
 async function validateApiKey(apiKey: string) {
 	// Keep the startup probe separate from the normal MCP-aware client. The
 	// server is not connected yet, so structured client logging is intentionally

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -16,7 +16,11 @@ import { serverStartups } from "./utils/metrics.js";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { SpanStatusCode, trace, type Span } from "@opentelemetry/api";
 import { z } from "zod";
-import { createHevyMcpServer, createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import {
+	createHevyMcpServer,
+	createSafeErrorDiagnostic,
+	ErrorType,
+} from "@hevy-mcp/core";
 import { createHevyClient, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { assertApiKey, parseConfig } from "./utils/config.js";
 import { parseNodeCliOptions, type NodeTransport } from "./utils/arguments.js";
@@ -144,10 +148,32 @@ function recordLifecycleFailure(
 	phase: "config" | "api_key_validation" | "build" | "connect" | "run",
 ): void {
 	const diagnostic = createSafeErrorDiagnostic(error);
+	const taxonomy = {
+		config: {
+			errorType: "MCP_SERVER_CONFIG_ERROR",
+			errorCategory: "McpServerConfigFailure",
+		},
+		api_key_validation: {
+			errorType: "MCP_API_KEY_VALIDATION_ERROR",
+			errorCategory: "McpApiKeyValidationFailure",
+		},
+		build: {
+			errorType: "MCP_SERVER_BUILD_ERROR",
+			errorCategory: "McpServerBuildFailure",
+		},
+		connect: {
+			errorType: "MCP_TRANSPORT_CONNECT_ERROR",
+			errorCategory: "McpTransportConnectFailure",
+		},
+		run: {
+			errorType: "MCP_SERVER_RUN_ERROR",
+			errorCategory: "McpServerRunFailure",
+		},
+	}[phase];
 	const attributes = {
 		"mcp.failure.phase": phase,
-		"error.type": diagnostic.category,
-		"error.category": diagnostic.category,
+		"error.type": taxonomy.errorType,
+		"error.category": taxonomy.errorCategory,
 		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 		...(diagnostic.status !== undefined
 			? { "http.response.status_code": diagnostic.status }
@@ -158,8 +184,9 @@ function recordLifecycleFailure(
 			: {}),
 	};
 	span.addEvent("mcp.lifecycle.failure", {
-		"error.type": diagnostic.category,
-		"error.category": diagnostic.category,
+		"mcp.failure.phase": phase,
+		"error.type": taxonomy.errorType,
+		"error.category": taxonomy.errorCategory,
 		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 	});
 	recordTelemetryException(error, attributes, span);
@@ -183,6 +210,36 @@ interface ToolResultLike {
 const sdkToolNameStorage = new AsyncLocalStorage<string>();
 const SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
 
+type SdkFailureKind = "protocol" | "tool_call" | "validation";
+
+const SDK_FAILURE_TAXONOMY: Record<
+	SdkFailureKind,
+	{ errorType: ErrorType; errorCategory: string }
+> = {
+	protocol: {
+		errorType: ErrorType.UNKNOWN_ERROR,
+		errorCategory: "McpSdkProtocolFailure",
+	},
+	tool_call: {
+		errorType: ErrorType.UNKNOWN_ERROR,
+		errorCategory: "McpSdkToolCallFailure",
+	},
+	validation: {
+		errorType: ErrorType.VALIDATION_ERROR,
+		errorCategory: "McpSdkValidationFailure",
+	},
+};
+
+function enrichActiveSdkSpan(
+	attributes: Record<string, string | number | boolean>,
+): void {
+	try {
+		trace.getActiveSpan()?.setAttributes(attributes);
+	} catch {
+		// SDK span enrichment is best-effort and cannot affect protocol handling.
+	}
+}
+
 function getSdkToolName(request: unknown): string {
 	if (!request || typeof request !== "object") return "unknown";
 	const candidate = (request as ToolRequestLike).params?.name;
@@ -195,14 +252,15 @@ function markSdkToolFailure(
 	span: Span,
 	error: unknown,
 	toolName = sdkToolNameStorage.getStore() ?? "unknown",
-	errorTypeOverride?: string,
+	kind: SdkFailureKind = "tool_call",
 ): void {
 	const diagnostic = createSafeErrorDiagnostic(error);
-	const errorType = errorTypeOverride ?? diagnostic.category;
+	const taxonomy = SDK_FAILURE_TAXONOMY[kind];
 	span.addEvent("mcp.tool.failure", {
 		"mcp.tool.name": toolName,
-		"error.type": errorType,
-		"error.category": diagnostic.category,
+		"mcp.failure.phase": "sdk",
+		"error.type": taxonomy.errorType,
+		"error.category": taxonomy.errorCategory,
 		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 		...(diagnostic.status !== undefined
 			? { "http.response.status_code": diagnostic.status }
@@ -212,13 +270,13 @@ function markSdkToolFailure(
 			? { "hevy.api.endpoint": diagnostic.endpoint }
 			: {}),
 	});
-	span.setAttribute("error.type", errorType);
+	span.setAttribute("error.type", taxonomy.errorType);
 	recordTelemetryException(
 		error,
 		{
 			"mcp.failure.phase": "sdk",
-			"error.type": errorType,
-			"error.category": diagnostic.category,
+			"error.type": taxonomy.errorType,
+			"error.category": taxonomy.errorCategory,
 			...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 			...(diagnostic.status !== undefined
 				? { "http.response.status_code": diagnostic.status }
@@ -229,17 +287,22 @@ function markSdkToolFailure(
 	span.setStatus({ code: SpanStatusCode.ERROR });
 }
 
-function installSdkErrorTracking(server: {
-	server?: { onerror?: (error: Error) => void };
-}): void {
+function installSdkErrorTracking(
+	server: {
+		server?: { onerror?: (error: Error) => void };
+	},
+	transport: NodeTransport,
+): void {
 	const protocol = server.server;
 	if (!protocol) return;
 	const previous = protocol.onerror;
 	protocol.onerror = (error) => {
 		const diagnostic = createSafeErrorDiagnostic(error);
+		const taxonomy = SDK_FAILURE_TAXONOMY.protocol;
 		const attributes = {
 			"mcp.failure.phase": "sdk",
-			"error.category": diagnostic.category,
+			"error.type": taxonomy.errorType,
+			"error.category": taxonomy.errorCategory,
 			...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 			...(diagnostic.status !== undefined
 				? { "http.response.status_code": diagnostic.status }
@@ -250,8 +313,9 @@ function installSdkErrorTracking(server: {
 		if (activeSpan) {
 			activeSpan.addEvent("mcp.tool.failure", {
 				"mcp.tool.name": sdkToolNameStorage.getStore() ?? "unknown",
-				"error.type": "UNKNOWN_ERROR",
-				"error.category": diagnostic.category,
+				"mcp.failure.phase": "sdk",
+				"error.type": taxonomy.errorType,
+				"error.category": taxonomy.errorCategory,
 				...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 			});
 			recordTelemetryException(error, attributes, activeSpan);
@@ -260,14 +324,17 @@ function installSdkErrorTracking(server: {
 				"mcp.sdk.failure",
 				{
 					attributes: {
+						"mcp.span.category": "protocol",
+						"mcp.transport": transport,
 						...(sessionId ? { "mcp.session.id": sessionId } : {}),
 					},
 				},
 				(span) => {
 					span.addEvent("mcp.tool.failure", {
 						"mcp.tool.name": "unknown",
-						"error.type": "UNKNOWN_ERROR",
-						"error.category": diagnostic.category,
+						"mcp.failure.phase": "sdk",
+						"error.type": taxonomy.errorType,
+						"error.category": taxonomy.errorCategory,
 						...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
 					});
 					recordTelemetryException(error, attributes, span);
@@ -293,7 +360,7 @@ function installSdkErrorTracking(server: {
 					activeSpan,
 					new Error("MCP tool validation failed"),
 					undefined,
-					"VALIDATION_ERROR",
+					"validation",
 				);
 			}
 			return result;
@@ -304,21 +371,35 @@ function installSdkErrorTracking(server: {
 		._requestHandlers;
 	if (!(handlers instanceof Map)) return;
 
+	const initializeHandler = handlers.get("initialize");
+	if (initializeHandler) {
+		handlers.set("initialize", (request, extra) => {
+			enrichActiveSdkSpan({
+				"mcp.span.category": "protocol",
+				"mcp.transport": transport,
+			});
+			return initializeHandler(request, extra);
+		});
+	}
+
 	const toolHandler = handlers.get("tools/call");
 	if (toolHandler) {
 		handlers.set("tools/call", (request, extra) => {
 			const sessionId = getCurrentMcpSessionId();
 			const toolName = getSdkToolName(request);
+			const attributes = {
+				"mcp.span.category": "protocol",
+				"mcp.transport": transport,
+				"mcp.operation.kind": "tool",
+				"mcp.tool.name": toolName,
+				...(sessionId ? { "mcp.session.id": sessionId } : {}),
+			};
+			enrichActiveSdkSpan(attributes);
 			return sdkToolNameStorage.run(toolName, () =>
 				tracer.startActiveSpan(
 					"mcp.sdk.tools.call",
 					{
-						attributes: {
-							"mcp.span.category": "protocol",
-							"mcp.operation.kind": "tool",
-							"mcp.tool.name": toolName,
-							...(sessionId ? { "mcp.session.id": sessionId } : {}),
-						},
+						attributes,
 					},
 					async (span) => {
 						try {
@@ -366,6 +447,7 @@ function installSdkErrorTracking(server: {
 					} catch (error) {
 						const diagnostic = createSafeErrorDiagnostic(error);
 						span.addEvent("mcp.discovery.failure", {
+							"mcp.failure.phase": "discovery",
 							"error.type": diagnostic.category,
 							"error.category": diagnostic.category,
 							...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
@@ -448,7 +530,7 @@ function buildServer(apiKey: string, transport: NodeTransport = "stdio") {
 					observer: createNodeToolObserver(),
 					cacheObserver: createNodeCacheObserver(),
 				});
-				installSdkErrorTracking(server);
+				installSdkErrorTracking(server, transport);
 				console.error("Hevy client initialized with API key");
 
 				span.setStatus({ code: SpanStatusCode.OK });

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -1,0 +1,295 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { SpanStatusCode, trace, type Span } from "@opentelemetry/api";
+import { createSafeErrorDiagnostic, ErrorType } from "@hevy-mcp/core";
+import type { NodeTransport } from "./arguments.js";
+import {
+	getCurrentMcpSessionId,
+	getCurrentMcpTransport,
+} from "./mcp-session-observability.js";
+import { recordTelemetryException, tracer } from "./telemetry.js";
+
+type SdkRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
+
+interface SdkProtocolInternals {
+	_requestHandlers?: Map<string, SdkRequestHandler>;
+}
+
+interface ToolRequestLike {
+	params?: { name?: unknown };
+}
+
+interface SdkToolErrorHost {
+	createToolError?: (message: string) => unknown;
+}
+
+interface ToolResultLike {
+	isError?: unknown;
+}
+
+type FailureAttributes = Record<string, string | number | boolean>;
+type SdkFailureKind = "protocol" | "tool_call" | "validation";
+
+const sdkToolNameStorage = new AsyncLocalStorage<string>();
+const SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
+const SDK_FAILURE_TAXONOMY: Record<
+	SdkFailureKind,
+	{ errorType: ErrorType; errorCategory: string }
+> = {
+	protocol: {
+		errorType: ErrorType.UNKNOWN_ERROR,
+		errorCategory: "McpSdkProtocolFailure",
+	},
+	tool_call: {
+		errorType: ErrorType.UNKNOWN_ERROR,
+		errorCategory: "McpSdkToolCallFailure",
+	},
+	validation: {
+		errorType: ErrorType.VALIDATION_ERROR,
+		errorCategory: "McpSdkValidationFailure",
+	},
+};
+
+function createFailureAttributes(
+	error: unknown,
+	phase: "discovery" | "sdk",
+	errorType: string,
+	errorCategory: string,
+): FailureAttributes {
+	const diagnostic = createSafeErrorDiagnostic(error);
+	return {
+		"mcp.failure.phase": phase,
+		"error.type": errorType,
+		"error.category": errorCategory,
+		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
+		...(diagnostic.status !== undefined
+			? { "http.response.status_code": diagnostic.status }
+			: {}),
+		...(diagnostic.method ? { "http.request.method": diagnostic.method } : {}),
+		...(diagnostic.endpoint
+			? { "hevy.api.endpoint": diagnostic.endpoint }
+			: {}),
+	};
+}
+
+function enrichActiveSdkSpan(attributes: FailureAttributes): void {
+	try {
+		trace.getActiveSpan()?.setAttributes(attributes);
+	} catch {
+		// SDK span enrichment is best-effort and cannot affect protocol handling.
+	}
+}
+
+function getSdkToolName(request: unknown): string {
+	if (!request || typeof request !== "object") return "unknown";
+	const candidate = (request as ToolRequestLike).params?.name;
+	return typeof candidate === "string" && SAFE_TOOL_NAME_PATTERN.test(candidate)
+		? candidate
+		: "unknown";
+}
+
+function markSdkToolFailure(
+	span: Span,
+	error: unknown,
+	toolName = sdkToolNameStorage.getStore() ?? "unknown",
+	kind: SdkFailureKind = "tool_call",
+): void {
+	const taxonomy = SDK_FAILURE_TAXONOMY[kind];
+	const attributes = createFailureAttributes(
+		error,
+		"sdk",
+		taxonomy.errorType,
+		taxonomy.errorCategory,
+	);
+	span.addEvent("mcp.tool.failure", {
+		"mcp.tool.name": toolName,
+		...attributes,
+	});
+	span.setAttribute("error.type", taxonomy.errorType);
+	recordTelemetryException(error, attributes, span);
+	span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+function installProtocolErrorTracking(
+	server: { server?: { onerror?: (error: Error) => void } },
+	transport: NodeTransport,
+): void {
+	const protocol = server.server;
+	if (!protocol) return;
+	const previous = protocol.onerror;
+	protocol.onerror = (error) => {
+		const taxonomy = SDK_FAILURE_TAXONOMY.protocol;
+		const attributes = createFailureAttributes(
+			error,
+			"sdk",
+			taxonomy.errorType,
+			taxonomy.errorCategory,
+		);
+		const activeSpan = trace.getActiveSpan();
+		const sessionId = getCurrentMcpSessionId();
+		if (activeSpan) {
+			activeSpan.addEvent("mcp.tool.failure", {
+				"mcp.tool.name": sdkToolNameStorage.getStore() ?? "unknown",
+				...attributes,
+			});
+			recordTelemetryException(error, attributes, activeSpan);
+		} else {
+			tracer.startActiveSpan(
+				"mcp.sdk.failure",
+				{
+					attributes: {
+						"mcp.span.category": "protocol",
+						"mcp.transport": transport,
+						...(sessionId ? { "mcp.session.id": sessionId } : {}),
+					},
+				},
+				(span) => {
+					span.addEvent("mcp.tool.failure", {
+						"mcp.tool.name": "unknown",
+						...attributes,
+					});
+					recordTelemetryException(error, attributes, span);
+					span.end();
+				},
+			);
+		}
+		try {
+			previous?.(error);
+		} catch {
+			// Existing SDK/Sentry handlers must not affect protocol behavior.
+		}
+	};
+}
+
+function installValidationErrorTracking(server: object): void {
+	const toolErrorHost = server as SdkToolErrorHost;
+	const previousCreateToolError = toolErrorHost.createToolError;
+	if (!previousCreateToolError) return;
+	const createToolError = previousCreateToolError.bind(server);
+	toolErrorHost.createToolError = (message) => {
+		const result = createToolError(message);
+		const activeSpan = trace.getActiveSpan();
+		if (activeSpan) {
+			markSdkToolFailure(
+				activeSpan,
+				new Error("MCP tool validation failed"),
+				undefined,
+				"validation",
+			);
+		}
+		return result;
+	};
+}
+
+function installInitializeEnrichment(
+	handlers: Map<string, SdkRequestHandler>,
+	transport: NodeTransport,
+): void {
+	const initializeHandler = handlers.get("initialize");
+	if (!initializeHandler) return;
+	handlers.set("initialize", (request, extra) => {
+		enrichActiveSdkSpan({
+			"mcp.span.category": "protocol",
+			"mcp.transport": transport,
+		});
+		return initializeHandler(request, extra);
+	});
+}
+
+function installToolCallTracking(
+	handlers: Map<string, SdkRequestHandler>,
+	transport: NodeTransport,
+): void {
+	const toolHandler = handlers.get("tools/call");
+	if (!toolHandler) return;
+	handlers.set("tools/call", (request, extra) => {
+		const sessionId = getCurrentMcpSessionId();
+		const toolName = getSdkToolName(request);
+		const attributes = {
+			"mcp.span.category": "protocol",
+			"mcp.transport": transport,
+			"mcp.operation.kind": "tool",
+			"mcp.tool.name": toolName,
+			...(sessionId ? { "mcp.session.id": sessionId } : {}),
+		};
+		enrichActiveSdkSpan(attributes);
+		return sdkToolNameStorage.run(toolName, () =>
+			tracer.startActiveSpan(
+				"mcp.sdk.tools.call",
+				{ attributes },
+				async (span) => {
+					try {
+						const result = (await toolHandler(
+							request,
+							extra,
+						)) as ToolResultLike;
+						if (result?.isError === true) {
+							span.setAttribute("mcp.tool.outcome", "returned_error");
+							span.setStatus({ code: SpanStatusCode.ERROR });
+						} else {
+							span.setStatus({ code: SpanStatusCode.OK });
+						}
+						return result;
+					} catch (error) {
+						markSdkToolFailure(span, error, toolName);
+						throw error;
+					} finally {
+						span.end();
+					}
+				},
+			),
+		);
+	});
+}
+
+function installDiscoveryTracking(
+	handlers: Map<string, SdkRequestHandler>,
+): void {
+	const discoveryHandler = handlers.get("server/discover");
+	if (!discoveryHandler) return;
+	handlers.set("server/discover", (request, extra) => {
+		const sessionId = getCurrentMcpSessionId();
+		return tracer.startActiveSpan(
+			"mcp.server.discover",
+			{
+				attributes: {
+					"mcp.span.category": "discovery",
+					"mcp.transport": getCurrentMcpTransport(),
+					...(sessionId ? { "mcp.session.id": sessionId } : {}),
+				},
+			},
+			async (span) => {
+				try {
+					const result = await discoveryHandler(request, extra);
+					span.setStatus({ code: SpanStatusCode.OK });
+					return result;
+				} catch (error) {
+					const attributes = createFailureAttributes(
+						error,
+						"discovery",
+						ErrorType.UNKNOWN_ERROR,
+						"McpServerDiscoveryFailure",
+					);
+					span.addEvent("mcp.discovery.failure", attributes);
+					recordTelemetryException(error, attributes, span);
+					throw error;
+				} finally {
+					span.end();
+				}
+			},
+		);
+	});
+}
+
+export function installSdkErrorTracking(
+	server: { server?: { onerror?: (error: Error) => void } },
+	transport: NodeTransport,
+): void {
+	installProtocolErrorTracking(server, transport);
+	installValidationErrorTracking(server);
+	const handlers = (server.server as SdkProtocolInternals | undefined)
+		?._requestHandlers;
+	if (!(handlers instanceof Map)) return;
+	installInitializeEnrichment(handlers, transport);
+	installToolCallTracking(handlers, transport);
+	installDiscoveryTracking(handlers);
+}

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -273,12 +273,18 @@ describe("telemetry initialization", () => {
 			expect.objectContaining({
 				"exception.type": "Error",
 				"exception.source": "uncaughtException",
+				"mcp.failure.phase": "uncaught_exception",
+				"error.type": "MCP_PROCESS_EXCEPTION",
+				"error.category": "McpProcessFailure",
 				"error.code": "ECONNREFUSED",
 			}),
 		);
 		expect(testDoubles.activeSpan.setAttributes).toHaveBeenCalledWith(
 			expect.objectContaining({
 				"exception.source": "uncaughtException",
+				"mcp.failure.phase": "uncaught_exception",
+				"error.type": "MCP_PROCESS_EXCEPTION",
+				"error.category": "McpProcessFailure",
 				"error.code": "ECONNREFUSED",
 			}),
 		);

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -13,6 +13,7 @@ const testDoubles = vi.hoisted(() => {
 
 	return {
 		activeSpan: {
+			addEvent: vi.fn(),
 			recordException: vi.fn(),
 			setAttribute: vi.fn(),
 			setAttributes: vi.fn(),
@@ -265,7 +266,16 @@ describe("telemetry initialization", () => {
 		cleanup();
 		cleanup();
 
-		expect(testDoubles.activeSpan.recordException).toHaveBeenCalledTimes(2);
+		expect(testDoubles.activeSpan.recordException).not.toHaveBeenCalled();
+		expect(testDoubles.activeSpan.addEvent).toHaveBeenCalledTimes(2);
+		expect(testDoubles.activeSpan.addEvent).toHaveBeenCalledWith(
+			"exception",
+			expect.objectContaining({
+				"exception.type": "Error",
+				"exception.source": "uncaughtException",
+				"error.code": "ECONNREFUSED",
+			}),
+		);
 		expect(testDoubles.activeSpan.setAttributes).toHaveBeenCalledWith(
 			expect.objectContaining({
 				"exception.source": "uncaughtException",
@@ -477,16 +487,34 @@ describe("telemetry initialization", () => {
 		expect(setAttribute).toHaveBeenCalledWith("user.hash", "abcdef0123");
 	});
 
-	it("preserves safe exception stacks", async () => {
+	it("exports only bounded exception attributes", async () => {
 		vi.resetModules();
 		const mod = await import("./telemetry.js");
-		const error = new Error("secret-exception-message");
+		const secret = "secret-exception-message";
+		const path = "/home/private/hevy-mcp/packages/node/src/index.ts";
+		const error = new Error(secret);
+		error.stack = `Error: ${secret}\n    at main (${path}:10:2)`;
 
-		mod.recordTelemetryException(error);
-
-		expect(testDoubles.activeSpan.recordException).toHaveBeenCalledWith({
-			name: "Error",
-			stack: error.stack,
+		mod.recordTelemetryException(error, {
+			"mcp.failure.phase": "run",
+			"error.type": "MCP_SERVER_RUN_ERROR",
+			"error.category": "McpServerRunFailure",
 		});
+
+		expect(testDoubles.activeSpan.recordException).not.toHaveBeenCalled();
+		expect(testDoubles.activeSpan.addEvent).toHaveBeenCalledWith("exception", {
+			"exception.type": "Error",
+			"mcp.failure.phase": "run",
+			"error.type": "MCP_SERVER_RUN_ERROR",
+			"error.category": "McpServerRunFailure",
+		});
+		const exported = JSON.stringify({
+			events: testDoubles.activeSpan.addEvent.mock.calls,
+			attributes: testDoubles.activeSpan.setAttributes.mock.calls,
+		});
+		expect(exported).not.toContain(secret);
+		expect(exported).not.toContain(path);
+		expect(exported).not.toContain("exception.message");
+		expect(exported).not.toContain("exception.stacktrace");
 	});
 });

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -56,6 +56,11 @@ export type ProcessExceptionSource = {
 	): void;
 };
 
+const PROCESS_FAILURE_TAXONOMY = {
+	uncaughtException: "uncaught_exception",
+	unhandledRejection: "unhandled_rejection",
+} as const;
+
 const SAFE_EXCEPTION_TYPES = new Set([
 	"AggregateError",
 	"DOMException",
@@ -133,20 +138,24 @@ export function installProcessExceptionTracking(
 	processLike: ProcessExceptionSource = process,
 ): () => void {
 	if (!telemetryEnabled) return () => {};
-	const recordProcessException = (source: string, error: unknown) => {
+	const recordProcessException = (
+		source: keyof typeof PROCESS_FAILURE_TAXONOMY,
+		error: unknown,
+	) => {
 		try {
 			tracer.startActiveSpan(
 				`mcp.process.${source}`,
 				{ attributes: { "mcp.span.category": "process" } },
 				(span) => {
 					try {
-						const normalized = normalizeTelemetryError(error);
 						const code = getSafeExceptionCode(error);
 						recordTelemetryException(
 							error,
 							{
 								"exception.source": source,
-								"error.category": normalized.name,
+								"mcp.failure.phase": PROCESS_FAILURE_TAXONOMY[source],
+								"error.type": "MCP_PROCESS_EXCEPTION",
+								"error.category": "McpProcessFailure",
 								...(code ? { "error.code": code } : {}),
 							},
 							span,

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -85,10 +85,7 @@ const SAFE_EXCEPTION_CODES = new Set([
 	"HEVY_RETRY_EXHAUSTED",
 ]);
 
-function normalizeTelemetryError(error: unknown): {
-	name: string;
-	stack?: string;
-} {
+function normalizeTelemetryError(error: unknown): { name: string } {
 	const candidate =
 		error instanceof Error && typeof error.name === "string"
 			? error.name
@@ -97,10 +94,7 @@ function normalizeTelemetryError(error: unknown): {
 		candidate && SAFE_EXCEPTION_TYPES.has(candidate)
 			? candidate
 			: "UnknownError";
-	return {
-		name,
-		...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
-	};
+	return { name };
 }
 
 function getSafeExceptionCode(error: unknown): string | undefined {
@@ -122,7 +116,10 @@ export function recordTelemetryException(
 		const target = span ?? trace.getActiveSpan();
 		if (!target) return;
 		const normalized = normalizeTelemetryError(error);
-		target.recordException(normalized);
+		target.addEvent("exception", {
+			...attributes,
+			"exception.type": normalized.name,
+		});
 		target.setAttribute("exception.type", normalized.name);
 		target.setAttribute("error.category", normalized.name);
 		if (attributes) target.setAttributes(attributes);


### PR DESCRIPTION
## Summary

- enrich the already-active MCP SDK `initialize` and `tools/call` spans with bounded protocol metadata
- attach the active opaque `mcp.session.id` to SDK tool-call spans while leaving pre-initialize spans uncorrelated
- replace raw OpenTelemetry exception recording with explicit privacy-safe exception events
- add bounded lifecycle, SDK, discovery, and process failure taxonomy
- isolate SDK hook instrumentation in a Node-only observability module

## Live 5.0.4 evidence

A live ClickHouse audit showed that application-owned 5.0.4 spans had substantially improved timing, parentage, session correlation, cache visibility, and resource metadata. Two residual gaps remained:

- 102 SDK-generated `tools/call <tool>` spans lacked `mcp.session.id` and `mcp.span.category`, and retained the non-canonical `StdioServerTransport` transport value
- 198 SDK-generated `initialize` spans lacked a category and canonical transport
- all 9 sampled failure spans exported `exception.stacktrace` values containing local/runtime path markers

No raw stack values are included here or retained by this change.

## Root cause

The existing #845 implementation created an enriched child `mcp.sdk.tools.call` span but did not update the SDK-generated parent span that was already active when the request handler ran. Separately, `recordTelemetryException()` delegated to OpenTelemetry `recordException()` with the original stack, which serialized `exception.stacktrace`.

## Changes

- Enrich the active SDK span through the public OpenTelemetry active-span API at the existing request-handler integration seam.
- Add `mcp.span.category=protocol`, canonical `mcp.transport=stdio|http`, and safe tool metadata.
- Add the active opaque `mcp.session.id` only for session-scoped tool calls; `initialize` intentionally receives no session ID.
- Keep enrichment best-effort so telemetry failures cannot change protocol behavior.
- Stop calling `recordException()`; emit an explicit `exception` event containing only allowlisted `exception.type` and bounded failure attributes.
- Add phase-specific lifecycle/SDK/process taxonomy while preserving canonical `mcp.tool.failure`, `mcp.lifecycle.failure`, and discovery failure event names.
- Reuse the existing MCP SDK `_requestHandlers` seam; this adds no new private SDK field dependency.
- Add a patch Changeset for `hevy-mcp`.

## Privacy impact

OTLP failure events no longer contain `exception.message` or `exception.stacktrace`. Tests assert that raw exception messages and local paths are absent. The change does not emit arguments, payloads, URLs, headers, tokens, filesystem paths, or user data.

## Validation

- `npm run build`
- `npx vitest run --exclude tests/integration/**`
- `npm run test:unit` — 65 files, 693 tests
- `npm run test:stdio` — 4 files, 42 tests
- focused telemetry/SDK/stdio suite — 3 files, 55 tests
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- two-axis Standards and Spec review, followed by verification re-review with no remaining findings

## Scope boundary

This PR does not change metric temporality or resource identity. Metric exemplars and maintained ClickStack dashboards remain tracked by #846. It also does not add a Node OpenTelemetry log pipeline.

Refs #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced telemetry for MCP protocol, validation, discovery, and tool-call outcomes.
  * Added richer session and transport context to diagnostic spans.
  * Improved lifecycle failure categorization for clearer troubleshooting.
* **Privacy**
  * Sanitized exported failure events to avoid exposing sensitive messages, file paths, or stack traces.
* **Reliability**
  * Telemetry and instrumentation failures no longer interrupt normal protocol behavior.
  * Preserved existing error handling while adding failure tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->