### PR TITLE
fix: close generated client output and detect drift #870

### DIFF
--- a/.changeset/strict-command-timeouts.md
+++ b/.changeset/strict-command-timeouts.md
@@ -1,0 +1,4 @@
+---
+---
+
+Harden generated client checker command cleanup and timeout handling.

--- a/scripts/check-generated-client.mjs
+++ b/scripts/check-generated-client.mjs
@@ -23,6 +23,7 @@ const generatedRoot = resolve(clientRoot, generatedRelative);
 const curatedBarrels = ["src/types.ts", "src/schemas.ts"];
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const DEFAULT_COMMAND_KILL_SIGNAL = "SIGTERM";
+const SIGKILL_GRACE_PERIOD_MS = 2_000;
 
 async function collectFiles(directory) {
 	try {
@@ -261,11 +262,13 @@ export function runCommand(
 		let timedOut = false;
 		let settled = false;
 		let timeoutHandle;
+		let gracePeriodHandle;
 
 		const finish = (callback) => {
 			if (settled) return;
 			settled = true;
 			if (timeoutHandle) clearTimeout(timeoutHandle);
+			if (gracePeriodHandle) clearTimeout(gracePeriodHandle);
 			callback();
 		};
 		const rejectWithMessage = (status, cause) => {
@@ -303,6 +306,14 @@ export function runCommand(
 				if (child.exitCode === null && child.signalCode === null) {
 					timedOut = true;
 					child.kill(killSignal);
+
+					if (killSignal !== "SIGKILL") {
+						gracePeriodHandle = setTimeout(() => {
+							if (child.exitCode === null && child.signalCode === null) {
+								child.kill("SIGKILL");
+							}
+						}, SIGKILL_GRACE_PERIOD_MS);
+					}
 				}
 			},
 			Math.max(1, commandTimeout - 1),
@@ -317,15 +328,15 @@ export function runCommand(
 			const code = error?.code ? ` (${error.code})` : "";
 			rejectWithMessage(`could not start${code}: ${error.message}`, error);
 		});
-		child.once("exit", (code, signal) => {
-			if (code === 0) {
-				finish(resolvePromise);
-				return;
-			}
+		child.once("close", (code, signal) => {
 			if (timedOut) {
 				rejectWithMessage(
 					`timed out after ${commandTimeout}ms; sent ${String(killSignal)}`,
 				);
+				return;
+			}
+			if (code === 0) {
+				finish(resolvePromise);
 				return;
 			}
 			rejectWithMessage(
@@ -355,6 +366,10 @@ async function createFixtureRepository(normalizedSpec) {
 		await cp(clientRoot, fixtureClient, {
 			recursive: true,
 			filter: (path) => !isNodeModulesPath(path),
+		});
+		await rm(resolve(fixtureClient, generatedRelative), {
+			recursive: true,
+			force: true,
 		});
 		await cp(
 			resolve(repositoryRoot, "tsconfig.base.json"),

--- a/scripts/check-generated-client.test.ts
+++ b/scripts/check-generated-client.test.ts
@@ -300,7 +300,7 @@ describe("generated client closure checks", () => {
 		const result = await checkGeneratedClient();
 
 		expect(result.generatedFiles).toBeGreaterThan(0);
-	}, 20_000);
+	}, 60_000);
 
 	it("reports a missing named public export", async () => {
 		const fixture = await materializeFixture(

--- a/scripts/check-generated-client.test.ts
+++ b/scripts/check-generated-client.test.ts
@@ -72,6 +72,43 @@ describe("generated client closure checks", () => {
 		expect(executable.args[0]).toMatch(/[\\/]bin[\\/]kubb\.cjs$/);
 	});
 
+	it("reports missing package metadata and executable declarations", async () => {
+		await expect(
+			resolvePackageExecutable("missing-generated-client-package", "missing"),
+		).rejects.toThrow(
+			"Unable to resolve missing-generated-client-package package metadata",
+		);
+		await expect(
+			resolvePackageExecutable("typescript", "missing"),
+		).rejects.toThrow(
+			"Package typescript does not declare a missing executable",
+		);
+	});
+
+	it("reports command startup and non-zero exit failures", async () => {
+		const root = await mkdtemp(
+			resolve(tmpdir(), "hevy-generated-client-command-failure-"),
+		);
+		const script = resolve(root, "fail.mjs");
+		try {
+			await expect(
+				runCommand(resolve(root, "missing-command"), [], root, {
+					timeout: 1_000,
+				}),
+			).rejects.toThrow(/failed: could not start \(ENOENT\)/);
+
+			await writeFile(
+				script,
+				'process.stderr.write("command failed\\n"); process.exitCode = 7;\n',
+			);
+			await expect(
+				runCommand(process.execPath, [script], root, { timeout: 1_000 }),
+			).rejects.toThrow(/failed: exited with code 7[\s\S]*command failed/);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("reports bounded command failures with timeout and captured output", async () => {
 		const root = await mkdtemp(
 			resolve(tmpdir(), "hevy-generated-client-command-timeout-"),
@@ -85,12 +122,74 @@ describe("generated client closure checks", () => {
 
 			await expect(
 				runCommand(process.execPath, [script], root, {
-					timeout: 200,
+					timeout: 1_000,
 					killSignal: "SIGTERM",
 				}),
 			).rejects.toMatchObject({
 				message: expect.stringMatching(
-					/failed: timed out after 200ms; sent SIGTERM[\s\S]*command started/,
+					/failed: timed out after 1000ms; sent SIGTERM[\s\S]*command started/,
+				),
+			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("treats a timed-out child that exits cleanly after SIGTERM as a failure", async () => {
+		const root = await mkdtemp(
+			resolve(tmpdir(), "hevy-generated-client-command-clean-exit-"),
+		);
+		const script = resolve(root, "exit-on-sigterm.mjs");
+		try {
+			await writeFile(
+				script,
+				[
+					'process.on("SIGTERM", () => process.exit(0));',
+					'process.stderr.write("process started\\n");',
+					"setInterval(() => {}, 1000);",
+				].join("\n"),
+			);
+
+			await expect(
+				runCommand(process.execPath, [script], root, {
+					timeout: 1_000,
+					killSignal: "SIGTERM",
+				}),
+			).rejects.toMatchObject({
+				message: expect.stringMatching(
+					/failed: timed out after 1000ms; sent SIGTERM[\s\S]*process started/,
+				),
+			});
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("forcefully terminates with SIGKILL after grace period if child ignores SIGTERM", async () => {
+		const root = await mkdtemp(
+			resolve(tmpdir(), "hevy-generated-client-command-sigkill-"),
+		);
+		const script = resolve(root, "ignore-sigterm.mjs");
+		try {
+			await writeFile(
+				script,
+				[
+					'process.on("SIGTERM", () => {',
+					'\tprocess.stderr.write("ignored SIGTERM\\n");',
+					"});",
+					'process.stderr.write("process started\\n");',
+					"setInterval(() => {}, 1000);",
+				].join("\n"),
+			);
+
+			await expect(
+				runCommand(process.execPath, [script], root, {
+					timeout: 1_000,
+					killSignal: "SIGTERM",
+				}),
+			).rejects.toMatchObject({
+				message: expect.stringMatching(
+					/failed: timed out after 1000ms; sent SIGTERM[\s\S]*process started/,
 				),
 			});
 		} finally {

--- a/scripts/check-generated-client.test.ts
+++ b/scripts/check-generated-client.test.ts
@@ -197,6 +197,44 @@ describe("generated client closure checks", () => {
 		}
 	});
 
+	it("uses SIGKILL directly when configured as the timeout signal", async () => {
+		const root = await mkdtemp(
+			resolve(tmpdir(), "hevy-generated-client-command-direct-sigkill-"),
+		);
+		const script = resolve(root, "sleep.mjs");
+		try {
+			await writeFile(script, "setInterval(() => {}, 1000);\n");
+
+			await expect(
+				runCommand(process.execPath, [script], root, {
+					timeout: 1_000,
+					killSignal: "SIGKILL",
+				}),
+			).rejects.toThrow(/failed: timed out after 1000ms; sent SIGKILL/);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reports a child terminated by a signal before the timeout", async () => {
+		const root = await mkdtemp(
+			resolve(tmpdir(), "hevy-generated-client-command-signal-"),
+		);
+		const script = resolve(root, "terminate.mjs");
+		try {
+			await writeFile(
+				script,
+				'setTimeout(() => process.kill(process.pid, "SIGTERM"), 50);\n',
+			);
+
+			await expect(
+				runCommand(process.execPath, [script], root, { timeout: 1_000 }),
+			).rejects.toThrow(/failed: terminated by signal SIGTERM/);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it("returns no differences when both comparison trees are absent", async () => {
 		const root = await mkdtemp(
 			resolve(tmpdir(), "hevy-generated-client-empty-trees-"),


### PR DESCRIPTION
## Primary changes

- Anchor Kubb generation to `packages/hevy-client` so invocation cwd cannot recreate a root runtime `src/` tree.
- Add a hermetic checked-spec → normalization → Kubb → formatting → public-barrel regeneration gate.
- Detect stale generated output, forbidden root output, and missing named public exports with focused fixtures.
- Harden generated-client command startup, timeout, signal, and cleanup handling, including a bounded `SIGKILL` fallback.
- Run the generation invariant through the existing `npm run check` lane.
- Add the package-policy-required cascaded patch Changeset.

## Reviewer walkthrough

1. Start with `packages/hevy-client/kubb.config.ts` and `scripts/check-generated-client.mjs` to verify package-rooted generation, checked-spec normalization, and temporary fixture comparison.
2. Follow `scripts/check-generated-client.test.ts` and `tests/fixtures/generated-client/` for stale output, forbidden root output, command failure/timeout, and curated public-export drift coverage.
3. Confirm `package.json` wires `check:generated` into `npm run check` and `.changeset/generated-client-closure.md` records the required cascaded patch release.

## Correctness and invariants

- Kubb output is anchored to `packages/hevy-client`, so invocation cwd cannot recreate a root runtime `src/` tree.
- Regeneration runs from the checked, normalized OpenAPI spec, formats the temporary output, and compares it byte-for-byte with the checked-in generated package.
- The check rejects forbidden root output, stale/missing/unexpected generated files, and curated-barrel references or public exports that no longer resolve.
- Command failures and timeouts are reported deterministically, with a bounded escalation from the configured kill signal to `SIGKILL` when needed.
- Generated runtime output and public behavior are unchanged; maintainers now get deterministic failures when generated output, output location, normalization, or curated public exports drift.

## Testing and QA

- `npm run build:client`
- `npm run check:openapi`
- `npm run check:boundaries`
- `npm run build`
- `npx vitest run --exclude tests/integration/**`
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- Focused generated-client tests cover regeneration, directory comparisons, command startup/exit/timeout handling, signal escalation, forbidden root output, and curated public-export drift.
- Independent Standards review: pass
- Independent Spec review: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command timeout handling to ensure stalled processes are terminated reliably.
  * Prevented cleanup issues during generated-client regeneration.
  * Improved handling of command startup failures, non-zero exits, and custom termination signals.

* **Tests**
  * Added coverage for timeout escalation, clean termination, and command failure scenarios.

* **Documentation**
  * Documented the strengthened command timeout and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #870

