### PR TITLE
feat: add execution outcomes and cancellation control (#871)

### DIFF
--- a/.changeset/quiet-execution-outcomes.md
+++ b/.changeset/quiet-execution-outcomes.md
@@ -1,0 +1,9 @@
+---
+"@hevy-mcp/hevy-client": minor
+"@hevy-mcp/core": minor
+"hevy-mcp": minor
+"@hevy-mcp/worker": minor
+"@chrisdoc/hevy-cli": minor
+---
+
+Add invocation-scoped cancellation, absolute deadlines, commit-state outcomes, and safe retry diagnostics across the Hevy client, MCP adapters, Worker, Node server, and CLI.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,25 @@
+import { DEFAULT_API_TIMEOUT_MS } from "@hevy-mcp/hevy-client";
 import { runCli } from "./main.js";
 
-const exitCode = await runCli({ argv: process.argv.slice(2) });
-if (exitCode !== 0) process.exitCode = exitCode;
+const lifecycleController = new AbortController();
+const abortOnSignal = (signal: NodeJS.Signals) => {
+	lifecycleController.abort(
+		new DOMException(`CLI shutdown requested by ${signal}`, "AbortError"),
+	);
+};
+process.once("SIGINT", abortOnSignal);
+process.once("SIGTERM", abortOnSignal);
+
+try {
+	const exitCode = await runCli({
+		argv: process.argv.slice(2),
+		execution: {
+			signal: lifecycleController.signal,
+			deadline: Date.now() + DEFAULT_API_TIMEOUT_MS,
+		},
+	});
+	if (exitCode !== 0) process.exitCode = exitCode;
+} finally {
+	process.removeListener("SIGINT", abortOnSignal);
+	process.removeListener("SIGTERM", abortOnSignal);
+}

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,7 +1,4 @@
-import {
-	createExecutionProjection,
-	createSafeErrorDiagnostic,
-} from "@hevy-mcp/core";
+import { createExecutionErrorProjection } from "@hevy-mcp/core";
 import { HevyHttpError, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { ConfigurationError, UsageError } from "./arguments.js";
 
@@ -27,7 +24,7 @@ function executionFields(
 		code: _code,
 		status: _status,
 		...execution
-	} = createExecutionProjection(createSafeErrorDiagnostic(error));
+	} = createExecutionErrorProjection(error);
 	return execution;
 }
 

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,3 +1,7 @@
+import {
+	createExecutionProjection,
+	createSafeErrorDiagnostic,
+} from "@hevy-mcp/core";
 import { HevyHttpError, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { ConfigurationError, UsageError } from "./arguments.js";
 
@@ -5,24 +9,49 @@ export class ApiResponseError extends Error {}
 
 export const EXIT = { configuration: 1, usage: 2, api: 3, network: 4 } as const;
 
-export function diagnostic(error: unknown): { code: number; message: string } {
+export interface CliDiagnostic {
+	code: number;
+	message: string;
+	outcome?: string;
+	phase?: string;
+	operation_safety?: string;
+	commit_state?: string;
+	safe_to_retry?: boolean;
+}
+
+function executionFields(
+	error: unknown,
+): Omit<CliDiagnostic, "code" | "message"> {
+	if (!isHevyHttpError(error)) return {};
+	const {
+		code: _code,
+		status: _status,
+		...execution
+	} = createExecutionProjection(createSafeErrorDiagnostic(error));
+	return execution;
+}
+
+export function diagnostic(error: unknown): CliDiagnostic {
 	if (error instanceof ConfigurationError)
 		return { code: EXIT.configuration, message: error.message };
 	if (error instanceof ApiResponseError)
 		return {
 			code: EXIT.api,
 			message: error.message.replace(/https?:\/\/\S+/gi, "[redacted]"),
+			...executionFields(error),
 		};
 	if (error instanceof HevyHttpError || isHevyHttpError(error)) {
 		if (error.status === 401)
 			return {
 				code: EXIT.api,
 				message: "Authentication failed; check HEVY_API_KEY",
+				...executionFields(error),
 			};
 		if (error.status !== undefined)
 			return {
 				code: EXIT.api,
 				message: `Hevy API request failed (HTTP ${error.status})`,
+				...executionFields(error),
 			};
 		return {
 			code: EXIT.network,
@@ -30,6 +59,7 @@ export function diagnostic(error: unknown): { code: number; message: string } {
 				error.code === "ETIMEDOUT"
 					? "Hevy API request timed out"
 					: "Unable to reach the Hevy API",
+			...executionFields(error),
 		};
 	}
 	if (error instanceof UsageError)

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -107,6 +107,7 @@ describe("CLI process contract", () => {
 	it("binds invocation control and projects execution fields in JSON errors", async () => {
 		const io = streams();
 		const signal = new AbortController().signal;
+		const deadline = Date.now() + 1_000;
 		const getWorkouts = vi.fn().mockRejectedValue(
 			new HevyHttpError("request failed", {
 				status: 503,
@@ -123,17 +124,18 @@ describe("CLI process contract", () => {
 			argv: ["workouts", "list", "--json"],
 			env: { HEVY_API_KEY: "key" },
 			clientFactory: () => mockClient(getWorkouts),
-			execution: { signal, deadline: Date.now() + 1_000 },
+			execution: { signal, deadline },
 			streams: io.streams,
 		});
 		expect(code).toBe(3);
 		expect(getWorkouts).toHaveBeenCalledWith(
 			{ page: 1, pageSize: 5 },
-			expect.objectContaining({ signal, deadline: expect.any(Number) }),
+			expect.objectContaining({ signal, deadline }),
 		);
 		expect(JSON.parse(io.err)).toMatchObject({
 			outcome: "deadline_exceeded",
 			phase: "response-content",
+			operation_safety: "read",
 			commit_state: "unknown",
 			safe_to_retry: false,
 		});

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -103,6 +103,41 @@ describe("CLI process contract", () => {
 		expect(getWorkouts).toHaveBeenCalledWith({ page: 2, pageSize: 10 });
 		expect(io.err).toBe("");
 	});
+
+	it("binds invocation control and projects execution fields in JSON errors", async () => {
+		const io = streams();
+		const signal = new AbortController().signal;
+		const getWorkouts = vi.fn().mockRejectedValue(
+			new HevyHttpError("request failed", {
+				status: 503,
+				method: "GET",
+				endpoint: "/v1/workouts",
+				phase: "response-content",
+				operationSafety: "read",
+				commitState: "unknown",
+				safeToRetry: false,
+				outcome: "deadline_exceeded",
+			}),
+		);
+		const code = await runCli({
+			argv: ["workouts", "list", "--json"],
+			env: { HEVY_API_KEY: "key" },
+			clientFactory: () => mockClient(getWorkouts),
+			execution: { signal, deadline: Date.now() + 1_000 },
+			streams: io.streams,
+		});
+		expect(code).toBe(3);
+		expect(getWorkouts).toHaveBeenCalledWith(
+			{ page: 1, pageSize: 5 },
+			expect.objectContaining({ signal, deadline: expect.any(Number) }),
+		);
+		expect(JSON.parse(io.err)).toMatchObject({
+			outcome: "deadline_exceeded",
+			phase: "response-content",
+			commit_state: "unknown",
+			safe_to_retry: false,
+		});
+	});
 });
 
 function mutationClient(): HevyClient {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,4 +1,5 @@
 import { createHevyClient, type HevyClient } from "@hevy-mcp/hevy-client";
+import { bindClientExecution, type ToolExecutionContext } from "@hevy-mcp/core";
 import { getApiKey } from "./auth.js";
 import { diagnostic, EXIT } from "./errors.js";
 import { readDataSource, type DataSourceReader } from "./input.js";
@@ -11,6 +12,7 @@ export interface RunCliOptions {
 	now?: () => Date;
 	readDataSource?: DataSourceReader;
 	streams?: Streams;
+	execution?: ToolExecutionContext;
 }
 
 export async function runCli(options: RunCliOptions): Promise<number> {
@@ -37,9 +39,12 @@ export async function runCli(options: RunCliOptions): Promise<number> {
 	try {
 		if (!metaCommand) {
 			const key = getApiKey(options.env ?? globalThis.process.env);
-			context.client = (
+			const createdClient = (
 				options.clientFactory ?? ((apiKey) => createHevyClient({ apiKey }))
 			)(key);
+			context.client = options.execution
+				? bindClientExecution(createdClient, options.execution)
+				: createdClient;
 		}
 		const exitCode = await runRoutes(options.argv, context);
 		if (state.error !== undefined) throw state.error;
@@ -51,7 +56,11 @@ export async function runCli(options: RunCliOptions): Promise<number> {
 		return 0;
 	} catch (error) {
 		const failure = diagnostic(error);
-		streams.stderr(`${failure.message}\n`);
+		if (options.argv.includes("--json")) {
+			streams.stderr(`${JSON.stringify(failure)}\n`);
+		} else {
+			streams.stderr(`${failure.message}\n`);
+		}
 		return failure.code;
 	}
 }

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -59,7 +59,6 @@ describe("bindClientExecution", () => {
 		const control = {
 			signal,
 			deadline: 123,
-			operation_safety: "read" as const,
 		};
 		const bound = bindClientExecution(methods, control) as unknown as Record<
 			string,
@@ -77,7 +76,7 @@ describe("bindClientExecution", () => {
 			const firstCall = spy.mock.calls.at(-1) ?? [];
 			expect(firstCall[index]).toMatchObject(control);
 
-			const existingOptions = { deadline: 456, operation_safety: "read" };
+			const existingOptions = { deadline: 456 };
 			const withOptions = [...baseArgs[method]];
 			withOptions[index] = existingOptions;
 			invoke(...withOptions);

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HevyClient } from "@hevy-mcp/hevy-client";
+import {
+	bindClientExecution,
+	createExecutionProjection,
+	HEVY_CLIENT_OPTION_INDEXES,
+} from "./execution.js";
+
+const baseArgs: { [K in keyof HevyClient]: unknown[] } = {
+	getWorkouts: [{ page: 1 }],
+	getWorkout: ["workout-1"],
+	createWorkout: [{ workout: {} }],
+	updateWorkout: ["workout-1", { workout: {} }],
+	getWorkoutCount: [],
+	getWorkoutEvents: [{ page: 1 }],
+	getRoutines: [{ page: 1 }],
+	getRoutineById: ["routine-1"],
+	createRoutine: [{ routine: {} }],
+	updateRoutine: ["routine-1", { routine: {} }],
+	getExerciseTemplates: [{ page: 1 }],
+	getExerciseTemplate: ["template-1"],
+	getExerciseHistory: ["template-1", { page: 1 }],
+	createExerciseTemplate: [{ exercise: {} }],
+	getRoutineFolders: [{ page: 1 }],
+	createRoutineFolder: [{ folder: {} }],
+	getRoutineFolder: ["folder-1"],
+	getBodyMeasurements: [{ page: 1 }],
+	getBodyMeasurement: ["2025-01-01"],
+	createBodyMeasurement: [{ body_measurement: {} }],
+	updateBodyMeasurement: ["2025-01-01", { body_measurement: {} }],
+	getUserInfo: [],
+};
+
+describe("bindClientExecution", () => {
+	it("binds unknown function properties without injecting options", () => {
+		const extra = vi.fn(function (this: object) {
+			return this;
+		});
+		const methods = {
+			...Object.fromEntries(
+				Object.keys(HEVY_CLIENT_OPTION_INDEXES).map((name) => [name, vi.fn()]),
+			),
+			extra,
+		} as unknown as HevyClient & { extra: typeof extra };
+
+		const bound = bindClientExecution(methods, {
+			deadline: 123,
+		}) as typeof methods;
+
+		expect(bound.extra()).toBe(methods);
+		expect(extra).toHaveBeenCalledOnce();
+	});
+
+	it("places merged control in every curated options slot", () => {
+		const methods = Object.fromEntries(
+			Object.keys(HEVY_CLIENT_OPTION_INDEXES).map((name) => [name, vi.fn()]),
+		) as unknown as HevyClient;
+		const signal = new AbortController().signal;
+		const control = {
+			signal,
+			deadline: 123,
+			operation_safety: "read" as const,
+		};
+		const bound = bindClientExecution(methods, control) as unknown as Record<
+			string,
+			(...args: unknown[]) => unknown
+		>;
+
+		for (const [name, index] of Object.entries(HEVY_CLIENT_OPTION_INDEXES)) {
+			const method = name as keyof HevyClient;
+			const invoke = bound[name];
+			const spy = (
+				methods as unknown as Record<string, ReturnType<typeof vi.fn>>
+			)[name];
+			const args = [...baseArgs[method]];
+			invoke(...args);
+			const firstCall = spy.mock.calls.at(-1) ?? [];
+			expect(firstCall[index]).toMatchObject(control);
+
+			const existingOptions = { deadline: 456, operation_safety: "read" };
+			const withOptions = [...baseArgs[method]];
+			withOptions[index] = existingOptions;
+			invoke(...withOptions);
+			const secondCall = spy.mock.calls.at(-1) ?? [];
+			expect(secondCall[index]).toMatchObject({
+				...existingOptions,
+				...control,
+			});
+			for (let i = 0; i < withOptions.length; i += 1) {
+				if (i === index) continue;
+				expect(secondCall[i]).toBe(withOptions[i]);
+			}
+		}
+	});
+
+	it("provides privacy-safe execution defaults for every adapter", () => {
+		expect(createExecutionProjection({ outcome: "cancelled" })).toEqual({
+			outcome: "cancelled",
+			phase: "before-dispatch",
+			operation_safety: "read",
+			commit_state: "not_sent",
+			safe_to_retry: false,
+		});
+	});
+});

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -23,6 +23,9 @@ export interface StructuredExecutionProjection {
 	readonly status?: number;
 }
 
+/** Backward-compatible name for the structured error projection. */
+export type StructuredExecutionError = StructuredExecutionProjection;
+
 export type ExecutionProjectionSource = Partial<
 	Pick<
 		StructuredExecutionProjection,

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -1,0 +1,131 @@
+import type {
+	HevyClient,
+	HevyCommitState,
+	HevyExecutionOutcome,
+	HevyOperationSafety,
+	HevyRequestOptions,
+	HevyRequestPhase,
+} from "@hevy-mcp/hevy-client";
+
+/** Per-request control supplied by MCP, HTTP, CLI, or a lifecycle owner. */
+export interface ToolExecutionContext extends HevyRequestOptions {
+	readonly requestId?: string;
+}
+
+/** Safe, adapter-neutral execution metadata used in every structured error. */
+export interface StructuredExecutionProjection {
+	readonly outcome: HevyExecutionOutcome;
+	readonly phase: HevyRequestPhase;
+	readonly operation_safety: HevyOperationSafety;
+	readonly commit_state: HevyCommitState;
+	readonly safe_to_retry: boolean;
+	readonly code?: string;
+	readonly status?: number;
+}
+
+export type ExecutionProjectionSource = Partial<
+	Pick<
+		StructuredExecutionProjection,
+		| "outcome"
+		| "phase"
+		| "operation_safety"
+		| "commit_state"
+		| "safe_to_retry"
+		| "code"
+		| "status"
+	>
+>;
+
+export function createExecutionProjection(
+	source?: ExecutionProjectionSource,
+): StructuredExecutionProjection {
+	return {
+		outcome: source?.outcome ?? "terminal_failure",
+		phase: source?.phase ?? "before-dispatch",
+		operation_safety: source?.operation_safety ?? "read",
+		commit_state: source?.commit_state ?? "not_sent",
+		safe_to_retry: source?.safe_to_retry ?? false,
+		...(source?.code ? { code: source.code } : {}),
+		...(source?.status !== undefined ? { status: source.status } : {}),
+	};
+}
+
+export function mergeAbortSignals(
+	...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined {
+	const active = signals.filter(
+		(signal): signal is AbortSignal => signal !== undefined,
+	);
+	if (active.length === 0) return undefined;
+	if (active.length === 1) return active[0];
+	// Node 24 and the supported Worker runtimes provide AbortSignal.any. The
+	// native composition owns listener cleanup when the derived signal settles,
+	// avoiding one retained lifecycle/request listener per invocation.
+	return AbortSignal.any(active);
+}
+
+type ClientMethod = keyof HevyClient;
+
+/**
+ * The curated client's options slot is deliberately explicit. Inferring it
+ * from the final argument is unsafe because IDs and request payloads are also
+ * objects/strings and most generated wrappers silently ignore extra args.
+ */
+/** Canonical options-slot metadata shared by binding and table-driven tests. */
+export const HEVY_CLIENT_OPTION_INDEXES: Record<ClientMethod, number> = {
+	getWorkouts: 1,
+	getWorkout: 1,
+	createWorkout: 1,
+	updateWorkout: 2,
+	getWorkoutCount: 0,
+	getWorkoutEvents: 1,
+	getRoutines: 1,
+	getRoutineById: 1,
+	createRoutine: 1,
+	updateRoutine: 2,
+	getExerciseTemplates: 1,
+	getExerciseTemplate: 1,
+	getExerciseHistory: 2,
+	createExerciseTemplate: 1,
+	getRoutineFolders: 1,
+	createRoutineFolder: 1,
+	getRoutineFolder: 1,
+	getBodyMeasurements: 1,
+	getBodyMeasurement: 1,
+	createBodyMeasurement: 1,
+	updateBodyMeasurement: 2,
+	getUserInfo: 0,
+};
+
+/**
+ * Bind one immutable control object to every curated client operation. A
+ * proxy keeps existing tool code source-compatible while making it impossible
+ * for one page of a workflow to silently lose cancellation/deadline state.
+ */
+export function bindClientExecution(
+	client: HevyClient,
+	control: ToolExecutionContext,
+): HevyClient {
+	return new Proxy(client, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (typeof value !== "function") return value;
+			const optionIndex =
+				property in HEVY_CLIENT_OPTION_INDEXES
+					? HEVY_CLIENT_OPTION_INDEXES[property as ClientMethod]
+					: undefined;
+			if (optionIndex === undefined) {
+				return value.bind(target);
+			}
+			return (...args: unknown[]) => {
+				const provided = args[optionIndex] as HevyRequestOptions | undefined;
+				const merged: HevyRequestOptions = {
+					...provided,
+					...control,
+				};
+				args[optionIndex] = merged;
+				return Reflect.apply(value, target, args);
+			};
+		},
+	}) as HevyClient;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,14 @@
 export {
+	HEVY_CLIENT_OPTION_INDEXES,
+	bindClientExecution,
+	createExecutionProjection,
+	mergeAbortSignals,
+	type ExecutionProjectionSource,
+	type StructuredExecutionProjection,
+	type ToolExecutionContext,
+} from "./execution.js";
+
+export {
 	createHevyMcpServer,
 	type CreateHevyMcpServerOptions,
 	type HevyClientFactoryContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
 export { createSafeErrorDiagnostic } from "./utils/safe-error-diagnostic.js";
 export {
 	createMcpToolFailureEvent,
+	createExecutionErrorProjection,
 	type McpToolFailureEvent,
 } from "./utils/error-handler.js";
 export { ErrorType } from "./utils/error-policy.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export {
 	createExecutionProjection,
 	mergeAbortSignals,
 	type ExecutionProjectionSource,
+	type StructuredExecutionError,
 	type StructuredExecutionProjection,
 	type ToolExecutionContext,
 } from "./execution.js";

--- a/packages/core/src/observation.ts
+++ b/packages/core/src/observation.ts
@@ -1,4 +1,5 @@
 import type { ErrorType, SafeErrorDiagnostic } from "./utils/error-policy.js";
+import type { StructuredExecutionProjection } from "./execution.js";
 import type {
 	ResultCountBucket,
 	ToolResultTelemetry,
@@ -80,6 +81,7 @@ export interface ToolCompletionObservation {
 	readonly result?: ToolResultObservation;
 	readonly errorType?: ErrorType;
 	readonly error?: SafeErrorDiagnostic;
+	readonly errorOutcome?: StructuredExecutionProjection;
 }
 
 export interface ToolObservationScope {

--- a/packages/core/src/resources/hevy.test.ts
+++ b/packages/core/src/resources/hevy.test.ts
@@ -9,7 +9,7 @@ import type {
 	ExerciseTemplate,
 	RoutineFolder,
 } from "@hevy-mcp/hevy-client/types";
-import type { HevyClient } from "@hevy-mcp/hevy-client";
+import { HevyHttpError, type HevyClient } from "@hevy-mcp/hevy-client";
 import { projectRoutineFolder } from "../utils/response-contracts.js";
 import {
 	createExerciseTemplateCatalog,
@@ -236,14 +236,22 @@ describe("registerHevyResources", () => {
 			createTestContext(3),
 		);
 
-		expect(vi.mocked(hevyClient.getRoutineFolders)).toHaveBeenNthCalledWith(1, {
-			page: 1,
-			pageSize: 10,
-		});
-		expect(vi.mocked(hevyClient.getRoutineFolders)).toHaveBeenNthCalledWith(2, {
-			page: 2,
-			pageSize: 10,
-		});
+		expect(vi.mocked(hevyClient.getRoutineFolders)).toHaveBeenNthCalledWith(
+			1,
+			{ page: 1, pageSize: 10 },
+			expect.objectContaining({
+				signal: expect.any(AbortSignal),
+				deadline: expect.any(Number),
+			}),
+		);
+		expect(vi.mocked(hevyClient.getRoutineFolders)).toHaveBeenNthCalledWith(
+			2,
+			{ page: 2, pageSize: 10 },
+			expect.objectContaining({
+				signal: expect.any(AbortSignal),
+				deadline: expect.any(Number),
+			}),
+		);
 		const serializedFolders = parseJsonContent(result).data;
 		expect(serializedFolders).toEqual([
 			projectRoutineFolder(firstFolder),
@@ -306,7 +314,7 @@ describe("registerHevyResources", () => {
 		expect(parseJsonContent(result).data).toEqual([]);
 	});
 
-	it("shares the template catalog cache and in-flight fetch with search", async () => {
+	it("shares completed catalog values while isolating controlled in-flight calls", async () => {
 		const { registerResource, server, tool } = createMockServer();
 		let resolveCatalog!: (value: {
 			page: number;
@@ -344,7 +352,7 @@ describe("registerHevyResources", () => {
 			refresh: false,
 		});
 
-		expect(vi.mocked(hevyClient.getExerciseTemplates)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(hevyClient.getExerciseTemplates)).toHaveBeenCalledTimes(2);
 		resolveCatalog({
 			page: 1,
 			page_count: 1,
@@ -361,21 +369,37 @@ describe("registerHevyResources", () => {
 		]);
 	});
 
-	it("propagates initialization and API failures", async () => {
+	it("returns structured outcomes for initialization and API failures", async () => {
 		const { registerResource, server } = createMockServer();
 		registerHevyResources(server, createTestRuntime(null));
 		const userRegistration = getResourceRegistration(
 			registerResource,
 			"user-profile",
 		);
-		await expect(
-			userRegistration.handler(
-				new URL(userRegistration.uri),
-				createTestContext(5),
-			),
-		).rejects.toThrow("API client not initialized");
+		const uninitializedResult = await userRegistration.handler(
+			new URL(userRegistration.uri),
+			createTestContext(5),
+		);
+		expect(parseJsonContent(uninitializedResult).data).toEqual({
+			error: {
+				outcome: "terminal_failure",
+				phase: "before-dispatch",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
 
-		const apiFailure = new Error("Hevy API unavailable");
+		const apiFailure = new HevyHttpError("Hevy API unavailable", {
+			status: 503,
+			method: "GET",
+			endpoint: "/v1/workouts/count",
+			phase: "response-content",
+			operationSafety: "read",
+			commitState: "not_sent",
+			safeToRetry: false,
+			outcome: "terminal_failure",
+		});
 		const failedServer = createMockServer();
 		registerHevyResources(
 			failedServer.server,
@@ -387,11 +411,22 @@ describe("registerHevyResources", () => {
 			failedServer.registerResource,
 			"workout-count",
 		);
-		await expect(
-			countRegistration.handler(
-				new URL(countRegistration.uri),
-				createTestContext(6),
-			),
-		).rejects.toBe(apiFailure);
+		const apiFailureResult = await countRegistration.handler(
+			new URL(countRegistration.uri),
+			createTestContext(6),
+		);
+		expect(parseJsonContent(apiFailureResult).data).toEqual({
+			error: {
+				status: 503,
+				outcome: "terminal_failure",
+				phase: "response-content",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
+		expect(JSON.stringify(apiFailureResult)).not.toContain(
+			"Hevy API unavailable",
+		);
 	});
 });

--- a/packages/core/src/resources/hevy.ts
+++ b/packages/core/src/resources/hevy.ts
@@ -11,8 +11,7 @@ import type {
 import type { ToolRuntime } from "../tools/tool-runtime.js";
 import { fetchAllPages } from "../utils/pagination.js";
 import { projectRoutineFolder } from "../utils/response-contracts.js";
-import { createExecutionProjection } from "../execution.js";
-import { createSafeErrorDiagnostic } from "../utils/safe-error-diagnostic.js";
+import { createExecutionErrorProjection } from "../utils/error-handler.js";
 
 const JSON_MIME_TYPE = "application/json";
 
@@ -33,7 +32,7 @@ function createResourceErrorResult(
 	error: unknown,
 ): ReadResourceResult {
 	return createJsonResourceResult(uri, {
-		error: createExecutionProjection(createSafeErrorDiagnostic(error)),
+		error: createExecutionErrorProjection(error),
 	});
 }
 

--- a/packages/core/src/resources/hevy.ts
+++ b/packages/core/src/resources/hevy.ts
@@ -1,6 +1,7 @@
 import type {
 	McpServer,
 	ReadResourceResult,
+	ServerContext,
 } from "@modelcontextprotocol/server";
 import type {
 	GetV1WorkoutsCount200,
@@ -10,6 +11,8 @@ import type {
 import type { ToolRuntime } from "../tools/tool-runtime.js";
 import { fetchAllPages } from "../utils/pagination.js";
 import { projectRoutineFolder } from "../utils/response-contracts.js";
+import { createExecutionProjection } from "../execution.js";
+import { createSafeErrorDiagnostic } from "../utils/safe-error-diagnostic.js";
 
 const JSON_MIME_TYPE = "application/json";
 
@@ -23,6 +26,26 @@ function createJsonResourceResult(uri: URL, data: unknown): ReadResourceResult {
 			},
 		],
 	};
+}
+
+function createResourceErrorResult(
+	uri: URL,
+	error: unknown,
+): ReadResourceResult {
+	return createJsonResourceResult(uri, {
+		error: createExecutionProjection(createSafeErrorDiagnostic(error)),
+	});
+}
+
+async function readResource(
+	uri: URL,
+	read: () => Promise<ReadResourceResult>,
+): Promise<ReadResourceResult> {
+	try {
+		return await read();
+	} catch (error) {
+		return createResourceErrorResult(uri, error);
+	}
 }
 
 async function fetchAllRoutineFolders(
@@ -49,10 +72,12 @@ export function registerHevyResources(
 			description: "Authenticated Hevy user profile",
 			mimeType: JSON_MIME_TYPE,
 		},
-		async (uri) => {
-			const data: UserInfoResponse = await runtime.getClient().getUserInfo();
-			return createJsonResourceResult(uri, data?.data ?? null);
-		},
+		async (uri, context: ServerContext) =>
+			readResource(uri, async () => {
+				const scoped = runtime.forExecution({ signal: context.mcpReq.signal });
+				const data: UserInfoResponse = await scoped.getClient().getUserInfo();
+				return createJsonResourceResult(uri, data?.data ?? null);
+			}),
 	);
 
 	server.registerResource(
@@ -62,14 +87,16 @@ export function registerHevyResources(
 			description: "Total number of workouts in the Hevy account",
 			mimeType: JSON_MIME_TYPE,
 		},
-		async (uri) => {
-			const data: GetV1WorkoutsCount200 = await runtime
-				.getClient()
-				.getWorkoutCount();
-			return createJsonResourceResult(uri, {
-				workout_count: data?.workout_count ?? 0,
-			});
-		},
+		async (uri, context: ServerContext) =>
+			readResource(uri, async () => {
+				const scoped = runtime.forExecution({ signal: context.mcpReq.signal });
+				const data: GetV1WorkoutsCount200 = await scoped
+					.getClient()
+					.getWorkoutCount();
+				return createJsonResourceResult(uri, {
+					workout_count: data?.workout_count ?? 0,
+				});
+			}),
 	);
 
 	server.registerResource(
@@ -79,10 +106,12 @@ export function registerHevyResources(
 			description: "Full formatted Hevy exercise template catalog",
 			mimeType: JSON_MIME_TYPE,
 		},
-		async (uri) => {
-			const templates = await runtime.catalog.get();
-			return createJsonResourceResult(uri, templates);
-		},
+		async (uri, context: ServerContext) =>
+			readResource(uri, async () => {
+				const scoped = runtime.forExecution({ signal: context.mcpReq.signal });
+				const templates = await scoped.catalog.get();
+				return createJsonResourceResult(uri, templates);
+			}),
 	);
 
 	server.registerResource(
@@ -92,9 +121,12 @@ export function registerHevyResources(
 			description: "Full formatted list of Hevy routine folders",
 			mimeType: JSON_MIME_TYPE,
 		},
-		async (uri) => {
-			const folders = await fetchAllRoutineFolders(runtime);
-			return createJsonResourceResult(uri, folders.map(projectRoutineFolder));
-		},
+		async (uri, context: ServerContext) =>
+			readResource(uri, async () => {
+				const folders = await fetchAllRoutineFolders(
+					runtime.forExecution({ signal: context.mcpReq.signal }),
+				);
+				return createJsonResourceResult(uri, folders.map(projectRoutineFolder));
+			}),
 	);
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -23,6 +23,11 @@ export interface CreateHevyMcpServerOptions {
 	readonly cacheObserver?: CacheObserver;
 	readonly decorateServer?: (server: McpServer) => McpServer;
 	readonly onToolsRegistered?: (count: number) => void;
+	/** One absolute budget for each incoming MCP invocation. */
+	readonly executionTimeoutMs?: number;
+	/** Absolute deadline shared by validation and every tool call in one invocation. */
+	readonly executionDeadline?: number;
+	readonly lifecycleSignal?: AbortSignal;
 }
 
 function createCountingServer(server: McpServer) {
@@ -58,6 +63,9 @@ export function createHevyMcpServer(
 		catalog: createExerciseTemplateCatalog(client, options.cacheObserver),
 		logger: mcpLogger,
 		observer: options.observer,
+		executionTimeoutMs: options.executionTimeoutMs,
+		executionDeadline: options.executionDeadline,
+		lifecycleSignal: options.lifecycleSignal,
 	});
 	const counting = createCountingServer(server);
 	registerHevyTools(counting.server, runtime);

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -46,10 +46,13 @@ export function registerToolDefinition(
 ): void {
 	const directHandler = createTypedToolHandler(
 		definition.inputSchema,
-		async (args) =>
+		async (args, requestContext) =>
 			respond(
 				definition.responseContract,
-				await definition.execute(runtime, args),
+				await definition.execute(
+					requestContext ? runtime.forExecution(requestContext) : runtime,
+					args,
+				),
 			),
 	);
 	const handler = runtime.createHandler(directHandler, definition.name, {
@@ -71,5 +74,15 @@ export function registerToolDefinition(
 			: {}),
 	};
 
-	server.registerTool(definition.name, config, callback);
+	server.registerTool(definition.name, config, (args, context) =>
+		callback(
+			args,
+			context
+				? {
+						signal: context.mcpReq.signal,
+						requestId: String(context.mcpReq.id),
+					}
+				: undefined,
+		),
+	);
 }

--- a/packages/core/src/tools/tool-runtime.test.ts
+++ b/packages/core/src/tools/tool-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { HevyClient } from "@hevy-mcp/hevy-client";
 import { createToolRuntime } from "./tool-runtime.js";
 
 const runImmediately = <T>(operation: () => Promise<T>): Promise<T> =>
@@ -194,5 +195,29 @@ describe("createToolRuntime observation scope", () => {
 		);
 		expect(JSON.stringify(finish.mock.calls)).not.toContain(secret);
 		stderr.mockRestore();
+	});
+
+	it("lets the newest nested execution scope control the client", async () => {
+		const getUserInfo = vi.fn().mockResolvedValue({ data: { id: "user" } });
+		const client = { getUserInfo } as unknown as HevyClient;
+		const runtime = createToolRuntime({ client, catalog });
+		const firstSignal = new AbortController().signal;
+		const secondSignal = new AbortController().signal;
+		const first = runtime.forExecution({
+			signal: firstSignal,
+			deadline: 111,
+		});
+		const second = first.forExecution({
+			signal: secondSignal,
+			deadline: 222,
+		});
+
+		expect(second.executionDeadline).toBe(222);
+		await second.getClient().getUserInfo();
+
+		expect(getUserInfo).toHaveBeenCalledWith({
+			signal: secondSignal,
+			deadline: 222,
+		});
 	});
 });

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -15,6 +15,12 @@ import {
 } from "../observation.js";
 import { bucketCount, getResultTelemetry } from "../utils/result-telemetry.js";
 import { resolveErrorPolicy } from "../utils/error-policy.js";
+import {
+	bindClientExecution,
+	mergeAbortSignals,
+	type ToolExecutionContext,
+} from "../execution.js";
+import { DEFAULT_API_TIMEOUT_MS } from "@hevy-mcp/hevy-client";
 
 const STRUCTURAL_ARGUMENT_KEYS: Readonly<Record<string, true>> = {
 	page: true,
@@ -109,7 +115,7 @@ function createSafeInvocation(
 
 export type ToolHandler<
 	TParams extends Record<string, unknown> = Record<string, unknown>,
-> = (args: TParams) => Promise<McpToolResponse>;
+> = (args: TParams, context?: ToolExecutionContext) => Promise<McpToolResponse>;
 
 export type ToolHandlerFactory = <TParams extends Record<string, unknown>>(
 	fn: ToolHandler<TParams>,
@@ -120,16 +126,27 @@ export interface ToolRuntime {
 	readonly client: HevyClient | null;
 	readonly catalog: ExerciseTemplateCatalog;
 	readonly logger?: McpClientLogger;
+	readonly execution?: ToolExecutionContext;
+	readonly executionTimeoutMs: number;
+	readonly executionDeadline?: number;
+	readonly lifecycleSignal?: AbortSignal;
 	readonly createHandler: ToolHandlerFactory;
 	getClient(): HevyClient;
+	forExecution(context?: ToolExecutionContext): ToolRuntime;
 }
 
 export interface CreateToolRuntimeOptions {
 	client: HevyClient | null;
+	/** Unbound client retained across nested execution scopes. */
+	baseClient?: HevyClient | null;
 	catalog: ExerciseTemplateCatalog;
 	logger?: McpClientLogger;
 	createHandler?: ToolHandlerFactory;
 	observer?: ToolObserver;
+	execution?: ToolExecutionContext;
+	executionTimeoutMs?: number;
+	executionDeadline?: number;
+	lifecycleSignal?: AbortSignal;
 }
 
 export const defaultHandlerFactory: ToolHandlerFactory = <
@@ -141,11 +158,18 @@ export const defaultHandlerFactory: ToolHandlerFactory = <
 
 export function createToolRuntime({
 	client,
+	baseClient,
 	catalog,
 	logger,
 	createHandler = defaultHandlerFactory,
 	observer,
+	execution,
+	executionTimeoutMs = DEFAULT_API_TIMEOUT_MS,
+	executionDeadline,
+	lifecycleSignal,
 }: CreateToolRuntimeOptions): ToolRuntime {
+	const rawClient = baseClient ?? client;
+	const effectiveExecutionDeadline = executionDeadline ?? execution?.deadline;
 	const createObservedHandler: ToolHandlerFactory = <
 		TParams extends Record<string, unknown>,
 	>(
@@ -154,7 +178,7 @@ export function createToolRuntime({
 		metadata?: ToolTelemetryMetadata,
 	) =>
 		createHandler<TParams>(
-			async (args: TParams) => {
+			async (args: TParams, requestContext?: ToolExecutionContext) => {
 				let scope;
 				try {
 					scope = memoizeObservationScope(
@@ -166,7 +190,9 @@ export function createToolRuntime({
 				const startedAt = Date.now();
 				let handlerPromise: Promise<McpToolResponse> | undefined;
 				const invokeHandler = () => {
-					handlerPromise ??= Promise.resolve().then(() => fn(args));
+					handlerPromise ??= Promise.resolve().then(() =>
+						fn(args, requestContext),
+					);
 					return handlerPromise;
 				};
 				try {
@@ -184,6 +210,9 @@ export function createToolRuntime({
 					void scope?.finish({
 						outcome: result.isError ? "returned_error" : "success",
 						durationMs: Date.now() - startedAt,
+						...(result.errorOutcome
+							? { errorOutcome: result.errorOutcome }
+							: {}),
 						result: {
 							isError: Boolean(result.isError),
 							hasStructuredContent: result.structuredContent !== undefined,
@@ -209,13 +238,50 @@ export function createToolRuntime({
 	const observedHandlerFactory = observer
 		? createObservedHandler
 		: createHandler;
-	return {
+	const runtime: ToolRuntime = {
 		client,
-		catalog,
+		catalog: execution
+			? {
+					get: (options) => catalog.get({ ...options, execution }),
+					reset: () => catalog.reset(),
+				}
+			: catalog,
 		logger,
+		execution,
+		executionTimeoutMs,
+		executionDeadline: effectiveExecutionDeadline,
+		lifecycleSignal,
 		createHandler: observedHandlerFactory,
 		getClient: () => requireClient(client),
+		forExecution: (nextExecution) =>
+			createToolRuntime({
+				client: rawClient,
+				baseClient: rawClient,
+				catalog,
+				logger,
+				createHandler,
+				observer,
+				execution: {
+					...(nextExecution ?? {}),
+					signal: mergeAbortSignals(lifecycleSignal, nextExecution?.signal),
+					deadline:
+						nextExecution?.deadline ??
+						effectiveExecutionDeadline ??
+						Date.now() + executionTimeoutMs,
+				},
+				executionTimeoutMs,
+				executionDeadline:
+					nextExecution?.deadline ?? effectiveExecutionDeadline,
+				lifecycleSignal,
+			}),
 	};
+	if (execution && client) {
+		Object.assign(runtime, {
+			client: bindClientExecution(requireClient(rawClient), execution),
+			getClient: () => bindClientExecution(requireClient(rawClient), execution),
+		});
+	}
+	return runtime;
 }
 
 export { HEVY_CLIENT_NOT_INITIALIZED_ERROR };

--- a/packages/core/src/utils/cache.test.ts
+++ b/packages/core/src/utils/cache.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
 import { AsyncTtlCache } from "./cache.js";
 
 describe("AsyncTtlCache", () => {
@@ -135,6 +136,95 @@ describe("AsyncTtlCache", () => {
 
 		expect(fetcher).toHaveBeenCalledTimes(2);
 	});
+
+	it("keeps caller cancellation classifiable while waiting on shared work", async () => {
+		const cache = new AsyncTtlCache<string, string>({
+			ttlMs: 60_000,
+			maxSize: 2,
+		});
+		let resolveFetch!: (value: string) => void;
+		const first = cache.getOrFetch(
+			"catalog",
+			() =>
+				new Promise<string>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+		const controller = new AbortController();
+		const second = cache.getOrFetch(
+			"catalog",
+			() => Promise.resolve("shared"),
+			{
+				signal: controller.signal,
+			},
+		);
+		controller.abort(new DOMException("caller cancelled", "AbortError"));
+		const error = await second.catch((reason: unknown) => reason);
+		expect(createSafeErrorDiagnostic(error)).toMatchObject({
+			outcome: "cancelled",
+			phase: "before-dispatch",
+			commit_state: "not_sent",
+			safe_to_retry: false,
+		});
+		resolveFetch("shared");
+		await first;
+	});
+
+	it("rejects an already-canceled caller before returning a cached value", async () => {
+		const cache = new AsyncTtlCache<string, string>({
+			ttlMs: 60_000,
+			maxSize: 2,
+		});
+		await cache.getOrFetch("catalog", () => Promise.resolve("cached"));
+		const controller = new AbortController();
+		const reason = new DOMException("caller canceled", "AbortError");
+		controller.abort(reason);
+
+		await expect(
+			cache.getOrFetch("catalog", () => Promise.resolve("unused"), {
+				signal: controller.signal,
+			}),
+		).rejects.toBe(reason);
+	});
+
+	it("rejects a caller whose cache deadline has already elapsed", async () => {
+		const cache = new AsyncTtlCache<string, string>({
+			ttlMs: 60_000,
+			maxSize: 2,
+		});
+		await cache.getOrFetch("catalog", () => Promise.resolve("cached"));
+
+		await expect(
+			cache.getOrFetch("catalog", () => Promise.resolve("unused"), {
+				deadline: Date.now() - 1,
+			}),
+		).rejects.toMatchObject({ name: "TimeoutError" });
+	});
+
+	it("enforces a caller deadline while shared work is still pending", async () => {
+		vi.useFakeTimers();
+		const cache = new AsyncTtlCache<string, string>({
+			ttlMs: 60_000,
+			maxSize: 2,
+		});
+		const pending = cache.getOrFetch(
+			"catalog",
+			() => new Promise<string>(() => {}),
+		);
+		const request = cache.getOrFetch(
+			"catalog",
+			() => Promise.resolve("unused"),
+			{ deadline: Date.now() + 1_000 },
+		);
+		const rejected = expect(request).rejects.toMatchObject({
+			name: "TimeoutError",
+		});
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		await rejected;
+		void pending;
+	});
+
 	it("observes cache states without exposing keys", async () => {
 		const events: string[] = [];
 		const cache = new AsyncTtlCache<string, string>({

--- a/packages/core/src/utils/cache.test.ts
+++ b/packages/core/src/utils/cache.test.ts
@@ -137,6 +137,39 @@ describe("AsyncTtlCache", () => {
 		expect(fetcher).toHaveBeenCalledTimes(2);
 	});
 
+	it("does not let an older unshared fetch commit after the newer generation settles", async () => {
+		const cache = new AsyncTtlCache<string, string>({
+			ttlMs: 60_000,
+			maxSize: 2,
+		});
+		let resolveFirst!: (value: string) => void;
+		const fetcher = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<string>((resolve) => {
+						resolveFirst = resolve;
+					}),
+			)
+			.mockResolvedValueOnce("newer");
+
+		const first = cache.getOrFetch("catalog", fetcher, {
+			shareInFlight: false,
+		});
+		const second = cache.getOrFetch("catalog", fetcher, {
+			shareInFlight: false,
+		});
+
+		await expect(second).resolves.toBe("newer");
+		resolveFirst("older");
+		await expect(first).resolves.toBe("older");
+		// The newer request cleaned up its generation before the older one
+		// settled; the older result must still be rejected for cache commit.
+		await expect(
+			cache.getOrFetch("catalog", () => Promise.resolve("unused")),
+		).resolves.toBe("newer");
+	});
+
 	it("keeps caller cancellation classifiable while waiting on shared work", async () => {
 		const cache = new AsyncTtlCache<string, string>({
 			ttlMs: 60_000,
@@ -162,8 +195,7 @@ describe("AsyncTtlCache", () => {
 		const error = await second.catch((reason: unknown) => reason);
 		expect(createSafeErrorDiagnostic(error)).toMatchObject({
 			outcome: "cancelled",
-			phase: "before-dispatch",
-			commit_state: "not_sent",
+			commit_state: "unknown",
 			safe_to_retry: false,
 		});
 		resolveFetch("shared");

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -61,6 +61,8 @@ export class AsyncTtlCache<TKey, TValue> {
 	private readonly observer?: CacheObserver;
 	private readonly entries = new Map<TKey, CacheEntry<TValue>>();
 	private readonly inFlight = new Map<TKey, InFlightEntry<TValue>>();
+	/** Latest request generation per key, including unshared requests. */
+	private readonly latestRequestIds = new Map<TKey, number>();
 	private requestCounter = 0;
 
 	constructor(options: AsyncCacheOptions, now: () => number = Date.now) {
@@ -199,12 +201,13 @@ export class AsyncTtlCache<TKey, TValue> {
 		}
 
 		const requestId = ++this.requestCounter;
+		this.latestRequestIds.set(key, requestId);
 		const observationScope = this.startObservation(observationState);
 		const request = (async () => {
 			try {
 				const value = await fetcher();
 
-				if (!shareInFlight || this.isCurrentRequest(key, requestId)) {
+				if (this.isCurrentRequest(key, requestId)) {
 					this.setValue(key, value);
 				}
 
@@ -223,6 +226,9 @@ export class AsyncTtlCache<TKey, TValue> {
 				if (inFlightEntry?.requestId === requestId) {
 					this.inFlight.delete(key);
 				}
+				if (this.latestRequestIds.get(key) === requestId) {
+					this.latestRequestIds.delete(key);
+				}
 			}
 		})();
 
@@ -233,11 +239,13 @@ export class AsyncTtlCache<TKey, TValue> {
 	invalidate(key: TKey): void {
 		this.entries.delete(key);
 		this.inFlight.delete(key);
+		this.latestRequestIds.delete(key);
 	}
 
 	clear(): void {
 		this.entries.clear();
 		this.inFlight.clear();
+		this.latestRequestIds.clear();
 	}
 
 	get size(): number {
@@ -245,7 +253,7 @@ export class AsyncTtlCache<TKey, TValue> {
 	}
 
 	private isCurrentRequest(key: TKey, requestId: number): boolean {
-		return this.inFlight.get(key)?.requestId === requestId;
+		return this.latestRequestIds.get(key) === requestId;
 	}
 
 	private markAsRecentlyUsed(key: TKey, entry: CacheEntry<TValue>): void {

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -33,6 +33,10 @@ export interface AsyncCacheOptions {
 
 export interface CacheGetOptions {
 	refresh?: boolean;
+	/** Controlled callers must not share an in-flight request they can cancel. */
+	shareInFlight?: boolean;
+	signal?: AbortSignal;
+	deadline?: number;
 	getObservationMetadata?: () => CacheObservationMetadata | undefined;
 }
 
@@ -95,16 +99,76 @@ export class AsyncTtlCache<TKey, TValue> {
 		}
 	}
 
+	private async waitForCaller<T>(
+		promise: Promise<T>,
+		signal?: AbortSignal,
+		deadline?: number,
+	): Promise<T> {
+		if (signal === undefined && deadline === undefined) return promise;
+		if (signal?.aborted) {
+			throw (
+				signal.reason ?? new DOMException("Operation canceled", "AbortError")
+			);
+		}
+		if (deadline !== undefined && Date.now() >= deadline) {
+			throw new DOMException("Operation deadline exceeded", "TimeoutError");
+		}
+		return new Promise<T>((resolve, reject) => {
+			let settled = false;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const cleanup = () => {
+				if (timer !== undefined) clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
+			};
+			const finish = (callback: () => void) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				callback();
+			};
+			const onAbort = () =>
+				finish(() =>
+					reject(
+						signal?.reason ??
+							new DOMException("Operation canceled", "AbortError"),
+					),
+				);
+			if (signal !== undefined)
+				signal.addEventListener("abort", onAbort, { once: true });
+			if (deadline !== undefined) {
+				timer = setTimeout(
+					() =>
+						finish(() =>
+							reject(
+								new DOMException("Operation deadline exceeded", "TimeoutError"),
+							),
+						),
+					Math.max(0, deadline - Date.now()),
+				);
+			}
+			void promise.then(
+				(value) => finish(() => resolve(value)),
+				(error: unknown) => finish(() => reject(error)),
+			);
+		});
+	}
+
 	async getOrFetch(
 		key: TKey,
 		fetcher: () => Promise<TValue>,
 		options: CacheGetOptions = {},
 	): Promise<TValue> {
-		const { refresh = false, getObservationMetadata } = options;
+		const {
+			refresh = false,
+			shareInFlight = true,
+			signal,
+			deadline,
+			getObservationMetadata,
+		} = options;
 		let observationState: CacheObservationState = refresh ? "refresh" : "miss";
 
 		if (refresh) {
-			this.invalidate(key);
+			if (shareInFlight) this.invalidate(key);
 		} else {
 			const cachedEntry = this.entries.get(key);
 			if (cachedEntry !== undefined) {
@@ -112,21 +176,25 @@ export class AsyncTtlCache<TKey, TValue> {
 					this.markAsRecentlyUsed(key, cachedEntry);
 					const observationScope = this.startObservation("hit");
 					this.finishObservation(observationScope);
-					return cachedEntry.value;
+					return this.waitForCaller(
+						Promise.resolve(cachedEntry.value),
+						signal,
+						deadline,
+					);
 				}
 
 				this.entries.delete(key);
 				observationState = "expired";
 			}
 
-			const inFlightEntry = this.inFlight.get(key);
+			const inFlightEntry = shareInFlight ? this.inFlight.get(key) : undefined;
 			if (inFlightEntry !== undefined) {
 				const observationScope = this.startObservation("inflight_wait");
 				void inFlightEntry.promise.then(
 					() => this.finishObservation(observationScope),
 					() => this.finishObservation(observationScope),
 				);
-				return inFlightEntry.promise;
+				return this.waitForCaller(inFlightEntry.promise, signal, deadline);
 			}
 		}
 
@@ -136,7 +204,7 @@ export class AsyncTtlCache<TKey, TValue> {
 			try {
 				const value = await fetcher();
 
-				if (this.isCurrentRequest(key, requestId)) {
+				if (!shareInFlight || this.isCurrentRequest(key, requestId)) {
 					this.setValue(key, value);
 				}
 
@@ -149,15 +217,17 @@ export class AsyncTtlCache<TKey, TValue> {
 					metadata = undefined;
 				}
 				this.finishObservation(observationScope, metadata);
-				const inFlightEntry = this.inFlight.get(key);
+				const inFlightEntry = shareInFlight
+					? this.inFlight.get(key)
+					: undefined;
 				if (inFlightEntry?.requestId === requestId) {
 					this.inFlight.delete(key);
 				}
 			}
 		})();
 
-		this.inFlight.set(key, { promise: request, requestId });
-		return request;
+		if (shareInFlight) this.inFlight.set(key, { promise: request, requestId });
+		return this.waitForCaller(request, signal, deadline);
 	}
 
 	invalidate(key: TKey): void {

--- a/packages/core/src/utils/error-handler.test.ts
+++ b/packages/core/src/utils/error-handler.test.ts
@@ -45,6 +45,11 @@ describe("createErrorResponse", () => {
 					"http.status_code": 500,
 					"http.method": "GET",
 					"hevy.api.endpoint": "/v1/user/info",
+					"hevy.api.outcome": "terminal_failure",
+					"hevy.api.phase": "before-dispatch",
+					"hevy.api.operation_safety": "read",
+					"hevy.api.commit_state": "not_sent",
+					"hevy.api.safe_to_retry": false,
 				}),
 			);
 		} finally {

--- a/packages/core/src/utils/error-handler.ts
+++ b/packages/core/src/utils/error-handler.ts
@@ -5,6 +5,11 @@
 import { ErrorType, resolveErrorPolicy } from "./error-policy.js";
 import type { McpToolResponse } from "./response-contracts.js";
 import { HEVY_CLIENT_NOT_INITIALIZED_ERROR } from "./tool-helpers.js";
+import {
+	createExecutionProjection,
+	type StructuredExecutionProjection,
+	type ToolExecutionContext,
+} from "../execution.js";
 
 export { ErrorType } from "./error-policy.js";
 
@@ -23,6 +28,8 @@ export interface ErrorResponse {
 export interface EnhancedErrorResponse extends ErrorResponse {
 	type: ErrorType;
 }
+
+export type StructuredExecutionError = StructuredExecutionProjection;
 export interface McpToolFailureEvent {
 	readonly event: "mcp.tool.failure";
 	readonly "mcp.tool.name": string;
@@ -32,6 +39,11 @@ export interface McpToolFailureEvent {
 	readonly "http.status_code"?: number;
 	readonly "http.method"?: string;
 	readonly "hevy.api.endpoint"?: string;
+	readonly "hevy.api.outcome"?: StructuredExecutionProjection["outcome"];
+	readonly "hevy.api.phase"?: StructuredExecutionProjection["phase"];
+	readonly "hevy.api.operation_safety"?: StructuredExecutionProjection["operation_safety"];
+	readonly "hevy.api.commit_state"?: StructuredExecutionProjection["commit_state"];
+	readonly "hevy.api.safe_to_retry"?: boolean;
 }
 
 export function createMcpToolFailureEvent(
@@ -43,8 +55,10 @@ export function createMcpToolFailureEvent(
 		status?: number;
 		method?: string;
 		endpoint?: string;
+		execution?: StructuredExecutionProjection;
 	},
 ): McpToolFailureEvent {
+	const execution = diagnostic.execution;
 	return {
 		event: "mcp.tool.failure",
 		"mcp.tool.name": toolName,
@@ -58,6 +72,15 @@ export function createMcpToolFailureEvent(
 		...(diagnostic.endpoint
 			? { "hevy.api.endpoint": diagnostic.endpoint }
 			: {}),
+		...(execution
+			? {
+					"hevy.api.outcome": execution.outcome,
+					"hevy.api.phase": execution.phase,
+					"hevy.api.operation_safety": execution.operation_safety,
+					"hevy.api.commit_state": execution.commit_state,
+					"hevy.api.safe_to_retry": execution.safe_to_retry,
+				}
+			: {}),
 	};
 }
 
@@ -67,6 +90,7 @@ export interface ErrorDebugContext {
 	originalErrorMessage: string;
 	errorCode?: string;
 	errorType: ErrorType;
+	execution?: StructuredExecutionError;
 	axios?: {
 		status?: number;
 		statusText?: string;
@@ -92,6 +116,7 @@ export function createErrorResponse(
 		HEVY_CLIENT_NOT_INITIALIZED_ERROR,
 	);
 	const { diagnostic } = policy;
+	const execution = createExecutionProjection(diagnostic);
 	const axiosErrorContext: ErrorDebugContext["axios"] | null =
 		diagnostic.status !== undefined ||
 		diagnostic.method !== undefined ||
@@ -107,13 +132,17 @@ export function createErrorResponse(
 		originalErrorMessage: `${diagnostic.category} occurred`,
 		errorCode: diagnostic.code,
 		errorType: policy.type,
+		execution,
 		axios: axiosErrorContext ?? undefined,
 	};
 	const contextPrefix = context ? `[${context}] ` : "";
 	const formattedMessage = `${contextPrefix}Error: ${policy.message}`;
 	console.error(
 		JSON.stringify(
-			createMcpToolFailureEvent(context || "unknown", policy.type, diagnostic),
+			createMcpToolFailureEvent(context || "unknown", policy.type, {
+				...diagnostic,
+				execution,
+			}),
 		),
 	);
 
@@ -121,6 +150,8 @@ export function createErrorResponse(
 		content: [{ type: "text" as const, text: formattedMessage }],
 		isError: true,
 		errorContext,
+		structuredContent: { error: execution },
+		errorOutcome: execution,
 	};
 }
 
@@ -132,14 +163,23 @@ export function createErrorResponse(
  * @returns A function that catches errors and returns standardized error responses
  */
 export function withErrorHandling<TParams extends Record<string, unknown>>(
-	fn: (args: TParams) => Promise<McpToolResponse>,
+	fn: (
+		args: TParams,
+		context?: ToolExecutionContext,
+	) => Promise<McpToolResponse>,
 	context: string,
 	onError?: (error: unknown, context: string, argumentKeyCount: number) => void,
-): (args: Record<string, unknown>) => Promise<McpToolResponse> {
-	return async (rawArgs: Record<string, unknown>) => {
+): (
+	args: Record<string, unknown>,
+	context?: ToolExecutionContext,
+) => Promise<McpToolResponse> {
+	return async (
+		rawArgs: Record<string, unknown>,
+		requestContext?: ToolExecutionContext,
+	) => {
 		const normalizedArgs = rawArgs ?? {};
 		try {
-			return await fn(normalizedArgs as TParams);
+			return await fn(normalizedArgs as TParams, requestContext);
 		} catch (error) {
 			try {
 				onError?.(error, context, Object.keys(normalizedArgs).length);

--- a/packages/core/src/utils/error-handler.ts
+++ b/packages/core/src/utils/error-handler.ts
@@ -13,6 +13,7 @@ import {
 import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
 
 export { ErrorType } from "./error-policy.js";
+export type { StructuredExecutionError } from "../execution.js";
 
 /**
  * Standard error response interface
@@ -30,12 +31,10 @@ export interface EnhancedErrorResponse extends ErrorResponse {
 	type: ErrorType;
 }
 
-export type StructuredExecutionError = StructuredExecutionProjection;
-
 /** Build the canonical execution projection for an arbitrary thrown value. */
 export function createExecutionErrorProjection(
 	error: unknown,
-): StructuredExecutionError {
+): StructuredExecutionProjection {
 	return createExecutionProjection(createSafeErrorDiagnostic(error));
 }
 
@@ -99,7 +98,7 @@ export interface ErrorDebugContext {
 	originalErrorMessage: string;
 	errorCode?: string;
 	errorType: ErrorType;
-	execution?: StructuredExecutionError;
+	execution?: StructuredExecutionProjection;
 	axios?: {
 		status?: number;
 		statusText?: string;

--- a/packages/core/src/utils/error-handler.ts
+++ b/packages/core/src/utils/error-handler.ts
@@ -10,6 +10,7 @@ import {
 	type StructuredExecutionProjection,
 	type ToolExecutionContext,
 } from "../execution.js";
+import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
 
 export { ErrorType } from "./error-policy.js";
 
@@ -30,6 +31,14 @@ export interface EnhancedErrorResponse extends ErrorResponse {
 }
 
 export type StructuredExecutionError = StructuredExecutionProjection;
+
+/** Build the canonical execution projection for an arbitrary thrown value. */
+export function createExecutionErrorProjection(
+	error: unknown,
+): StructuredExecutionError {
+	return createExecutionProjection(createSafeErrorDiagnostic(error));
+}
+
 export interface McpToolFailureEvent {
 	readonly event: "mcp.tool.failure";
 	readonly "mcp.tool.name": string;

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -66,6 +66,36 @@ type RetryAwareError = {
 	hevyRetryExhausted?: boolean;
 };
 
+const ABORT_TIMEOUT_METADATA = {
+	AbortError: {
+		code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+		outcome: "cancelled" as const,
+	},
+	TimeoutError: {
+		code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+		outcome: "deadline_exceeded" as const,
+	},
+} as const;
+
+type AbortTimeoutErrorMetadata =
+	(typeof ABORT_TIMEOUT_METADATA)[keyof typeof ABORT_TIMEOUT_METADATA] & {
+		name: keyof typeof ABORT_TIMEOUT_METADATA;
+	};
+
+/** Map raw cancellation errors to their bounded execution metadata. */
+function getAbortTimeoutErrorMetadata(
+	error: unknown,
+): AbortTimeoutErrorMetadata | undefined {
+	try {
+		if (!(error instanceof Error)) return undefined;
+		const name = error.name as keyof typeof ABORT_TIMEOUT_METADATA;
+		const metadata = ABORT_TIMEOUT_METADATA[name];
+		return metadata ? { name, ...metadata } : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 const SAFE_ERROR_CODES = new Set([
 	"EAI_AGAIN",
 	"ECONNABORTED",
@@ -334,10 +364,8 @@ function classifyError(error: unknown): SafeErrorCategory {
 }
 
 function getSafeCode(error: unknown): string | undefined {
-	if (error instanceof Error) {
-		if (error.name === "TimeoutError") return HEVY_DEADLINE_EXCEEDED_ERROR_CODE;
-		if (error.name === "AbortError") return HEVY_REQUEST_ABORTED_ERROR_CODE;
-	}
+	const abortTimeout = getAbortTimeoutErrorMetadata(error);
+	if (abortTimeout) return abortTimeout.code;
 	if (!error || typeof error !== "object" || !("code" in error)) {
 		return undefined;
 	}
@@ -365,23 +393,12 @@ function getExecutionFields(
 	"phase" | "operation_safety" | "commit_state" | "safe_to_retry" | "outcome"
 > {
 	if (!isHevyHttpError(error)) {
-		const name = error instanceof Error ? error.name : undefined;
-		if (name === "TimeoutError") {
+		const abortTimeout = getAbortTimeoutErrorMetadata(error);
+		if (abortTimeout) {
 			return {
-				phase: "before-dispatch",
-				operation_safety: "read",
-				commit_state: "not_sent",
+				commit_state: "unknown",
 				safe_to_retry: false,
-				outcome: "deadline_exceeded",
-			};
-		}
-		if (name === "AbortError") {
-			return {
-				phase: "before-dispatch",
-				operation_safety: "read",
-				commit_state: "not_sent",
-				safe_to_retry: false,
-				outcome: "cancelled",
+				outcome: abortTimeout.outcome,
 			};
 		}
 		return {};

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -1,7 +1,14 @@
 import {
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	isHevyHttpError,
+} from "@hevy-mcp/hevy-client";
+import type {
+	HevyCommitState,
+	HevyExecutionOutcome,
+	HevyOperationSafety,
+	HevyRequestPhase,
 } from "@hevy-mcp/hevy-client";
 
 /** Specific error types for categorization and metrics. */
@@ -40,6 +47,11 @@ export interface SafeErrorDiagnostic {
 	method?: string;
 	endpoint?: string;
 	frames?: SafeStackFrame[];
+	phase?: HevyRequestPhase;
+	operation_safety?: HevyOperationSafety;
+	commit_state?: HevyCommitState;
+	safe_to_retry?: boolean;
+	outcome?: HevyExecutionOutcome;
 }
 
 type SafeSourceId =
@@ -67,6 +79,7 @@ const SAFE_ERROR_CODES = new Set([
 	"HEVY_INVALID_ENDPOINT",
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 ]);
 
 const SAFE_HTTP_METHODS = new Set([
@@ -321,6 +334,10 @@ function classifyError(error: unknown): SafeErrorCategory {
 }
 
 function getSafeCode(error: unknown): string | undefined {
+	if (error instanceof Error) {
+		if (error.name === "TimeoutError") return HEVY_DEADLINE_EXCEEDED_ERROR_CODE;
+		if (error.name === "AbortError") return HEVY_REQUEST_ABORTED_ERROR_CODE;
+	}
 	if (!error || typeof error !== "object" || !("code" in error)) {
 		return undefined;
 	}
@@ -339,6 +356,47 @@ function getSafeMethod(error: unknown): string | undefined {
 function getSafeEndpoint(error: unknown): string | undefined {
 	if (!isHevyHttpError(error)) return undefined;
 	return SAFE_ENDPOINTS.has(error.endpoint) ? error.endpoint : undefined;
+}
+
+function getExecutionFields(
+	error: unknown,
+): Pick<
+	SafeErrorDiagnostic,
+	"phase" | "operation_safety" | "commit_state" | "safe_to_retry" | "outcome"
+> {
+	if (!isHevyHttpError(error)) {
+		const name = error instanceof Error ? error.name : undefined;
+		if (name === "TimeoutError") {
+			return {
+				phase: "before-dispatch",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+				outcome: "deadline_exceeded",
+			};
+		}
+		if (name === "AbortError") {
+			return {
+				phase: "before-dispatch",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+				outcome: "cancelled",
+			};
+		}
+		return {};
+	}
+	return {
+		...(error.phase ? { phase: error.phase } : {}),
+		...(error.operation_safety
+			? { operation_safety: error.operation_safety }
+			: {}),
+		...(error.commit_state ? { commit_state: error.commit_state } : {}),
+		...(typeof error.safe_to_retry === "boolean"
+			? { safe_to_retry: error.safe_to_retry }
+			: {}),
+		...(error.outcome ? { outcome: error.outcome } : {}),
+	};
 }
 
 function parseSafeStackFrames(error: unknown): SafeStackFrame[] | undefined {
@@ -399,6 +457,7 @@ export function createSafeErrorDiagnostic(error: unknown): SafeErrorDiagnostic {
 		if (method) diagnostic.method = method;
 		if (endpoint) diagnostic.endpoint = endpoint;
 		if (frames) diagnostic.frames = frames;
+		Object.assign(diagnostic, getExecutionFields(error));
 		return diagnostic;
 	} catch {
 		return { category: "UnknownError" };

--- a/packages/core/src/utils/exercise-template-catalog.test.ts
+++ b/packages/core/src/utils/exercise-template-catalog.test.ts
@@ -67,8 +67,11 @@ describe("exercise template catalog", () => {
 	it("does not share a controlled refresh between independently cancellable callers", async () => {
 		const firstController = new AbortController();
 		const secondController = new AbortController();
-		const responses = [
-			new Promise<unknown>((resolve, reject) => {
+		type ExerciseTemplatesResponse = Awaited<
+			ReturnType<HevyClient["getExerciseTemplates"]>
+		>;
+		const responses: Array<Promise<ExerciseTemplatesResponse>> = [
+			new Promise<ExerciseTemplatesResponse>((resolve, reject) => {
 				firstController.signal.addEventListener(
 					"abort",
 					() => reject(firstController.signal.reason),
@@ -84,7 +87,7 @@ describe("exercise template catalog", () => {
 					100,
 				);
 			}),
-			new Promise<unknown>((resolve) =>
+			new Promise<ExerciseTemplatesResponse>((resolve) =>
 				setTimeout(
 					() =>
 						resolve({
@@ -96,8 +99,8 @@ describe("exercise template catalog", () => {
 				),
 			),
 		];
-		const getExerciseTemplates = vi.fn(
-			(_params: unknown, _options?: { signal?: AbortSignal }) => {
+		const getExerciseTemplates = vi.fn<HevyClient["getExerciseTemplates"]>(
+			(_params, _options) => {
 				const response = responses.shift();
 				if (!response) throw new Error("Unexpected extra page");
 				return response;
@@ -105,7 +108,7 @@ describe("exercise template catalog", () => {
 		);
 		const client = {
 			getExerciseTemplates,
-		} as unknown as HevyClient;
+		} satisfies Pick<HevyClient, "getExerciseTemplates">;
 		const catalog = createExerciseTemplateCatalog(client);
 
 		const first = catalog.get({

--- a/packages/core/src/utils/exercise-template-catalog.test.ts
+++ b/packages/core/src/utils/exercise-template-catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createHevyClient } from "@hevy-mcp/hevy-client";
+import { createHevyClient, type HevyClient } from "@hevy-mcp/hevy-client";
 import { createExerciseTemplateCatalog } from "./exercise-template-catalog.js";
 
 describe("exercise template catalog", () => {
@@ -62,6 +62,63 @@ describe("exercise template catalog", () => {
 			[{ id: "shared", title: "Shared" }],
 			[{ id: "shared", title: "Shared" }],
 		]);
+	});
+
+	it("does not share a controlled refresh between independently cancellable callers", async () => {
+		const firstController = new AbortController();
+		const secondController = new AbortController();
+		const responses = [
+			new Promise<unknown>((resolve, reject) => {
+				firstController.signal.addEventListener(
+					"abort",
+					() => reject(firstController.signal.reason),
+					{ once: true },
+				);
+				setTimeout(
+					() =>
+						resolve({
+							page: 1,
+							page_count: 1,
+							exercise_templates: [{ id: "first", title: "First" }],
+						}),
+					100,
+				);
+			}),
+			new Promise<unknown>((resolve) =>
+				setTimeout(
+					() =>
+						resolve({
+							page: 1,
+							page_count: 1,
+							exercise_templates: [{ id: "second", title: "Second" }],
+						}),
+					20,
+				),
+			),
+		];
+		const getExerciseTemplates = vi.fn(
+			(_params: unknown, _options?: { signal?: AbortSignal }) => {
+				const response = responses.shift();
+				if (!response) throw new Error("Unexpected extra page");
+				return response;
+			},
+		);
+		const client = {
+			getExerciseTemplates,
+		} as unknown as HevyClient;
+		const catalog = createExerciseTemplateCatalog(client);
+
+		const first = catalog.get({
+			execution: { signal: firstController.signal },
+		});
+		const second = catalog.get({
+			execution: { signal: secondController.signal },
+		});
+		firstController.abort(new DOMException("first canceled", "AbortError"));
+
+		await expect(first).rejects.toMatchObject({ name: "AbortError" });
+		await expect(second).resolves.toMatchObject([{ id: "second" }]);
+		expect(getExerciseTemplates).toHaveBeenCalledTimes(2);
 	});
 
 	it("returns an empty catalog when a page omits its template array", async () => {

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -32,7 +32,7 @@ export interface ExerciseTemplateCatalog {
 }
 
 export function createExerciseTemplateCatalog(
-	hevyClient: HevyClient,
+	hevyClient: Pick<HevyClient, "getExerciseTemplates">,
 	cacheObserver?: CacheObserver,
 ): ExerciseTemplateCatalog {
 	const cache = new AsyncTtlCache<string, ExerciseTemplate[]>({

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -2,7 +2,7 @@ import type {
 	ExerciseTemplate,
 	GetV1ExerciseTemplates200,
 } from "@hevy-mcp/hevy-client/types";
-import type { HevyClient } from "@hevy-mcp/hevy-client";
+import type { HevyClient, HevyRequestOptions } from "@hevy-mcp/hevy-client";
 import { AsyncTtlCache } from "./cache.js";
 import type { CacheObservationMetadata, CacheObserver } from "./cache.js";
 import { fetchAllPages } from "./pagination.js";
@@ -19,6 +19,7 @@ export type ExerciseTemplateCatalogRefreshReason =
 
 export interface ExerciseTemplateCatalogOptions {
 	refresh?: boolean;
+	execution?: HevyRequestOptions;
 	onRefreshed?: (
 		catalog: ExerciseTemplate[],
 		reason: ExerciseTemplateCatalogRefreshReason,
@@ -56,10 +57,13 @@ export function createExerciseTemplateCatalog(
 						async (page, pageSize) => {
 							pagesLoaded = page;
 							const data: GetV1ExerciseTemplates200 =
-								await hevyClient.getExerciseTemplates({
-									page,
-									pageSize,
-								});
+								await hevyClient.getExerciseTemplates(
+									{
+										page,
+										pageSize,
+									},
+									options.execution,
+								);
 							return {
 								items: data?.exercise_templates ?? [],
 								pageCount: data?.page_count,
@@ -77,6 +81,9 @@ export function createExerciseTemplateCatalog(
 				},
 				{
 					refresh: options.refresh,
+					shareInFlight: options.execution === undefined,
+					signal: options.execution?.signal,
+					deadline: options.execution?.deadline,
 					getObservationMetadata: () => observationMetadata,
 				},
 			);

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -15,6 +15,7 @@ import type {
 	Workout,
 } from "@hevy-mcp/hevy-client/types";
 import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+import type { StructuredExecutionError } from "./error-handler.js";
 import {
 	attachResultTelemetry,
 	bucketCount,
@@ -27,6 +28,7 @@ import {
  */
 export type McpToolResponse = Omit<CallToolResult, "content"> & {
 	content: TextContent[];
+	errorOutcome?: StructuredExecutionError;
 };
 
 type OutputShape = z.ZodRawShape;

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -14,8 +14,8 @@ import type {
 	UserInfo,
 	Workout,
 } from "@hevy-mcp/hevy-client/types";
+import type { StructuredExecutionError } from "../execution.js";
 import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
-import type { StructuredExecutionError } from "./error-handler.js";
 import {
 	attachResultTelemetry,
 	bucketCount,

--- a/packages/core/src/utils/safe-error-diagnostic.test.ts
+++ b/packages/core/src/utils/safe-error-diagnostic.test.ts
@@ -99,19 +99,21 @@ describe("createSafeErrorDiagnostic", () => {
 		).toMatchObject({
 			code: "HEVY_REQUEST_ABORTED",
 			outcome: "cancelled",
-			phase: "before-dispatch",
-			operation_safety: "read",
-			commit_state: "not_sent",
+			commit_state: "unknown",
 			safe_to_retry: false,
 		});
+		expect(
+			createSafeErrorDiagnostic(new DOMException("cancel", "AbortError")),
+		).not.toHaveProperty("phase");
+		expect(
+			createSafeErrorDiagnostic(new DOMException("cancel", "AbortError")),
+		).not.toHaveProperty("operation_safety");
 		expect(
 			createSafeErrorDiagnostic(new DOMException("deadline", "TimeoutError")),
 		).toMatchObject({
 			code: "HEVY_DEADLINE_EXCEEDED",
 			outcome: "deadline_exceeded",
-			phase: "before-dispatch",
-			operation_safety: "read",
-			commit_state: "not_sent",
+			commit_state: "unknown",
 			safe_to_retry: false,
 		});
 	});

--- a/packages/core/src/utils/safe-error-diagnostic.test.ts
+++ b/packages/core/src/utils/safe-error-diagnostic.test.ts
@@ -92,4 +92,27 @@ describe("createSafeErrorDiagnostic", () => {
 			createSafeErrorDiagnostic(new DOMException(SECRET, "AbortError")),
 		).toMatchObject({ category: "DOMException" });
 	});
+
+	it("normalizes cache and transport cancellation taxonomy", () => {
+		expect(
+			createSafeErrorDiagnostic(new DOMException("cancel", "AbortError")),
+		).toMatchObject({
+			code: "HEVY_REQUEST_ABORTED",
+			outcome: "cancelled",
+			phase: "before-dispatch",
+			operation_safety: "read",
+			commit_state: "not_sent",
+			safe_to_retry: false,
+		});
+		expect(
+			createSafeErrorDiagnostic(new DOMException("deadline", "TimeoutError")),
+		).toMatchObject({
+			code: "HEVY_DEADLINE_EXCEEDED",
+			outcome: "deadline_exceeded",
+			phase: "before-dispatch",
+			operation_safety: "read",
+			commit_state: "not_sent",
+			safe_to_retry: false,
+		});
+	});
 });

--- a/packages/core/src/utils/tool-helpers.ts
+++ b/packages/core/src/utils/tool-helpers.ts
@@ -4,6 +4,7 @@
 
 import { z } from "zod";
 import type { McpToolResponse } from "./response-contracts.js";
+import type { ToolExecutionContext } from "../execution.js";
 
 export const HEVY_CLIENT_NOT_INITIALIZED_ERROR =
 	"API client not initialized. Please provide HEVY_API_KEY.";
@@ -62,11 +63,20 @@ export type InferToolParams<T extends Record<string, z.ZodTypeAny>> = z.infer<
  */
 export function createTypedToolHandler<T extends Record<string, z.ZodTypeAny>>(
 	schema: T,
-	handler: (args: InferToolParams<T>) => Promise<McpToolResponse>,
-): (args: Record<string, unknown>) => Promise<McpToolResponse> {
+	handler: (
+		args: InferToolParams<T>,
+		context?: ToolExecutionContext,
+	) => Promise<McpToolResponse>,
+): (
+	args: Record<string, unknown>,
+	context?: ToolExecutionContext,
+) => Promise<McpToolResponse> {
 	const zodSchema = z.strictObject(schema);
-	return async (args: Record<string, unknown>) => {
+	return async (
+		args: Record<string, unknown>,
+		context?: ToolExecutionContext,
+	) => {
 		const validated = zodSchema.parse(args);
-		return handler(validated);
+		return handler(validated, context);
 	};
 }

--- a/packages/hevy-client/src/execution.ts
+++ b/packages/hevy-client/src/execution.ts
@@ -47,6 +47,9 @@ export interface HevyExecutionControl {
 
 export interface HevyExecutionOptions extends HevyExecutionControl {}
 
+/** Request options shared by the curated client and generated adapters. */
+export interface HevyRequestOptions extends HevyExecutionOptions {}
+
 export function isDeadlineExceeded(deadline: number | undefined): boolean {
 	return deadline !== undefined && Date.now() >= deadline;
 }

--- a/packages/hevy-client/src/execution.ts
+++ b/packages/hevy-client/src/execution.ts
@@ -43,7 +43,6 @@ export interface HevyExecutionControl {
 	readonly signal?: AbortSignal;
 	/** Absolute epoch milliseconds. It is never reset for a retry or page. */
 	readonly deadline?: number;
-	readonly operation_safety?: HevyOperationSafety;
 }
 
 export interface HevyExecutionOptions extends HevyExecutionControl {}
@@ -138,9 +137,6 @@ export function createExecutionSignal(control: HevyExecutionControl): {
 }
 
 export function isAbortLike(error: unknown): boolean {
-	return (
-		(error instanceof DOMException && error.name === "AbortError") ||
-		(error instanceof DOMException && error.name === "TimeoutError") ||
-		(error instanceof Error && error.name === "AbortError")
-	);
+	if (!(error instanceof Error)) return false;
+	return error.name === "AbortError" || error.name === "TimeoutError";
 }

--- a/packages/hevy-client/src/execution.ts
+++ b/packages/hevy-client/src/execution.ts
@@ -1,0 +1,146 @@
+/**
+ * Runtime-neutral execution control shared by every Hevy adapter.
+ *
+ * The client owns this vocabulary so adapters can only present the same
+ * outcome; they cannot accidentally grow incompatible retry/error taxonomies.
+ */
+
+export type HevyOperationSafety =
+	| "read"
+	| "idempotent-write"
+	| "non-idempotent-write";
+
+export type HevyRequestPhase =
+	| "before-dispatch"
+	| "dispatch"
+	| "response-headers"
+	| "response-content"
+	| "backoff"
+	| "completed";
+
+export type HevyCommitState = "not_sent" | "confirmed" | "unknown";
+
+export type HevyExecutionOutcome =
+	| "success"
+	| "expected"
+	| "retryable_failure"
+	| "terminal_failure"
+	| "cancelled"
+	| "deadline_exceeded";
+
+export interface HevyExecutionOutcomeDetails {
+	readonly outcome: HevyExecutionOutcome;
+	readonly phase: HevyRequestPhase;
+	readonly operation_safety: HevyOperationSafety;
+	readonly commit_state: HevyCommitState;
+	readonly safe_to_retry: boolean;
+	readonly status?: number;
+	readonly code?: string;
+}
+
+/** Caller-owned control for one logical operation (not one retry attempt). */
+export interface HevyExecutionControl {
+	readonly signal?: AbortSignal;
+	/** Absolute epoch milliseconds. It is never reset for a retry or page. */
+	readonly deadline?: number;
+	readonly operation_safety?: HevyOperationSafety;
+}
+
+export interface HevyExecutionOptions extends HevyExecutionControl {}
+
+export function isDeadlineExceeded(deadline: number | undefined): boolean {
+	return deadline !== undefined && Date.now() >= deadline;
+}
+
+export function remainingDeadlineMs(deadline: number | undefined): number {
+	return deadline === undefined
+		? Number.POSITIVE_INFINITY
+		: deadline - Date.now();
+}
+
+export function operationSafetyForMethod(method: string): HevyOperationSafety {
+	const normalizedMethod = method.toUpperCase();
+	if (["GET", "HEAD", "OPTIONS"].includes(normalizedMethod)) {
+		return "read";
+	}
+	if (["PUT", "DELETE"].includes(normalizedMethod)) {
+		return "idempotent-write";
+	}
+	return "non-idempotent-write";
+}
+
+export function canRetryOperation(
+	safety: HevyOperationSafety,
+	phase: HevyRequestPhase,
+): boolean {
+	if (safety === "non-idempotent-write") return false;
+	return (
+		phase === "before-dispatch" ||
+		phase === "dispatch" ||
+		phase === "response-headers" ||
+		phase === "response-content" ||
+		phase === "backoff"
+	);
+}
+
+export function commitStateFor(
+	safety: HevyOperationSafety,
+	phase: HevyRequestPhase,
+	confirmed: boolean,
+): HevyCommitState {
+	if (safety === "read") return confirmed ? "confirmed" : "not_sent";
+	if (confirmed) return "confirmed";
+	return phase === "before-dispatch" ? "not_sent" : "unknown";
+}
+
+/**
+ * Build a signal that follows both caller cancellation and one absolute
+ * deadline. The returned cleanup function must be called when the operation
+ * completes so a long-lived server does not retain timers/listeners.
+ */
+export function createExecutionSignal(control: HevyExecutionControl): {
+	signal: AbortSignal;
+	abort: (reason?: unknown) => void;
+	cleanup: () => void;
+	deadlineTriggered: () => boolean;
+} {
+	const controller = new AbortController();
+	let deadlineTriggered = false;
+	const abortFromCaller = () => {
+		if (!controller.signal.aborted) controller.abort(control.signal?.reason);
+	};
+	if (control.signal?.aborted) abortFromCaller();
+	else
+		control.signal?.addEventListener("abort", abortFromCaller, { once: true });
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	if (control.deadline !== undefined) {
+		const delay = Math.max(0, control.deadline - Date.now());
+		timer = setTimeout(() => {
+			deadlineTriggered = true;
+			if (!controller.signal.aborted) {
+				controller.abort(
+					new DOMException("Operation deadline exceeded", "TimeoutError"),
+				);
+			}
+		}, delay);
+	}
+	return {
+		signal: controller.signal,
+		abort: (reason?: unknown) => {
+			if (!controller.signal.aborted) controller.abort(reason);
+		},
+		cleanup: () => {
+			if (timer !== undefined) clearTimeout(timer);
+			control.signal?.removeEventListener("abort", abortFromCaller);
+		},
+		deadlineTriggered: () => deadlineTriggered,
+	};
+}
+
+export function isAbortLike(error: unknown): boolean {
+	return (
+		(error instanceof DOMException && error.name === "AbortError") ||
+		(error instanceof DOMException && error.name === "TimeoutError") ||
+		(error instanceof Error && error.name === "AbortError")
+	);
+}

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -19,10 +19,24 @@ import type {
 } from "./generated/client/types";
 import {
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	HevyHttpError,
 	isHevyHttpError,
 } from "./hevy-http-error.js";
+import {
+	canRetryOperation,
+	commitStateFor,
+	createExecutionSignal,
+	isAbortLike,
+	isDeadlineExceeded,
+	operationSafetyForMethod,
+	remainingDeadlineMs,
+	type HevyCommitState,
+	type HevyOperationSafety,
+	type HevyRequestPhase,
+} from "./execution.js";
+import type { HevyRequestOptions } from "./hevy-client.js";
 export interface HevyClientLogEvent {
 	readonly level: "debug" | "warning" | "error";
 	readonly logger: "hevy-api";
@@ -41,17 +55,24 @@ export type HevyClientLogger = (event: HevyClientLogEvent) => void;
 
 type KubbClient = {
 	<TData, _TError = unknown, TVariables = unknown>(
-		config: RequestConfig<TVariables>,
+		config: RequestConfig<TVariables> & InternalRequestControl,
 	): Promise<ResponseConfig<TData>>;
 	getConfig: () => Partial<RequestConfig<unknown>>;
 	setConfig: (config: RequestConfig) => Partial<RequestConfig<unknown>>;
+};
+
+type InternalRequestControl = {
+	readonly hevyDeadline?: number;
+	readonly hevyOperationSafety?: HevyOperationSafety;
 };
 
 export type HevyApiOutcome =
 	| "success"
 	| "retryable_failure"
 	| "terminal_failure"
-	| "expected";
+	| "expected"
+	| "cancelled"
+	| "deadline_exceeded";
 
 export interface HevyRequestStart {
 	readonly method: string;
@@ -66,6 +87,10 @@ export interface HevyRequestObservation {
 	readonly durationMs: number;
 	readonly retryCount: number;
 	readonly outcome: HevyApiOutcome;
+	readonly phase?: HevyRequestPhase;
+	readonly operationSafety?: HevyOperationSafety;
+	readonly commitState?: HevyCommitState;
+	readonly safeToRetry?: boolean;
 	readonly expectedReason?: "not_found" | "end_of_list";
 	readonly error?: {
 		readonly status?: number;
@@ -99,7 +124,7 @@ export interface HevyClientOptions {
 	) => HevyRequestObservationScope | void;
 	onRequestComplete?: (observation: HevyRequestObservation) => void;
 	onRetryWait?: (observation: HevyRetryWait) => HevyRetryWaitScope | void;
-	sleep?: (milliseconds: number) => Promise<void>;
+	sleep?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
 	timeoutMs?: number;
 }
 
@@ -108,6 +133,7 @@ export const MAX_GET_RETRIES = 3;
 export const RETRY_BACKOFF_BASE_MS = 300;
 export { HEVY_RETRY_EXHAUSTED_ERROR_CODE };
 export { HEVY_REQUEST_ABORTED_ERROR_CODE };
+export { HEVY_DEADLINE_EXCEEDED_ERROR_CODE };
 
 const RETRY_BACKOFF_MAX_MS = 5_000;
 const RETRYABLE_STATUS_CODES = new Set([408, 429]);
@@ -149,6 +175,7 @@ export const SAFE_OBSERVATION_CODES = new Set([
 	"ETIMEDOUT",
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 ]);
 const SAFE_DYNAMIC_ENDPOINTS = [
 	["/v1/body_measurements/", "/v1/body_measurements/:date"],
@@ -171,40 +198,91 @@ function normalizeMaxGetRetries(value: number | undefined) {
 		: Math.floor(value);
 }
 
-function defaultSleep(milliseconds: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+function defaultSleep(
+	milliseconds: number,
+	signal?: AbortSignal,
+): Promise<void> {
+	if (signal?.aborted) {
+		return Promise.reject(
+			signal.reason ?? new DOMException("Operation canceled", "AbortError"),
+		);
+	}
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const cleanup = () => {
+			if (timer !== undefined) clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+		};
+		const resolveSleep = () => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve();
+		};
+		const rejectSleep = (reason: unknown) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(reason);
+		};
+		const onAbort = () =>
+			rejectSleep(
+				signal?.reason ?? new DOMException("Operation canceled", "AbortError"),
+			);
+		timer = setTimeout(resolveSleep, Math.max(0, milliseconds));
+		signal?.addEventListener("abort", onAbort, { once: true });
+		if (signal?.aborted) onAbort();
+	});
 }
 
 function withTimeout<T>(
 	operation: Promise<T>,
 	timeoutMs: number,
 	onTimeout: () => void,
+	signal?: AbortSignal,
 ): Promise<T> {
 	const promise = new Promise<T>((resolve, reject) => {
 		let settled = false;
-		const timer = setTimeout(
-			() => {
-				if (settled) return;
-				settled = true;
-				onTimeout();
-				reject(new DOMException("Operation timed out", "AbortError"));
-			},
-			Math.max(0, timeoutMs),
-		);
+		const onAbort = () => {
+			if (settled) return;
+			settled = true;
+			if (timer !== undefined) clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			reject(
+				signal?.reason ?? new DOMException("Operation canceled", "AbortError"),
+			);
+		};
+		const timer = Number.isFinite(timeoutMs)
+			? setTimeout(
+					() => {
+						if (settled) return;
+						settled = true;
+						signal?.removeEventListener("abort", onAbort);
+						onTimeout();
+						reject(new DOMException("Operation timed out", "AbortError"));
+					},
+					Math.max(0, timeoutMs),
+				)
+			: undefined;
 		operation.then(
 			(value) => {
 				if (settled) return;
 				settled = true;
-				clearTimeout(timer);
+				if (timer !== undefined) clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
 				resolve(value);
 			},
 			(error: unknown) => {
 				if (settled) return;
 				settled = true;
-				clearTimeout(timer);
+				if (timer !== undefined) clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
 				reject(error);
 			},
 		);
+		if (signal?.aborted) onAbort();
+		else signal?.addEventListener("abort", onAbort, { once: true });
 	});
 	return promise;
 }
@@ -320,12 +398,12 @@ function parseRetryAfterMs(value: string | null): number | undefined {
 	if (!value) return undefined;
 	const seconds = Number(value);
 	if (Number.isFinite(seconds) && seconds >= 0) {
-		return Math.min(RETRY_BACKOFF_MAX_MS, Math.round(seconds * 1_000));
+		return Math.round(seconds * 1_000);
 	}
 	const dateMillis = Date.parse(value);
 	return Number.isNaN(dateMillis)
 		? undefined
-		: Math.min(RETRY_BACKOFF_MAX_MS, Math.max(0, dateMillis - Date.now()));
+		: Math.max(0, dateMillis - Date.now());
 }
 
 function getRetryDelayMs(error: HevyHttpError, retryAttempt: number): number {
@@ -337,9 +415,13 @@ function getRetryDelayMs(error: HevyHttpError, retryAttempt: number): number {
 		error.status === 429
 			? parseRetryAfterMs(error.headers?.get("retry-after") ?? null)
 			: undefined;
-	return retryAfter === undefined
-		? exponential
-		: Math.min(RETRY_BACKOFF_MAX_MS, Math.max(exponential, retryAfter));
+	if (retryAfter === undefined) return exponential;
+	// Keep the server's usable lower bound while adding bounded jitter to avoid
+	// a thundering herd when many callers receive the same Retry-After value.
+	const jitter = Math.floor(
+		Math.random() * Math.min(250, Math.max(1, retryAfter * 0.1)),
+	);
+	return Math.max(exponential, retryAfter) + jitter;
 }
 
 function buildUrl(baseUrl: string, config: RequestConfig<unknown>): URL {
@@ -379,12 +461,470 @@ function getNetworkCode(error: unknown): string {
 }
 
 function isRetryable(error: HevyHttpError): boolean {
-	if (error.code === HEVY_REQUEST_ABORTED_ERROR_CODE) return false;
+	if (
+		error.code === HEVY_REQUEST_ABORTED_ERROR_CODE ||
+		error.code === HEVY_RETRY_EXHAUSTED_ERROR_CODE
+	)
+		return false;
 	return (
 		error.status === undefined ||
 		RETRYABLE_STATUS_CODES.has(error.status) ||
 		(error.status >= 500 && error.status <= 599)
 	);
+}
+
+async function waitForRetry(
+	delayMs: number,
+	signal: AbortSignal,
+	sleep: (milliseconds: number, signal?: AbortSignal) => Promise<void>,
+): Promise<void> {
+	if (signal.aborted) {
+		throw signal.reason ?? new DOMException("Operation canceled", "AbortError");
+	}
+	await new Promise<void>((resolve, reject) => {
+		let settled = false;
+		const onAbort = () => {
+			if (settled) return;
+			settled = true;
+			signal.removeEventListener("abort", onAbort);
+			reject(
+				signal.reason ?? new DOMException("Operation canceled", "AbortError"),
+			);
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		void sleep(delayMs, signal).then(
+			() => {
+				if (settled) return;
+				settled = true;
+				signal.removeEventListener("abort", onAbort);
+				resolve();
+			},
+			(error) => {
+				if (settled) return;
+				settled = true;
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+interface ExecutionErrorOptions {
+	method: string;
+	endpoint: string;
+	safety: HevyOperationSafety;
+	phase: HevyRequestPhase;
+	deadlineExceeded: boolean;
+	canceled: boolean;
+	responseConfirmed?: boolean;
+	code?: string;
+	cause?: unknown;
+}
+
+interface ExecutionFailureState {
+	deadlineExceeded: boolean;
+	canceled: boolean;
+	attemptTimedOut: boolean;
+}
+
+function classifyExecutionFailure(
+	cause: unknown,
+	executionSignal: AbortSignal,
+	deadline: number,
+	deadlineTriggered = false,
+): ExecutionFailureState {
+	const deadlineExceeded = deadlineTriggered || isDeadlineExceeded(deadline);
+	return {
+		deadlineExceeded,
+		canceled: executionSignal.aborted && !deadlineExceeded,
+		attemptTimedOut: isAbortLike(cause) && !executionSignal.aborted,
+	};
+}
+
+function createExecutionError(options: ExecutionErrorOptions): HevyHttpError {
+	const { deadlineExceeded, canceled } = options;
+	return new HevyHttpError(
+		deadlineExceeded
+			? "Hevy API request deadline exceeded"
+			: canceled
+				? "Hevy API request was canceled"
+				: "Hevy API network request failed",
+		{
+			method: options.method,
+			endpoint: options.endpoint,
+			code: deadlineExceeded
+				? HEVY_DEADLINE_EXCEEDED_ERROR_CODE
+				: canceled
+					? HEVY_REQUEST_ABORTED_ERROR_CODE
+					: (options.code ?? "ERR_NETWORK"),
+			phase: options.phase,
+			operationSafety: options.safety,
+			commitState: commitStateFor(
+				options.safety,
+				options.phase,
+				options.responseConfirmed ?? false,
+			),
+			safeToRetry: false,
+			outcome: deadlineExceeded
+				? "deadline_exceeded"
+				: canceled
+					? "cancelled"
+					: "terminal_failure",
+			cause: options.cause,
+		},
+	);
+}
+
+function applyExecutionMetadata(
+	error: HevyHttpError,
+	phase: HevyRequestPhase,
+	safety: HevyOperationSafety,
+	commitState: HevyCommitState,
+	safeToRetry: boolean,
+	outcome: HevyApiOutcome,
+): void {
+	Object.assign(error, {
+		phase,
+		phase_name: phase,
+		operationSafety: safety,
+		operation_safety: safety,
+		commitState,
+		commit_state: commitState,
+		safeToRetry,
+		safe_to_retry: safeToRetry,
+		outcome,
+	});
+}
+
+function requestOptions(
+	options: HevyRequestOptions | undefined,
+	client: KubbClient,
+): InternalRequestControl & { client: KubbClient; signal?: AbortSignal } {
+	return {
+		client,
+		...(options?.signal ? { signal: options.signal } : {}),
+		...(options?.deadline !== undefined
+			? { hevyDeadline: options.deadline }
+			: {}),
+		...(options?.operation_safety
+			? { hevyOperationSafety: options.operation_safety }
+			: {}),
+	};
+}
+
+interface RequestAttemptExecutionOptions {
+	apiKey: string;
+	fetchImplementation: typeof globalThis.fetch;
+	normalized: RequestConfig<unknown> & InternalRequestControl;
+	url: URL;
+	method: string;
+	endpoint: string;
+	safety: HevyOperationSafety;
+	deadline: number;
+	executionSignal: AbortSignal;
+	startedAt: number;
+	retryCount: number;
+	observationScope: HevyRequestObservationScope | undefined;
+	onRequestComplete: HevyClientOptions["onRequestComplete"];
+}
+
+type RequestAttemptOutcome<TData> =
+	| {
+			readonly ok: true;
+			readonly result: ResponseConfig<TData>;
+	  }
+	| {
+			readonly ok: false;
+			readonly cause: unknown;
+			readonly phase: HevyRequestPhase;
+			readonly responseConfirmed: boolean;
+	  };
+
+/** Execute one dispatch/response attempt and retain its safe phase state. */
+async function executeRequestAttempt<TData>(
+	options: RequestAttemptExecutionOptions,
+): Promise<RequestAttemptOutcome<TData>> {
+	let phase: HevyRequestPhase = "before-dispatch";
+	let responseConfirmed = false;
+	const attemptController = new AbortController();
+	const abortAttempt = () =>
+		attemptController.abort(options.executionSignal.reason);
+	options.executionSignal.addEventListener("abort", abortAttempt, {
+		once: true,
+	});
+	try {
+		const result = await runRequestObservation(
+			options.observationScope,
+			async () => {
+				const headers = new Headers({ "api-key": options.apiKey });
+				if (
+					options.normalized.data !== undefined &&
+					!(options.normalized.data instanceof FormData)
+				) {
+					headers.set("content-type", "application/json");
+				}
+				const requestInit: RequestInit = {
+					method: options.method,
+					headers,
+					redirect: "manual",
+					body:
+						options.normalized.data instanceof FormData
+							? options.normalized.data
+							: options.normalized.data === undefined
+								? undefined
+								: JSON.stringify(options.normalized.data),
+					signal: attemptController.signal,
+				};
+				let fetchPromise: Promise<Response>;
+				try {
+					const fetchImplementation = options.fetchImplementation;
+					fetchPromise = Promise.resolve(
+						fetchImplementation(options.url, requestInit),
+					);
+				} catch (error) {
+					phase = "before-dispatch";
+					throw error;
+				}
+				phase = "dispatch";
+				const response = await withTimeout(
+					fetchPromise,
+					remainingDeadlineMs(options.deadline),
+					() =>
+						attemptController.abort(
+							new DOMException("Operation timed out", "TimeoutError"),
+						),
+					attemptController.signal,
+				);
+				phase = "response-headers";
+				phase = "response-content";
+				const data = await withTimeout(
+					parseResponseData(response),
+					remainingDeadlineMs(options.deadline),
+					() =>
+						attemptController.abort(
+							new DOMException("Operation timed out", "TimeoutError"),
+						),
+					attemptController.signal,
+				);
+				if (!response.ok) {
+					throw new HevyHttpError(
+						`Hevy API request failed (HTTP ${response.status})`,
+						{
+							status: response.status,
+							statusText: response.statusText,
+							data,
+							headers: response.headers,
+							method: options.method,
+							endpoint: options.endpoint,
+							phase,
+							operationSafety: options.safety,
+							commitState: commitStateFor(options.safety, phase, false),
+							safeToRetry: false,
+						},
+					);
+				}
+				responseConfirmed = true;
+				const observation: HevyRequestObservation = {
+					method: options.method,
+					endpoint: options.endpoint,
+					status: response.status,
+					durationMs: Date.now() - options.startedAt,
+					retryCount: options.retryCount,
+					outcome: "success",
+					phase: "completed",
+					operationSafety: options.safety,
+					commitState: "confirmed",
+					safeToRetry: false,
+				};
+				finishRequestObservation(options.observationScope, observation);
+				emitRequestObservation(options.onRequestComplete, observation);
+				return {
+					data: data as TData,
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers,
+				};
+			},
+		);
+		return { ok: true, result };
+	} catch (cause) {
+		return { ok: false, cause, phase, responseConfirmed };
+	} finally {
+		options.executionSignal.removeEventListener("abort", abortAttempt);
+	}
+}
+
+interface AttemptFailureTransitionOptions {
+	cause: unknown;
+	method: string;
+	endpoint: string;
+	page: number | undefined;
+	safety: HevyOperationSafety;
+	phase: HevyRequestPhase;
+	responseConfirmed: boolean;
+	executionSignal: ReturnType<typeof createExecutionSignal>;
+	deadline: number;
+	retryCount: number;
+	maxGetRetries: number;
+	startedAt: number;
+	observationScope: HevyRequestObservationScope | undefined;
+	clientOptions: HevyClientOptions;
+}
+
+interface AttemptFailureTransition {
+	readonly retry: boolean;
+	readonly error: HevyHttpError;
+	readonly retryCount: number;
+	readonly delayMs?: number;
+	readonly retryWaitScope?: HevyRetryWaitScope;
+}
+
+/** Classify an attempt failure, emit its observation, and choose retry/backoff. */
+function transitionAfterAttemptFailure(
+	options: AttemptFailureTransitionOptions,
+): AttemptFailureTransition {
+	const failure = classifyExecutionFailure(
+		options.cause,
+		options.executionSignal.signal,
+		options.deadline,
+		options.executionSignal.deadlineTriggered(),
+	);
+	const { deadlineExceeded, canceled, attemptTimedOut } = failure;
+	const error = isHevyHttpError(options.cause)
+		? options.cause
+		: createExecutionError({
+				method: options.method,
+				endpoint: options.endpoint,
+				safety: options.safety,
+				phase: options.phase,
+				deadlineExceeded,
+				canceled,
+				responseConfirmed: options.responseConfirmed,
+				code: attemptTimedOut ? "ETIMEDOUT" : getNetworkCode(options.cause),
+				cause: options.cause,
+			});
+	const safeToRetry =
+		!deadlineExceeded &&
+		!canceled &&
+		options.safety !== "non-idempotent-write" &&
+		canRetryOperation(options.safety, options.phase) &&
+		isRetryable(error) &&
+		remainingDeadlineMs(options.deadline) > 0;
+	const commitState =
+		error.commitState ??
+		commitStateFor(options.safety, options.phase, options.responseConfirmed);
+	applyExecutionMetadata(
+		error,
+		options.phase,
+		options.safety,
+		commitState,
+		safeToRetry,
+		deadlineExceeded
+			? "deadline_exceeded"
+			: canceled
+				? "cancelled"
+				: "terminal_failure",
+	);
+	const expectedReason =
+		error.status === 404 &&
+		options.method === "GET" &&
+		EXPECTED_READ_404_ENDPOINTS.has(options.endpoint)
+			? "not_found"
+			: error.status === 404 &&
+				  options.method === "GET" &&
+				  options.page !== undefined &&
+				  options.page > 1 &&
+				  EXPECTED_LIST_404_ENDPOINTS.has(options.endpoint)
+				? "end_of_list"
+				: undefined;
+	const retryExhausted =
+		safeToRetry && options.retryCount >= options.maxGetRetries;
+	if (retryExhausted) {
+		error.hevyRetryExhausted = true;
+		error.hevyRetryCount = options.retryCount;
+		error.code = HEVY_RETRY_EXHAUSTED_ERROR_CODE;
+		Object.assign(error, {
+			safeToRetry: false,
+			safe_to_retry: false,
+			outcome: "terminal_failure" as const,
+		});
+	}
+	const observationOutcome: HevyApiOutcome = expectedReason
+		? "expected"
+		: deadlineExceeded
+			? "deadline_exceeded"
+			: canceled
+				? "cancelled"
+				: safeToRetry && !retryExhausted
+					? "retryable_failure"
+					: "terminal_failure";
+	const observation: HevyRequestObservation = {
+		method: options.method,
+		endpoint: options.endpoint,
+		status: error.status ?? 0,
+		durationMs: Date.now() - options.startedAt,
+		retryCount: options.retryCount,
+		outcome: observationOutcome,
+		phase: options.phase,
+		operationSafety: options.safety,
+		commitState,
+		safeToRetry: safeToRetry && !retryExhausted,
+		...(expectedReason ? { expectedReason } : {}),
+		error: {
+			status: error.status,
+			code:
+				typeof error.code === "string" && SAFE_OBSERVATION_CODES.has(error.code)
+					? error.code
+					: undefined,
+			category: error.status === undefined ? "NetworkError" : "HevyHttpError",
+		},
+	};
+	finishRequestObservation(options.observationScope, observation);
+	emitRequestObservation(options.clientOptions.onRequestComplete, observation);
+	if (expectedReason || !safeToRetry || retryExhausted) {
+		emitClientLog(options.clientOptions.onLog, {
+			level: "error",
+			logger: "hevy-api",
+			data: {
+				message: "Hevy API request failed",
+				status: error.status ?? null,
+				method: options.method,
+				endpoint: options.endpoint,
+			},
+		});
+		return {
+			retry: false,
+			error,
+			retryCount: options.retryCount,
+		};
+	}
+	const retryCount = options.retryCount + 1;
+	const delayMs = getRetryDelayMs(error, retryCount);
+	emitClientLog(options.clientOptions.onLog, {
+		level: error.status === 429 ? "warning" : "debug",
+		logger: "hevy-api",
+		data: {
+			message: "Retrying Hevy API request",
+			status: error.status ?? null,
+			attempt: retryCount + 1,
+			maxAttempts: options.maxGetRetries + 1,
+			delayMs,
+			method: options.method,
+			endpoint: options.endpoint,
+		},
+	});
+	return {
+		retry: true,
+		error,
+		retryCount,
+		delayMs,
+		retryWaitScope: emitRetryWait(options.clientOptions.onRetryWait, {
+			method: options.method,
+			endpoint: options.endpoint,
+			retryCount,
+			delayMs,
+		}),
+	};
 }
 
 function createNativeClient(
@@ -402,202 +942,148 @@ function createNativeClient(
 	let clientConfig: Partial<RequestConfig<unknown>> = { baseURL: baseUrl };
 
 	const client = (async <TData, _TError = unknown, TVariables = unknown>(
-		config: RequestConfig<TVariables>,
+		config: RequestConfig<TVariables> & InternalRequestControl,
 	): Promise<ResponseConfig<TData>> => {
-		const normalized = { ...clientConfig, ...config } as RequestConfig<unknown>;
+		const normalized = {
+			...clientConfig,
+			...config,
+		} as RequestConfig<unknown> & InternalRequestControl;
 		const { method, endpoint, page } = getRequestContext(normalized);
 		const url = buildUrl(baseUrl, normalized);
+		// The HTTP method is authoritative. Caller-controlled metadata may only
+		// describe an operation; it must never reclassify a POST as retryable.
+		const safety = operationSafetyForMethod(method);
+		// `timeoutMs` is the default logical-operation budget. Establish its
+		// absolute deadline once so retries and response-body consumption cannot
+		// each restart a fresh timeout window.
+		const deadline = normalized.hevyDeadline ?? Date.now() + timeoutMs;
+		const executionSignal = createExecutionSignal({
+			signal: normalized.signal,
+			deadline,
+		});
 		let retryCount = 0;
 
-		while (true) {
-			if (normalized.signal?.aborted) {
-				throw new HevyHttpError("Hevy API request was canceled", {
-					method,
-					endpoint,
-					code: HEVY_REQUEST_ABORTED_ERROR_CODE,
-				});
-			}
-			const startedAt = Date.now();
-			const observationScope = emitRequestStart(options.onRequestStart, {
-				method,
-				endpoint,
-				retryCount,
-			});
-			const controller = new AbortController();
-			const abortFromCaller = () => controller.abort();
-			normalized.signal?.addEventListener("abort", abortFromCaller, {
-				once: true,
-			});
-			const timeout = setTimeout(() => controller.abort(), timeoutMs);
-			try {
-				return await runRequestObservation(observationScope, async () => {
-					const headers = new Headers({ "api-key": apiKey });
-					if (
-						normalized.data !== undefined &&
-						!(normalized.data instanceof FormData)
-					) {
-						headers.set("content-type", "application/json");
-					}
-					const attemptDeadline = Date.now() + timeoutMs;
-					const response = await withTimeout(
-						fetchImplementation(url, {
-							method,
-							headers,
-							redirect: "manual",
-							body:
-								normalized.data instanceof FormData
-									? normalized.data
-									: normalized.data === undefined
-										? undefined
-										: JSON.stringify(normalized.data),
-							signal: controller.signal,
-						}),
-						Math.max(0, attemptDeadline - Date.now()),
-						() => controller.abort(),
-					);
-					const data = await withTimeout(
-						parseResponseData(response),
-						Math.max(0, attemptDeadline - Date.now()),
-						() => controller.abort(),
-					);
-					if (!response.ok) {
-						throw new HevyHttpError(
-							`Hevy API request failed (HTTP ${response.status})`,
-							{
-								status: response.status,
-								statusText: response.statusText,
-								data,
-								headers: response.headers,
-								method,
-								endpoint,
-							},
-						);
-					}
-					const observation: HevyRequestObservation = {
+		try {
+			while (true) {
+				const remaining =
+					deadline === undefined ? timeoutMs : remainingDeadlineMs(deadline);
+				if (executionSignal.signal.aborted || remaining <= 0) {
+					const deadlineExceeded = remaining <= 0;
+					const error = createExecutionError({
 						method,
 						endpoint,
-						status: response.status,
-						durationMs: Date.now() - startedAt,
+						safety,
+						phase: "before-dispatch",
+						deadlineExceeded,
+						canceled: !deadlineExceeded,
+					});
+					emitRequestObservation(options.onRequestComplete, {
+						method,
+						endpoint,
+						status: 0,
+						durationMs: 0,
 						retryCount,
-						outcome: "success",
-					};
-					finishRequestObservation(observationScope, observation);
-					emitRequestObservation(options.onRequestComplete, observation);
-					return {
-						data: data as TData,
-						status: response.status,
-						statusText: response.statusText,
-						headers: response.headers,
-					};
-				});
-			} catch (cause) {
-				const error = isHevyHttpError(cause)
-					? cause
-					: new HevyHttpError(
-							normalized.signal?.aborted
-								? "Hevy API request was canceled"
-								: "Hevy API network request failed",
-							{
-								method,
-								endpoint,
-								code: normalized.signal?.aborted
-									? HEVY_REQUEST_ABORTED_ERROR_CODE
-									: getNetworkCode(cause),
-								cause,
-							},
-						);
-				const expectedReason =
-					error.status === 404 &&
-					method === "GET" &&
-					EXPECTED_READ_404_ENDPOINTS.has(endpoint)
-						? "not_found"
-						: error.status === 404 &&
-							  method === "GET" &&
-							  page !== undefined &&
-							  page > 1 &&
-							  EXPECTED_LIST_404_ENDPOINTS.has(endpoint)
-							? "end_of_list"
-							: undefined;
-				const canRetry = method === "GET" && isRetryable(error);
-				const retryExhausted = canRetry && retryCount >= maxGetRetries;
-				if (retryExhausted) {
-					error.hevyRetryExhausted = true;
-					error.hevyRetryCount = retryCount;
-					error.code = HEVY_RETRY_EXHAUSTED_ERROR_CODE;
-				}
-				const observation: HevyRequestObservation = {
-					method,
-					endpoint,
-					status: error.status ?? 0,
-					durationMs: Date.now() - startedAt,
-					retryCount,
-					outcome: expectedReason
-						? "expected"
-						: canRetry && !retryExhausted
-							? "retryable_failure"
-							: "terminal_failure",
-					...(expectedReason ? { expectedReason } : {}),
-					error: {
-						status: error.status,
-						code:
-							typeof error.code === "string" &&
-							SAFE_OBSERVATION_CODES.has(error.code)
-								? error.code
-								: undefined,
-						category:
-							error.status === undefined ? "NetworkError" : "HevyHttpError",
-					},
-				};
-				finishRequestObservation(observationScope, observation);
-				emitRequestObservation(options.onRequestComplete, observation);
-				if (!expectedReason && !canRetry) {
-					emitClientLog(options.onLog, {
-						level: "error",
-						logger: "hevy-api",
-						data: {
-							message: "Hevy API request failed",
-							status: error.status ?? null,
-							method,
-							endpoint,
+						outcome: error.outcome ?? "cancelled",
+						phase: error.phase,
+						operationSafety: safety,
+						commitState: error.commitState,
+						safeToRetry: false,
+						error: {
+							code: error.code,
+							category: "NetworkError",
 						},
 					});
 					throw error;
 				}
-				if (expectedReason || error.hevyRetryExhausted) {
-					throw error;
-				}
-				retryCount += 1;
-				const delayMs = getRetryDelayMs(error, retryCount);
-				emitClientLog(options.onLog, {
-					level: error.status === 429 ? "warning" : "debug",
-					logger: "hevy-api",
-					data: {
-						message: "Retrying Hevy API request",
-						status: error.status ?? null,
-						attempt: retryCount + 1,
-						maxAttempts: maxGetRetries + 1,
-						delayMs,
-						method,
-						endpoint,
-					},
+				const startedAt = Date.now();
+				const observationScope = emitRequestStart(options.onRequestStart, {
+					method,
+					endpoint,
+					retryCount,
 				});
-				await runRequestObservation(observationScope, async () => {
-					const retryWaitScope = emitRetryWait(options.onRetryWait, {
+				const attempt = await executeRequestAttempt<TData>({
+					apiKey,
+					fetchImplementation,
+					normalized,
+					url,
+					method,
+					endpoint,
+					safety,
+					deadline,
+					executionSignal: executionSignal.signal,
+					startedAt,
+					retryCount,
+					observationScope,
+					onRequestComplete: options.onRequestComplete,
+				});
+				if (attempt.ok) return attempt.result;
+				{
+					const { cause, phase, responseConfirmed } = attempt;
+					const transition = transitionAfterAttemptFailure({
+						cause,
 						method,
 						endpoint,
+						page,
+						safety,
+						phase,
+						responseConfirmed,
+						executionSignal,
+						deadline,
 						retryCount,
-						delayMs,
+						maxGetRetries,
+						startedAt,
+						observationScope,
+						clientOptions: options,
 					});
+					if (!transition.retry) throw transition.error;
+					retryCount = transition.retryCount;
+					const delayMs = transition.delayMs ?? 0;
+					const remaining = remainingDeadlineMs(deadline);
 					try {
-						await sleep(delayMs);
+						await runRequestObservation(observationScope, () =>
+							waitForRetry(
+								Math.min(delayMs, Math.max(0, remaining)),
+								executionSignal.signal,
+								sleep,
+							),
+						);
+					} catch (waitError) {
+						const waitDeadlineExceeded =
+							executionSignal.deadlineTriggered() ||
+							isDeadlineExceeded(deadline);
+						const waitErrorResponse = createExecutionError({
+							method,
+							endpoint,
+							safety,
+							phase: "backoff",
+							deadlineExceeded: waitDeadlineExceeded,
+							canceled: !waitDeadlineExceeded,
+							cause: waitError,
+						});
+						emitRequestObservation(options.onRequestComplete, {
+							method,
+							endpoint,
+							status: 0,
+							durationMs: Date.now() - startedAt,
+							retryCount,
+							outcome: waitErrorResponse.outcome ?? "cancelled",
+							phase: waitErrorResponse.phase,
+							operationSafety: safety,
+							commitState: waitErrorResponse.commitState,
+							safeToRetry: false,
+							error: {
+								code: waitErrorResponse.code,
+								category: "NetworkError",
+							},
+						});
+						throw waitErrorResponse;
 					} finally {
-						finishRetryWait(retryWaitScope);
+						finishRetryWait(transition.retryWaitScope);
 					}
-				});
-			} finally {
-				clearTimeout(timeout);
-				normalized.signal?.removeEventListener("abort", abortFromCaller);
+				}
 			}
+		} finally {
+			executionSignal.cleanup();
 		}
 	}) as KubbClient;
 
@@ -619,100 +1105,171 @@ export function createClient(
 	return {
 		getWorkouts: (
 			params?: GetV1WorkoutsQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1Workouts> =>
-			api.getV1Workouts(headers, params, { client }),
+			api.getV1Workouts(headers, params, requestOptions(options, client)),
 		getWorkout: (
 			workoutId: string,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1WorkoutsWorkoutid> =>
-			api.getV1WorkoutsWorkoutid(workoutId, headers, { client }),
+			api.getV1WorkoutsWorkoutid(
+				workoutId,
+				headers,
+				requestOptions(options, client),
+			),
 		createWorkout: (
 			data: PostV1WorkoutsMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.postV1Workouts> =>
-			api.postV1Workouts(data, headers, { client }),
+			api.postV1Workouts(data, headers, requestOptions(options, client)),
 		updateWorkout: (
 			workoutId: string,
 			data: PutV1WorkoutsWorkoutidMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.putV1WorkoutsWorkoutid> =>
-			api.putV1WorkoutsWorkoutid(workoutId, data, headers, { client }),
-		getWorkoutCount: (): ReturnType<typeof api.getV1WorkoutsCount> =>
-			api.getV1WorkoutsCount(headers, { client }),
+			api.putV1WorkoutsWorkoutid(
+				workoutId,
+				data,
+				headers,
+				requestOptions(options, client),
+			),
+		getWorkoutCount: (
+			options?: HevyRequestOptions,
+		): ReturnType<typeof api.getV1WorkoutsCount> =>
+			api.getV1WorkoutsCount(headers, requestOptions(options, client)),
 		getWorkoutEvents: (
 			params?: GetV1WorkoutsEventsQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1WorkoutsEvents> =>
-			api.getV1WorkoutsEvents(headers, params, { client }),
+			api.getV1WorkoutsEvents(headers, params, requestOptions(options, client)),
 		getRoutines: (
 			params?: GetV1RoutinesQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1Routines> =>
-			api.getV1Routines(headers, params, { client }),
+			api.getV1Routines(headers, params, requestOptions(options, client)),
 		getRoutineById: (
 			routineId: string,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1RoutinesRoutineid> =>
-			api.getV1RoutinesRoutineid(routineId, headers, { client }),
+			api.getV1RoutinesRoutineid(
+				routineId,
+				headers,
+				requestOptions(options, client),
+			),
 		createRoutine: (
 			data: PostV1RoutinesMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.postV1Routines> =>
-			api.postV1Routines(data, headers, { client }),
+			api.postV1Routines(data, headers, requestOptions(options, client)),
 		updateRoutine: (
 			routineId: string,
 			data: PutV1RoutinesRoutineidMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.putV1RoutinesRoutineid> =>
-			api.putV1RoutinesRoutineid(routineId, data, headers, { client }),
+			api.putV1RoutinesRoutineid(
+				routineId,
+				data,
+				headers,
+				requestOptions(options, client),
+			),
 		getExerciseTemplates: (
 			params?: GetV1ExerciseTemplatesQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1ExerciseTemplates> =>
-			api.getV1ExerciseTemplates(headers, params, { client }),
+			api.getV1ExerciseTemplates(
+				headers,
+				params,
+				requestOptions(options, client),
+			),
 		getExerciseTemplate: (
 			templateId: string,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1ExerciseTemplatesExercisetemplateid> =>
 			api.getV1ExerciseTemplatesExercisetemplateid(templateId, headers, {
-				client,
+				...requestOptions(options, client),
 			}),
 		getExerciseHistory: (
 			exerciseTemplateId: string,
 			params?: GetV1ExerciseHistoryExercisetemplateidQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1ExerciseHistoryExercisetemplateid> =>
 			api.getV1ExerciseHistoryExercisetemplateid(
 				exerciseTemplateId,
 				headers,
 				params,
-				{ client },
+				requestOptions(options, client),
 			),
 		createExerciseTemplate: (
 			data: PostV1ExerciseTemplatesMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.postV1ExerciseTemplates> =>
-			api.postV1ExerciseTemplates(data, headers, { client }),
+			api.postV1ExerciseTemplates(
+				data,
+				headers,
+				requestOptions(options, client),
+			),
 		getRoutineFolders: (
 			params?: GetV1RoutineFoldersQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1RoutineFolders> =>
-			api.getV1RoutineFolders(headers, params, { client }),
+			api.getV1RoutineFolders(headers, params, requestOptions(options, client)),
 		createRoutineFolder: (
 			data: PostV1RoutineFoldersMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.postV1RoutineFolders> =>
-			api.postV1RoutineFolders(data, headers, { client }),
+			api.postV1RoutineFolders(data, headers, requestOptions(options, client)),
 		getRoutineFolder: (
 			folderId: string,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1RoutineFoldersFolderid> =>
-			api.getV1RoutineFoldersFolderid(folderId, headers, { client }),
+			api.getV1RoutineFoldersFolderid(
+				folderId,
+				headers,
+				requestOptions(options, client),
+			),
 		getBodyMeasurements: (
 			params?: GetV1BodyMeasurementsQueryParams,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1BodyMeasurements> =>
-			api.getV1BodyMeasurements(headers, params, { client }),
+			api.getV1BodyMeasurements(
+				headers,
+				params,
+				requestOptions(options, client),
+			),
 		getBodyMeasurement: (
 			date: string,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1BodyMeasurementsDate> =>
-			api.getV1BodyMeasurementsDate(date, headers, { client }),
+			api.getV1BodyMeasurementsDate(
+				date,
+				headers,
+				requestOptions(options, client),
+			),
 		createBodyMeasurement: (
 			data: PostV1BodyMeasurementsMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.postV1BodyMeasurements> =>
-			api.postV1BodyMeasurements(data, headers, { client }),
+			api.postV1BodyMeasurements(
+				data,
+				headers,
+				requestOptions(options, client),
+			),
 		updateBodyMeasurement: (
 			date: string,
 			data: PutV1BodyMeasurementsDateMutationRequest,
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.putV1BodyMeasurementsDate> =>
-			api.putV1BodyMeasurementsDate(date, data, headers, { client }),
+			api.putV1BodyMeasurementsDate(
+				date,
+				data,
+				headers,
+				requestOptions(options, client),
+			),
 		getUserInfo: (
-			options: { signal?: AbortSignal } = {},
+			options: HevyRequestOptions = {},
 		): ReturnType<typeof api.getV1UserInfo> =>
-			api.getV1UserInfo(headers, { ...options, client }),
+			api.getV1UserInfo(headers, {
+				...requestOptions(options, client),
+			}),
 	};
 }

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -34,9 +34,9 @@ import {
 	remainingDeadlineMs,
 	type HevyCommitState,
 	type HevyOperationSafety,
+	type HevyRequestOptions,
 	type HevyRequestPhase,
 } from "./execution.js";
-import type { HevyRequestOptions } from "./hevy-client.js";
 export interface HevyClientLogEvent {
 	readonly level: "debug" | "warning" | "error";
 	readonly logger: "hevy-api";

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -63,7 +63,6 @@ type KubbClient = {
 
 type InternalRequestControl = {
 	readonly hevyDeadline?: number;
-	readonly hevyOperationSafety?: HevyOperationSafety;
 };
 
 export type HevyApiOutcome =
@@ -260,7 +259,7 @@ function withTimeout<T>(
 						settled = true;
 						signal?.removeEventListener("abort", onAbort);
 						onTimeout();
-						reject(new DOMException("Operation timed out", "AbortError"));
+						reject(new DOMException("Operation timed out", "TimeoutError"));
 					},
 					Math.max(0, timeoutMs),
 				)
@@ -533,11 +532,17 @@ function classifyExecutionFailure(
 	deadline: number,
 	deadlineTriggered = false,
 ): ExecutionFailureState {
-	const deadlineExceeded = deadlineTriggered || isDeadlineExceeded(deadline);
+	const attemptTimedOut = isAbortLike(cause) && !executionSignal.aborted;
+	const deadlineExceeded =
+		deadlineTriggered ||
+		isDeadlineExceeded(deadline) ||
+		(attemptTimedOut &&
+			cause instanceof Error &&
+			cause.name === "TimeoutError");
 	return {
 		deadlineExceeded,
 		canceled: executionSignal.aborted && !deadlineExceeded,
-		attemptTimedOut: isAbortLike(cause) && !executionSignal.aborted,
+		attemptTimedOut,
 	};
 }
 
@@ -583,15 +588,11 @@ function applyExecutionMetadata(
 	safeToRetry: boolean,
 	outcome: HevyApiOutcome,
 ): void {
-	Object.assign(error, {
+	error.setExecutionMetadata({
 		phase,
-		phase_name: phase,
 		operationSafety: safety,
-		operation_safety: safety,
 		commitState,
-		commit_state: commitState,
 		safeToRetry,
-		safe_to_retry: safeToRetry,
 		outcome,
 	});
 }
@@ -605,9 +606,6 @@ function requestOptions(
 		...(options?.signal ? { signal: options.signal } : {}),
 		...(options?.deadline !== undefined
 			? { hevyDeadline: options.deadline }
-			: {}),
-		...(options?.operation_safety
-			? { hevyOperationSafety: options.operation_safety }
 			: {}),
 	};
 }
@@ -843,10 +841,12 @@ function transitionAfterAttemptFailure(
 		error.hevyRetryExhausted = true;
 		error.hevyRetryCount = options.retryCount;
 		error.code = HEVY_RETRY_EXHAUSTED_ERROR_CODE;
-		Object.assign(error, {
+		error.setExecutionMetadata({
+			phase: error.phase,
+			operationSafety: error.operationSafety,
+			commitState: error.commitState,
 			safeToRetry: false,
-			safe_to_retry: false,
-			outcome: "terminal_failure" as const,
+			outcome: "terminal_failure",
 		});
 	}
 	const observationOutcome: HevyApiOutcome = expectedReason
@@ -950,8 +950,7 @@ function createNativeClient(
 		} as RequestConfig<unknown> & InternalRequestControl;
 		const { method, endpoint, page } = getRequestContext(normalized);
 		const url = buildUrl(baseUrl, normalized);
-		// The HTTP method is authoritative. Caller-controlled metadata may only
-		// describe an operation; it must never reclassify a POST as retryable.
+		// The HTTP method is authoritative for operation safety and retry policy.
 		const safety = operationSafetyForMethod(method);
 		// `timeoutMs` is the default logical-operation budget. Establish its
 		// absolute deadline once so retries and response-body consumption cannot
@@ -965,8 +964,7 @@ function createNativeClient(
 
 		try {
 			while (true) {
-				const remaining =
-					deadline === undefined ? timeoutMs : remainingDeadlineMs(deadline);
+				const remaining = remainingDeadlineMs(deadline);
 				if (executionSignal.signal.aborted || remaining <= 0) {
 					const deadlineExceeded = remaining <= 0;
 					const error = createExecutionError({
@@ -1185,9 +1183,11 @@ export function createClient(
 			templateId: string,
 			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1ExerciseTemplatesExercisetemplateid> =>
-			api.getV1ExerciseTemplatesExercisetemplateid(templateId, headers, {
-				...requestOptions(options, client),
-			}),
+			api.getV1ExerciseTemplatesExercisetemplateid(
+				templateId,
+				headers,
+				requestOptions(options, client),
+			),
 		getExerciseHistory: (
 			exerciseTemplateId: string,
 			params?: GetV1ExerciseHistoryExercisetemplateidQueryParams,
@@ -1266,10 +1266,8 @@ export function createClient(
 				requestOptions(options, client),
 			),
 		getUserInfo: (
-			options: HevyRequestOptions = {},
+			options?: HevyRequestOptions,
 		): ReturnType<typeof api.getV1UserInfo> =>
-			api.getV1UserInfo(headers, {
-				...requestOptions(options, client),
-			}),
+			api.getV1UserInfo(headers, requestOptions(options, client)),
 	};
 }

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -6,7 +6,7 @@ import {
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	HevyHttpError,
 } from "./hevy-http-error.js";
-import { createExecutionSignal } from "./execution.js";
+import { createExecutionSignal, isAbortLike } from "./execution.js";
 function response(data: unknown, status = 200): Response {
 	return new Response(JSON.stringify(data), {
 		status,
@@ -63,6 +63,46 @@ describe("@hevy-mcp/hevy-client", () => {
 		execution.abort(new DOMException("ignored", "AbortError"));
 		execution.cleanup();
 		expect(execution.signal.reason).toMatchObject({ message: "done" });
+	});
+
+	it.each(["AbortError", "TimeoutError"])(
+		"recognizes plain Error %s values as abort-like",
+		(name) => {
+			const error = new Error(name);
+			error.name = name;
+			expect(isAbortLike(error)).toBe(true);
+		},
+	);
+
+	it("does not classify unrelated errors as abort-like", () => {
+		expect(isAbortLike(new Error("network failure"))).toBe(false);
+		expect(isAbortLike({ name: "AbortError" })).toBe(false);
+	});
+
+	it("synchronizes HevyHttpError execution aliases", () => {
+		const error = new HevyHttpError("request failed", {
+			method: "PUT",
+			endpoint: "/v1/workouts/:workoutId",
+		});
+		error.setExecutionMetadata({
+			phase: "dispatch",
+			operationSafety: "idempotent-write",
+			commitState: "unknown",
+			safeToRetry: true,
+			outcome: "retryable_failure",
+		});
+
+		expect(error).toMatchObject({
+			phase: "dispatch",
+			phase_name: "dispatch",
+			operationSafety: "idempotent-write",
+			operation_safety: "idempotent-write",
+			commitState: "unknown",
+			commit_state: "unknown",
+			safeToRetry: true,
+			safe_to_retry: true,
+			outcome: "retryable_failure",
+		});
 	});
 
 	it("emits bounded events without raw response or exception data", async () => {
@@ -544,7 +584,7 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 
-	it("does not let public safety metadata make a POST retryable", async () => {
+	it("derives POST safety from the HTTP method", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
 		const client = createHevyClient({
 			apiKey: "secret-key",
@@ -554,7 +594,7 @@ describe("@hevy-mcp/hevy-client", () => {
 
 		await expect(
 			client.createWorkout({ workout: {} } as never, {
-				operation_safety: "read",
+				deadline: Date.now() + 1_000,
 			}),
 		).rejects.toMatchObject({
 			commit_state: "unknown",

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHevyClient } from "./hevy-client.js";
 import {
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	HevyHttpError,
 } from "./hevy-http-error.js";
+import { createExecutionSignal } from "./execution.js";
 function response(data: unknown, status = 200): Response {
 	return new Response(JSON.stringify(data), {
 		status,
@@ -55,6 +57,14 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 
+	it("does not abort an execution signal twice", () => {
+		const execution = createExecutionSignal({});
+		execution.abort(new DOMException("done", "AbortError"));
+		execution.abort(new DOMException("ignored", "AbortError"));
+		execution.cleanup();
+		expect(execution.signal.reason).toMatchObject({ message: "done" });
+	});
+
 	it("emits bounded events without raw response or exception data", async () => {
 		const onLog = vi.fn(() => {
 			throw new Error("observer-secret");
@@ -90,7 +100,9 @@ describe("@hevy-mcp/hevy-client", () => {
 		});
 
 		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
-			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			phase: "response-content",
+			outcome: "deadline_exceeded",
 		});
 	});
 
@@ -104,7 +116,9 @@ describe("@hevy-mcp/hevy-client", () => {
 		});
 
 		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
-			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			phase: "dispatch",
+			outcome: "deadline_exceeded",
 		});
 	});
 	it("finishes request observations when callers cancel", async () => {
@@ -135,10 +149,10 @@ describe("@hevy-mcp/hevy-client", () => {
 		await expect(request).rejects.toMatchObject({
 			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
 		});
-		expect(outcomes).toEqual(["terminal_failure"]);
+		expect(outcomes).toEqual(["cancelled"]);
 	});
 
-	it("bounds retries for hanging response bodies", async () => {
+	it("uses one timeout budget for hanging response bodies", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());
 		const client = createHevyClient({
 			apiKey: "secret-key",
@@ -149,10 +163,52 @@ describe("@hevy-mcp/hevy-client", () => {
 		});
 
 		await expect(client.getRoutineById("routine-1")).rejects.toMatchObject({
-			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			phase: "response-content",
+			outcome: "deadline_exceeded",
 		});
-		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenCalledOnce();
 	});
+
+	it("cancels response-content consumption through the caller signal", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 0,
+		});
+		const request = client.getRoutineById("routine-1", {
+			signal: controller.signal,
+		});
+		await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+		controller.abort(new DOMException("caller canceled", "AbortError"));
+
+		await expect(request).rejects.toMatchObject({
+			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+			phase: "response-content",
+			outcome: "cancelled",
+		});
+	});
+
+	it("does not restart timeoutMs during retry backoff", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			timeoutMs: 20,
+			maxGetRetries: 3,
+			sleep: () => new Promise<void>(() => {}),
+		});
+
+		await expect(client.getUserInfo()).rejects.toMatchObject({
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			phase: "backoff",
+			outcome: "deadline_exceeded",
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
 	it("times API observations across response parsing", async () => {
 		let releaseBody!: () => void;
 		const bodyReady = new Promise<void>((resolve) => {
@@ -314,8 +370,12 @@ describe("@hevy-mcp/hevy-client", () => {
 			},
 		});
 
-		await expect(client.getUserInfo()).rejects.toMatchObject({
+		const thrown = await client.getUserInfo().catch((error: unknown) => error);
+		expect(thrown).toMatchObject({
 			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+			safeToRetry: false,
+			safe_to_retry: false,
+			outcome: "terminal_failure",
 		});
 		expect(observations).toEqual([
 			{ outcome: "retryable_failure", code: undefined },
@@ -356,5 +416,390 @@ describe("@hevy-mcp/hevy-client", () => {
 				code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 			},
 		]);
+	});
+
+	it("classifies synchronous pre-dispatch failures as not sent", async () => {
+		const fetchMock = vi.fn(() => {
+			throw Object.assign(new TypeError("socket unavailable"), {
+				code: "ECONNREFUSED",
+			});
+		});
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 0,
+		});
+
+		await expect(client.getUserInfo()).rejects.toMatchObject({
+			phase: "before-dispatch",
+			commit_state: "not_sent",
+			safe_to_retry: false,
+			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("cancels an in-flight retry backoff without starting another attempt", async () => {
+		const controller = new AbortController();
+		let releaseSleep!: () => void;
+		let sleepStarted!: () => void;
+		const sleepWasStarted = new Promise<void>((resolve) => {
+			sleepStarted = resolve;
+		});
+		const sleep = new Promise<void>((resolve) => {
+			releaseSleep = resolve;
+		});
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 2,
+			sleep: async () => {
+				sleepStarted();
+				return sleep;
+			},
+		});
+
+		const request = client.getUserInfo({ signal: controller.signal });
+		await sleepWasStarted;
+		controller.abort();
+		await expect(request).rejects.toMatchObject({
+			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+			phase: "backoff",
+			safe_to_retry: false,
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+		releaseSleep();
+	});
+
+	it("cancels the default retry backoff and clears its timer", async () => {
+		vi.useFakeTimers();
+		try {
+			const controller = new AbortController();
+			let retryWaitStarted!: () => void;
+			const retryWait = new Promise<void>((resolve) => {
+				retryWaitStarted = resolve;
+			});
+			const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+			const client = createHevyClient({
+				apiKey: "secret-key",
+				fetch: fetchMock,
+				maxGetRetries: 1,
+				timeoutMs: 60_000,
+				onRetryWait: () => {
+					retryWaitStarted();
+				},
+			});
+
+			const request = client.getUserInfo({ signal: controller.signal });
+			await retryWait;
+			controller.abort();
+
+			await expect(request).rejects.toMatchObject({
+				code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+				phase: "backoff",
+			});
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("uses one absolute deadline across retries and response consumption", async () => {
+		const fetchMock = vi.fn().mockImplementation(
+			() =>
+				new Promise<Response>((resolve) => {
+					setTimeout(() => resolve(response({})), 50);
+				}),
+		);
+		const deadline = Date.now() + 10;
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 5,
+		});
+
+		await expect(client.getUserInfo({ deadline })).rejects.toMatchObject({
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			outcome: "deadline_exceeded",
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("never retries a non-idempotent write and marks dispatch uncertainty", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 5,
+		});
+
+		await expect(
+			client.createWorkout({ workout: {} } as never),
+		).rejects.toMatchObject({
+			commit_state: "unknown",
+			safe_to_retry: false,
+			operation_safety: "non-idempotent-write",
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("does not let public safety metadata make a POST retryable", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 5,
+		});
+
+		await expect(
+			client.createWorkout({ workout: {} } as never, {
+				operation_safety: "read",
+			}),
+		).rejects.toMatchObject({
+			commit_state: "unknown",
+			safe_to_retry: false,
+			operation_safety: "non-idempotent-write",
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("retries idempotent PUT updates with an unknown commit state", async () => {
+		const observations: Array<{
+			operationSafety?: string;
+			commitState?: string;
+			safeToRetry?: boolean;
+		}> = [];
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(response({}, 503))
+			.mockResolvedValueOnce(response({ id: "workout-1" }));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			sleep: async () => {},
+			onRequestComplete: ({ operationSafety, commitState, safeToRetry }) =>
+				observations.push({ operationSafety, commitState, safeToRetry }),
+		});
+
+		await expect(
+			client.updateWorkout("workout-1", {} as never),
+		).resolves.toEqual({ id: "workout-1" });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(observations[0]).toMatchObject({
+			operationSafety: "idempotent-write",
+			commitState: "unknown",
+			safeToRetry: true,
+		});
+	});
+
+	it("honors Retry-After while adding bounded jitter", async () => {
+		const waits: number[] = [];
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("{}", {
+					status: 429,
+					headers: { "retry-after": "2" },
+				}),
+			)
+			.mockResolvedValueOnce(response({}));
+		const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+		try {
+			const client = createHevyClient({
+				apiKey: "secret-key",
+				fetch: fetchMock,
+				maxGetRetries: 1,
+				sleep: async (delay) => {
+					waits.push(delay);
+				},
+			});
+			await client.getUserInfo();
+		} finally {
+			random.mockRestore();
+		}
+		expect(waits).toHaveLength(1);
+		expect(waits[0]).toBeGreaterThanOrEqual(2_000);
+		expect(waits[0]).toBeLessThanOrEqual(2_250);
+	});
+
+	it("honors a Retry-After hint above the exponential cap", async () => {
+		const waits: number[] = [];
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("{}", {
+					status: 429,
+					headers: { "retry-after": "20" },
+				}),
+			)
+			.mockResolvedValueOnce(response({}));
+		const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+		try {
+			const client = createHevyClient({
+				apiKey: "secret-key",
+				fetch: fetchMock,
+				maxGetRetries: 1,
+				sleep: async (delay) => {
+					waits.push(delay);
+				},
+			});
+			await client.getUserInfo({ deadline: Date.now() + 30_000 });
+		} finally {
+			random.mockRestore();
+		}
+		expect(waits[0]).toBeGreaterThan(20_000);
+		expect(waits[0]).toBeLessThanOrEqual(20_250);
+	});
+
+	it("completes the native retry timer before the next attempt", async () => {
+		vi.useFakeTimers();
+		try {
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce(response({}, 503))
+				.mockResolvedValueOnce(response({ recovered: true }));
+			const client = createHevyClient({
+				apiKey: "secret-key",
+				fetch: fetchMock,
+				maxGetRetries: 1,
+				timeoutMs: 10_000,
+			});
+
+			const request = client.getUserInfo();
+			await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+			await vi.advanceTimersByTimeAsync(300);
+			await expect(request).resolves.toEqual({ recovered: true });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("honors cancellation that arrives before retry backoff starts", async () => {
+		const controller = new AbortController();
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			onRequestComplete: ({ outcome }) => {
+				if (outcome === "retryable_failure") controller.abort();
+			},
+		});
+
+		await expect(
+			client.getUserInfo({ signal: controller.signal }),
+		).rejects.toMatchObject({
+			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+			phase: "backoff",
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("projects a retry sleep failure as a backoff error", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			sleep: vi.fn().mockRejectedValue(new Error("sleep failed")),
+		});
+
+		await expect(client.getUserInfo()).rejects.toMatchObject({
+			phase: "backoff",
+			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("rejects before dispatch when the caller deadline is already elapsed", async () => {
+		const fetchMock = vi.fn();
+		const complete = vi.fn();
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 0,
+			onRequestComplete: complete,
+		});
+
+		await expect(
+			client.getUserInfo({ deadline: Date.now() - 1 }),
+		).rejects.toMatchObject({
+			code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+			phase: "before-dispatch",
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(complete).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "deadline_exceeded" }),
+		);
+	});
+
+	it("forwards every curated operation through its generated API wrapper", async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => response({}));
+		const client = createHevyClient({
+			apiKey: "secret-key",
+			fetch: fetchMock,
+			maxGetRetries: 0,
+		});
+
+		await client.getWorkouts({ page: 1 });
+		await client.getWorkout("workout-1");
+		await client.createWorkout({} as never);
+		await client.updateWorkout("workout-1", {} as never);
+		await client.getWorkoutCount();
+		await client.getWorkoutEvents({ page: 1 });
+		await client.getRoutines({ page: 1 });
+		await client.getRoutineById("routine-1");
+		await client.createRoutine({} as never);
+		await client.updateRoutine("routine-1", {} as never);
+		await client.getExerciseTemplates({ page: 1 });
+		await client.getExerciseTemplate("template-1");
+		await client.getExerciseHistory("template-1", { start_date: "2025-01-01" });
+		await client.createExerciseTemplate({} as never);
+		await client.getRoutineFolders({ page: 1 });
+		await client.createRoutineFolder({} as never);
+		await client.getRoutineFolder("folder-1");
+		await client.getBodyMeasurements({ page: 1 });
+		await client.getBodyMeasurement("2025-01-01");
+		await client.createBodyMeasurement({} as never);
+		await client.updateBodyMeasurement("2025-01-01", {} as never);
+		await client.getUserInfo();
+
+		expect(fetchMock).toHaveBeenCalledTimes(22);
+	});
+
+	it("bounds an over-budget Retry-After by the absolute deadline", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"));
+		try {
+			const waits: number[] = [];
+			const fetchMock = vi.fn().mockResolvedValue(
+				new Response("{}", {
+					status: 429,
+					headers: { "retry-after": "20" },
+				}),
+			);
+			const client = createHevyClient({
+				apiKey: "secret-key",
+				fetch: fetchMock,
+				maxGetRetries: 1,
+				sleep: async (delay) => {
+					waits.push(delay);
+					vi.advanceTimersByTime(delay);
+				},
+			});
+			await expect(
+				client.getUserInfo({ deadline: Date.now() + 1_000 }),
+			).rejects.toMatchObject({
+				code: HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+				phase: "backoff",
+				outcome: "deadline_exceeded",
+			});
+			expect(waits).toEqual([1_000]);
+			expect(fetchMock).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/hevy-client/src/hevy-client.ts
+++ b/packages/hevy-client/src/hevy-client.ts
@@ -39,11 +39,10 @@ import type {
 } from "./generated/client/types";
 import { createClient as createKubbClient } from "./hevy-client-kubb.js";
 import type { HevyClientOptions } from "./hevy-client-kubb.js";
-import type { HevyExecutionOptions } from "./execution.js";
+import type { HevyRequestOptions } from "./execution.js";
 
 export type { HevyClientOptions };
-
-export interface HevyRequestOptions extends HevyExecutionOptions {}
+export type { HevyRequestOptions } from "./execution.js";
 
 export type { HevyOperationSafety } from "./execution.js";
 

--- a/packages/hevy-client/src/hevy-client.ts
+++ b/packages/hevy-client/src/hevy-client.ts
@@ -39,76 +39,101 @@ import type {
 } from "./generated/client/types";
 import { createClient as createKubbClient } from "./hevy-client-kubb.js";
 import type { HevyClientOptions } from "./hevy-client-kubb.js";
+import type { HevyExecutionOptions } from "./execution.js";
 
 export type { HevyClientOptions };
 
-export interface HevyRequestOptions {
-	readonly signal?: AbortSignal;
-}
+export interface HevyRequestOptions extends HevyExecutionOptions {}
+
+export type { HevyOperationSafety } from "./execution.js";
 
 export interface HevyClient {
 	getWorkouts(
 		params?: GetV1WorkoutsQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1WorkoutsQueryResponse>;
-	getWorkout(workoutId: string): Promise<GetV1WorkoutsWorkoutidQueryResponse>;
+	getWorkout(
+		workoutId: string,
+		options?: HevyRequestOptions,
+	): Promise<GetV1WorkoutsWorkoutidQueryResponse>;
 	createWorkout(
 		data: PostV1WorkoutsMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PostV1WorkoutsMutationResponse>;
 	updateWorkout(
 		workoutId: string,
 		data: PutV1WorkoutsWorkoutidMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PutV1WorkoutsWorkoutidMutationResponse>;
-	getWorkoutCount(): Promise<GetV1WorkoutsCountQueryResponse>;
+	getWorkoutCount(
+		options?: HevyRequestOptions,
+	): Promise<GetV1WorkoutsCountQueryResponse>;
 	getWorkoutEvents(
 		params?: GetV1WorkoutsEventsQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1WorkoutsEventsQueryResponse>;
 	getRoutines(
 		params?: GetV1RoutinesQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1RoutinesQueryResponse>;
 	getRoutineById(
 		routineId: string,
+		options?: HevyRequestOptions,
 	): Promise<GetV1RoutinesRoutineidQueryResponse>;
 	createRoutine(
 		data: PostV1RoutinesMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PostV1RoutinesMutationResponse>;
 	updateRoutine(
 		routineId: string,
 		data: PutV1RoutinesRoutineidMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PutV1RoutinesRoutineidMutationResponse>;
 	getExerciseTemplates(
 		params?: GetV1ExerciseTemplatesQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1ExerciseTemplatesQueryResponse>;
 	getExerciseTemplate(
 		templateId: string,
+		options?: HevyRequestOptions,
 	): Promise<GetV1ExerciseTemplatesExercisetemplateidQueryResponse>;
 	getExerciseHistory(
 		exerciseTemplateId: string,
 		params?: GetV1ExerciseHistoryExercisetemplateidQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1ExerciseHistoryExercisetemplateidQueryResponse>;
 	createExerciseTemplate(
 		data: PostV1ExerciseTemplatesMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PostV1ExerciseTemplatesMutationResponse>;
 	getRoutineFolders(
 		params?: GetV1RoutineFoldersQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1RoutineFoldersQueryResponse>;
 	createRoutineFolder(
 		data: PostV1RoutineFoldersMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PostV1RoutineFoldersMutationResponse>;
 	getRoutineFolder(
 		folderId: string,
+		options?: HevyRequestOptions,
 	): Promise<GetV1RoutineFoldersFolderidQueryResponse>;
 	getBodyMeasurements(
 		params?: GetV1BodyMeasurementsQueryParams,
+		options?: HevyRequestOptions,
 	): Promise<GetV1BodyMeasurementsQueryResponse>;
 	getBodyMeasurement(
 		date: string,
+		options?: HevyRequestOptions,
 	): Promise<GetV1BodyMeasurementsDateQueryResponse>;
 	createBodyMeasurement(
 		data: PostV1BodyMeasurementsMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PostV1BodyMeasurementsMutationResponse>;
 	updateBodyMeasurement(
 		date: string,
 		data: PutV1BodyMeasurementsDateMutationRequest,
+		options?: HevyRequestOptions,
 	): Promise<PutV1BodyMeasurementsDateMutationResponse>;
 	getUserInfo(
 		options?: HevyRequestOptions,

--- a/packages/hevy-client/src/hevy-http-error.ts
+++ b/packages/hevy-client/src/hevy-http-error.ts
@@ -25,6 +25,14 @@ export interface HevyHttpErrorOptions {
 	outcome?: HevyExecutionOutcome;
 }
 
+export interface HevyExecutionMetadata {
+	phase?: HevyRequestPhase;
+	operationSafety?: HevyOperationSafety;
+	commitState?: HevyCommitState;
+	safeToRetry?: boolean;
+	outcome?: HevyExecutionOutcome;
+}
+
 /** Sanitized HTTP error that never contains credentials or full request URLs. */
 export class HevyHttpError extends Error {
 	readonly status?: number;
@@ -33,16 +41,16 @@ export class HevyHttpError extends Error {
 	readonly headers?: Headers;
 	readonly method: string;
 	readonly endpoint: string;
-	readonly phase?: HevyRequestPhase;
-	readonly operationSafety?: HevyOperationSafety;
-	readonly commitState?: HevyCommitState;
-	readonly safeToRetry?: boolean;
-	readonly outcome?: HevyExecutionOutcome;
+	phase?: HevyRequestPhase;
+	operationSafety?: HevyOperationSafety;
+	commitState?: HevyCommitState;
+	safeToRetry?: boolean;
+	outcome?: HevyExecutionOutcome;
 	/** Stable snake-case aliases for adapter/protocol projections. */
-	readonly phase_name?: HevyRequestPhase;
-	readonly operation_safety?: HevyOperationSafety;
-	readonly commit_state?: HevyCommitState;
-	readonly safe_to_retry?: boolean;
+	phase_name?: HevyRequestPhase;
+	operation_safety?: HevyOperationSafety;
+	commit_state?: HevyCommitState;
+	safe_to_retry?: boolean;
 	code?: string;
 	hevyRetryCount?: number;
 	hevyRetryExhausted?: boolean;
@@ -57,15 +65,20 @@ export class HevyHttpError extends Error {
 		this.method = options.method;
 		this.endpoint = options.endpoint;
 		this.code = options.code;
-		this.phase = options.phase;
-		this.operationSafety = options.operationSafety;
-		this.commitState = options.commitState;
-		this.safeToRetry = options.safeToRetry;
-		this.outcome = options.outcome;
-		this.phase_name = options.phase;
-		this.operation_safety = options.operationSafety;
-		this.commit_state = options.commitState;
-		this.safe_to_retry = options.safeToRetry;
+		this.setExecutionMetadata(options);
+	}
+
+	/** Update execution fields and their protocol aliases as one lifecycle step. */
+	setExecutionMetadata(metadata: HevyExecutionMetadata): void {
+		this.phase = metadata.phase;
+		this.phase_name = metadata.phase;
+		this.operationSafety = metadata.operationSafety;
+		this.operation_safety = metadata.operationSafety;
+		this.commitState = metadata.commitState;
+		this.commit_state = metadata.commitState;
+		this.safeToRetry = metadata.safeToRetry;
+		this.safe_to_retry = metadata.safeToRetry;
+		this.outcome = metadata.outcome;
 	}
 }
 

--- a/packages/hevy-client/src/hevy-http-error.ts
+++ b/packages/hevy-client/src/hevy-http-error.ts
@@ -1,5 +1,13 @@
+import type {
+	HevyCommitState,
+	HevyExecutionOutcome,
+	HevyOperationSafety,
+	HevyRequestPhase,
+} from "./execution.js";
+
 export const HEVY_RETRY_EXHAUSTED_ERROR_CODE = "HEVY_RETRY_EXHAUSTED";
 export const HEVY_REQUEST_ABORTED_ERROR_CODE = "HEVY_REQUEST_ABORTED";
+export const HEVY_DEADLINE_EXCEEDED_ERROR_CODE = "HEVY_DEADLINE_EXCEEDED";
 
 export interface HevyHttpErrorOptions {
 	status?: number;
@@ -10,6 +18,11 @@ export interface HevyHttpErrorOptions {
 	endpoint: string;
 	code?: string;
 	cause?: unknown;
+	phase?: HevyRequestPhase;
+	operationSafety?: HevyOperationSafety;
+	commitState?: HevyCommitState;
+	safeToRetry?: boolean;
+	outcome?: HevyExecutionOutcome;
 }
 
 /** Sanitized HTTP error that never contains credentials or full request URLs. */
@@ -20,6 +33,16 @@ export class HevyHttpError extends Error {
 	readonly headers?: Headers;
 	readonly method: string;
 	readonly endpoint: string;
+	readonly phase?: HevyRequestPhase;
+	readonly operationSafety?: HevyOperationSafety;
+	readonly commitState?: HevyCommitState;
+	readonly safeToRetry?: boolean;
+	readonly outcome?: HevyExecutionOutcome;
+	/** Stable snake-case aliases for adapter/protocol projections. */
+	readonly phase_name?: HevyRequestPhase;
+	readonly operation_safety?: HevyOperationSafety;
+	readonly commit_state?: HevyCommitState;
+	readonly safe_to_retry?: boolean;
 	code?: string;
 	hevyRetryCount?: number;
 	hevyRetryExhausted?: boolean;
@@ -34,6 +57,15 @@ export class HevyHttpError extends Error {
 		this.method = options.method;
 		this.endpoint = options.endpoint;
 		this.code = options.code;
+		this.phase = options.phase;
+		this.operationSafety = options.operationSafety;
+		this.commitState = options.commitState;
+		this.safeToRetry = options.safeToRetry;
+		this.outcome = options.outcome;
+		this.phase_name = options.phase;
+		this.operation_safety = options.operationSafety;
+		this.commit_state = options.commitState;
+		this.safe_to_retry = options.safeToRetry;
 	}
 }
 

--- a/packages/hevy-client/src/index.ts
+++ b/packages/hevy-client/src/index.ts
@@ -40,5 +40,6 @@ export {
 export {
 	HevyHttpError,
 	isHevyHttpError,
+	type HevyExecutionMetadata,
 	type HevyHttpErrorOptions,
 } from "./hevy-http-error.js";

--- a/packages/hevy-client/src/index.ts
+++ b/packages/hevy-client/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./hevy-client.js";
 export {
 	DEFAULT_API_TIMEOUT_MS,
+	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	MAX_GET_RETRIES,
@@ -20,6 +21,22 @@ export {
 	type HevyRetryWait,
 	type HevyRetryWaitScope,
 } from "./hevy-client-kubb.js";
+export {
+	canRetryOperation,
+	commitStateFor,
+	createExecutionSignal,
+	isAbortLike,
+	isDeadlineExceeded,
+	operationSafetyForMethod,
+	remainingDeadlineMs,
+	type HevyCommitState,
+	type HevyExecutionControl,
+	type HevyExecutionOptions,
+	type HevyExecutionOutcome,
+	type HevyExecutionOutcomeDetails,
+	type HevyOperationSafety,
+	type HevyRequestPhase,
+} from "./execution.js";
 export {
 	HevyHttpError,
 	isHevyHttpError,

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -95,6 +95,13 @@ vi.mock("@hevy-mcp/hevy-client", () => ({
 vi.mock("@hevy-mcp/core", () => ({
 	createHevyMcpServer: testDoubles.createHevyMcpServer,
 	createSafeErrorDiagnostic: vi.fn(() => ({ category: "Error" })),
+	mergeAbortSignals: (...signals: Array<AbortSignal | undefined>) => {
+		const active = signals.filter(
+			(signal): signal is AbortSignal => signal !== undefined,
+		);
+		if (active.length <= 1) return active[0];
+		return AbortSignal.any(active);
+	},
 	ErrorType: {
 		UNKNOWN_ERROR: "UNKNOWN_ERROR",
 		VALIDATION_ERROR: "VALIDATION_ERROR",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -15,7 +15,11 @@ import { serverStartups } from "./utils/metrics.js";
 
 import { SpanStatusCode, type Span } from "@opentelemetry/api";
 import { z } from "zod";
-import { createHevyMcpServer, createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import {
+	createHevyMcpServer,
+	createSafeErrorDiagnostic,
+	mergeAbortSignals,
+} from "@hevy-mcp/core";
 import { createHevyClient, isHevyHttpError } from "@hevy-mcp/hevy-client";
 import { assertApiKey, parseConfig } from "./utils/config.js";
 import { parseNodeCliOptions, type NodeTransport } from "./utils/arguments.js";
@@ -199,7 +203,7 @@ function recordLifecycleFailure(
 	span.addEvent("mcp.lifecycle.failure", attributes);
 	recordTelemetryException(error, attributes, span);
 }
-async function validateApiKey(apiKey: string) {
+async function validateApiKey(apiKey: string, signal?: AbortSignal) {
 	// Keep the startup probe separate from the normal MCP-aware client. The
 	// server is not connected yet, so structured client logging is intentionally
 	// omitted until the normal client is built below.
@@ -211,8 +215,12 @@ async function validateApiKey(apiKey: string) {
 	});
 
 	try {
-		await startupProbeClient.getUserInfo();
+		await startupProbeClient.getUserInfo({
+			signal,
+			deadline: Date.now() + STARTUP_PROBE_TIMEOUT_MS,
+		});
 	} catch (error) {
+		if (signal?.aborted) throw error;
 		const status = getHttpStatus(error);
 		if (status === 401 || status === 403) {
 			throw new Error(INVALID_API_KEY_MESSAGE);
@@ -227,7 +235,11 @@ async function validateApiKey(apiKey: string) {
 	}
 }
 
-function buildServer(apiKey: string, transport: NodeTransport = "stdio") {
+function buildServer(
+	apiKey: string,
+	transport: NodeTransport = "stdio",
+	lifecycleSignal?: AbortSignal,
+) {
 	return tracer.startActiveSpan(
 		"mcp.server.build",
 		{
@@ -247,6 +259,7 @@ function buildServer(apiKey: string, transport: NodeTransport = "stdio") {
 							...createNodeHevyClientOptions(),
 							onLog,
 						}),
+					lifecycleSignal,
 					decorateServer: (baseServer) =>
 						Sentry.wrapMcpServerWithSentry(baseServer, {
 							recordInputs: false,
@@ -276,11 +289,12 @@ function buildServer(apiKey: string, transport: NodeTransport = "stdio") {
 export async function createNodeMcpServer(
 	{ apiKey }: { apiKey: string },
 	transport: NodeTransport = "stdio",
+	lifecycleSignal?: AbortSignal,
 ) {
 	const { apiKey: validatedApiKey } = serverConfigSchema.parse({ apiKey });
 	setTelemetryUser(validatedApiKey);
-	await validateApiKey(validatedApiKey);
-	return buildServer(validatedApiKey, transport);
+	await validateApiKey(validatedApiKey, lifecycleSignal);
+	return buildServer(validatedApiKey, transport, lifecycleSignal);
 }
 
 export async function runStdioServer() {
@@ -297,6 +311,7 @@ export async function runStdioServer() {
 		return;
 	}
 	const cleanupProcessExceptionTracking = installProcessExceptionTracking();
+	const lifecycleController = new AbortController();
 
 	serverStartups.add(1, { version });
 
@@ -322,7 +337,11 @@ export async function runStdioServer() {
 				const apiKey = cfg.apiKey;
 				assertApiKey(apiKey);
 
-				const server = await createNodeMcpServer({ apiKey });
+				const server = await createNodeMcpServer(
+					{ apiKey },
+					"stdio",
+					lifecycleController.signal,
+				);
 				console.error("Starting MCP server in stdio mode");
 				const transport = createInstrumentedStdioTransport(
 					new StdioServerTransport(),
@@ -357,6 +376,7 @@ export async function runStdioServer() {
 				});
 				installGracefulShutdown({
 					target: server,
+					cancel: lifecycleController,
 					onComplete: async (succeeded) => {
 						recordMcpSessionTermination(
 							resolveSessionTerminationCategory(succeeded),
@@ -402,6 +422,7 @@ export async function runServer(): Promise<void> {
 		return;
 	}
 	const cleanupProcessExceptionTracking = installProcessExceptionTracking();
+	const lifecycleController = new AbortController();
 
 	await tracer.startActiveSpan(
 		"mcp.server.run",
@@ -418,11 +439,21 @@ export async function runServer(): Promise<void> {
 				const cfg = parseConfig(process.env);
 				assertApiKey(cfg.apiKey);
 				setTelemetryUser(cfg.apiKey);
-				await validateApiKey(cfg.apiKey);
+				await validateApiKey(cfg.apiKey, lifecycleController.signal);
 				const handle = await startStreamableHttpServer(
 					options,
 					cfg.apiKey,
-					(params) => Promise.resolve(buildServer(params.apiKey, "http")),
+					(params) =>
+						Promise.resolve(
+							buildServer(
+								params.apiKey,
+								"http",
+								mergeAbortSignals(
+									lifecycleController.signal,
+									params.lifecycleSignal,
+								),
+							),
+						),
 				);
 				listening = true;
 				console.error(
@@ -434,6 +465,7 @@ export async function runServer(): Promise<void> {
 				});
 				installGracefulShutdown({
 					target: handle,
+					cancel: lifecycleController,
 					onComplete: async () => {
 						cleanupProcessExceptionTracking();
 						await flushTelemetry();

--- a/packages/node/src/utils/execution-telemetry.test.ts
+++ b/packages/node/src/utils/execution-telemetry.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { projectExecutionAttributes } from "./execution-telemetry.js";
+
+describe("projectExecutionAttributes", () => {
+	it("projects snake_case execution fields for spans", () => {
+		expect(
+			projectExecutionAttributes({
+				outcome: "terminal_failure",
+				phase: "response-content",
+				operation_safety: "read",
+				commit_state: "unknown",
+				safe_to_retry: false,
+			}),
+		).toEqual({
+			"hevy.api.outcome": "terminal_failure",
+			"hevy.api.phase": "response-content",
+			"hevy.api.operation_safety": "read",
+			"hevy.api.commit_state": "unknown",
+			"hevy.api.safe_to_retry": false,
+		});
+	});
+
+	it("projects camelCase observation fields for metrics", () => {
+		expect(
+			projectExecutionAttributes(
+				{
+					outcome: "retryable_failure",
+					phase: "dispatch",
+					operationSafety: "idempotent-write",
+					commitState: "unknown",
+					safeToRetry: false,
+				},
+				"metric",
+			),
+		).toEqual({
+			outcome: "retryable_failure",
+			phase: "dispatch",
+			operation_safety: "idempotent-write",
+			commit_state: "unknown",
+			safe_to_retry: false,
+		});
+	});
+
+	it("prefers snake_case fields when both representations are present", () => {
+		expect(
+			projectExecutionAttributes({
+				operation_safety: "read",
+				operationSafety: "non-idempotent-write",
+				commit_state: "not_sent",
+				commitState: "confirmed",
+				safe_to_retry: false,
+				safeToRetry: true,
+			}),
+		).toEqual({
+			"hevy.api.operation_safety": "read",
+			"hevy.api.commit_state": "not_sent",
+			"hevy.api.safe_to_retry": false,
+		});
+	});
+});

--- a/packages/node/src/utils/execution-telemetry.ts
+++ b/packages/node/src/utils/execution-telemetry.ts
@@ -1,0 +1,39 @@
+import type { StructuredExecutionProjection } from "@hevy-mcp/core";
+import type { HevyRequestObservation } from "@hevy-mcp/hevy-client";
+
+type ExecutionAttributeSource = {
+	readonly outcome?: StructuredExecutionProjection["outcome"];
+	readonly phase?: StructuredExecutionProjection["phase"];
+	readonly operation_safety?: StructuredExecutionProjection["operation_safety"];
+	readonly operationSafety?: HevyRequestObservation["operationSafety"];
+	readonly commit_state?: StructuredExecutionProjection["commit_state"];
+	readonly commitState?: HevyRequestObservation["commitState"];
+	readonly safe_to_retry?: StructuredExecutionProjection["safe_to_retry"];
+	readonly safeToRetry?: HevyRequestObservation["safeToRetry"];
+};
+
+export type ExecutionTelemetryNamespace = "span" | "metric";
+
+/** Project either structured errors or client observations into stable OTel keys. */
+export function projectExecutionAttributes(
+	execution: ExecutionAttributeSource | undefined,
+	namespace: ExecutionTelemetryNamespace = "span",
+): Record<string, string | boolean> {
+	if (!execution) return {};
+	const prefix = namespace === "span" ? "hevy.api." : "";
+	const operationSafety =
+		execution.operation_safety ?? execution.operationSafety;
+	const commitState = execution.commit_state ?? execution.commitState;
+	const safeToRetry = execution.safe_to_retry ?? execution.safeToRetry;
+	return {
+		...(execution.outcome ? { [`${prefix}outcome`]: execution.outcome } : {}),
+		...(execution.phase ? { [`${prefix}phase`]: execution.phase } : {}),
+		...(operationSafety
+			? { [`${prefix}operation_safety`]: operationSafety }
+			: {}),
+		...(commitState ? { [`${prefix}commit_state`]: commitState } : {}),
+		...(safeToRetry !== undefined
+			? { [`${prefix}safe_to_retry`]: safeToRetry }
+			: {}),
+	};
+}

--- a/packages/node/src/utils/graceful-shutdown.test.ts
+++ b/packages/node/src/utils/graceful-shutdown.test.ts
@@ -74,4 +74,53 @@ describe("package-local graceful shutdown", () => {
 
 		expect(close).toHaveBeenCalledOnce();
 	});
+
+	it("aborts active execution before closing the server", async () => {
+		const process = new FakeProcess();
+		const cancel = new AbortController();
+		const close = vi.fn().mockResolvedValue(undefined);
+		const controller = installGracefulShutdown({
+			target: { close },
+			process,
+			cancel,
+			flush: vi.fn().mockResolvedValue(undefined),
+		});
+
+		process.emit("SIGINT");
+		await controller.getShutdownPromise();
+
+		expect(cancel.signal.aborted).toBe(true);
+		expect(close).toHaveBeenCalledOnce();
+	});
+
+	it("releases pending Hevy work before forced shutdown cleanup", async () => {
+		const process = new FakeProcess();
+		const cancel = new AbortController();
+		let activeSettled = false;
+		const activeWork = new Promise<void>((resolve) => {
+			cancel.signal.addEventListener(
+				"abort",
+				() => {
+					activeSettled = true;
+					resolve();
+				},
+				{ once: true },
+			);
+		});
+		const close = vi.fn(async () => {
+			await activeWork;
+		});
+		const controller = installGracefulShutdown({
+			target: { close },
+			process,
+			cancel,
+			flush: vi.fn().mockResolvedValue(undefined),
+		});
+
+		process.emit("SIGTERM");
+		await controller.getShutdownPromise();
+
+		expect(activeSettled).toBe(true);
+		expect(close).toHaveBeenCalledOnce();
+	});
 });

--- a/packages/node/src/utils/graceful-shutdown.ts
+++ b/packages/node/src/utils/graceful-shutdown.ts
@@ -32,6 +32,7 @@ interface GracefulShutdownOptions {
 	forcedExitTimeoutMs?: number;
 	onComplete?: (succeeded: boolean) => void | Promise<void>;
 	scheduleForcedExit?: ScheduleForcedExit;
+	cancel?: AbortController;
 }
 
 export interface GracefulShutdownController {
@@ -71,6 +72,7 @@ export function installGracefulShutdown({
 	flush = flushStdout,
 	forcedExitTimeoutMs = FORCED_EXIT_TIMEOUT_MS,
 	scheduleForcedExit = setTimeout,
+	cancel,
 	onComplete,
 }: GracefulShutdownOptions): GracefulShutdownController {
 	let listenersInstalled = true;
@@ -116,6 +118,9 @@ export function installGracefulShutdown({
 		if (processLike.exitCode == null) {
 			processLike.exitCode = 0;
 		}
+		cancel?.abort(
+			new DOMException(`Shutdown requested by ${signal}`, "AbortError"),
+		);
 
 		const forcedExitTimer = scheduleForcedExit(() => {
 			void reportCompletion(false);

--- a/packages/node/src/utils/hevy-client-observability.ts
+++ b/packages/node/src/utils/hevy-client-observability.ts
@@ -13,6 +13,7 @@ import {
 	getCurrentMcpSessionId,
 	getCurrentMcpTransport,
 } from "./mcp-session-observability.js";
+import { projectExecutionAttributes } from "./execution-telemetry.js";
 import { tracer } from "./telemetry.js";
 
 const SAFE_STATIC_ENDPOINTS = new Set([
@@ -73,7 +74,11 @@ function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 	if (observation.status > 0) {
 		span.setAttribute("http.response.status_code", observation.status);
 	}
-	span.setAttribute("hevy.api.outcome", observation.outcome);
+	for (const [key, value] of Object.entries(
+		projectExecutionAttributes(observation),
+	)) {
+		span.setAttribute(key, value);
+	}
 	if (observation.expectedReason) {
 		span.setAttribute("hevy.api.expected_reason", observation.expectedReason);
 	}
@@ -122,12 +127,16 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 			const retryCountBucket = bucketCount(observation.retryCount);
 			const errorAttributes = safeErrorAttributes(observation);
 			const metricEndpoint = normalizeHevyMetricEndpoint(observation.endpoint);
+			const metricExecutionAttributes = projectExecutionAttributes(
+				observation,
+				"metric",
+			);
 			apiCalls.add(1, {
 				method: observation.method,
 				endpoint: metricEndpoint,
 				status_code: observation.status,
 				retry_count_bucket: retryCountBucket,
-				outcome: observation.outcome,
+				...metricExecutionAttributes,
 				transport: getCurrentMcpTransport(),
 				...(observation.expectedReason
 					? { expected_reason: observation.expectedReason }
@@ -138,7 +147,7 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 				method: observation.method,
 				endpoint: metricEndpoint,
 				retry_count_bucket: retryCountBucket,
-				outcome: observation.outcome,
+				...metricExecutionAttributes,
 				transport: getCurrentMcpTransport(),
 				...(observation.expectedReason
 					? { expected_reason: observation.expectedReason }

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -6,6 +6,7 @@ import {
 	getCurrentMcpSessionId,
 	getCurrentMcpTransport,
 } from "./mcp-session-observability.js";
+import { projectExecutionAttributes } from "./execution-telemetry.js";
 import { recordTelemetryException, tracer } from "./telemetry.js";
 
 type SdkRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
@@ -68,6 +69,7 @@ function createFailureAttributes(
 		...(diagnostic.endpoint
 			? { "hevy.api.endpoint": diagnostic.endpoint }
 			: {}),
+		...projectExecutionAttributes(diagnostic),
 	};
 }
 

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -1,6 +1,6 @@
 import { request, type Server } from "node:http";
 import { McpServer } from "@modelcontextprotocol/server";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startStreamableHttpServer } from "./streamable-http.js";
 
 const createMcpServer = async () => {
@@ -117,6 +117,37 @@ async function startTestServer(host = "127.0.0.1") {
 	return { handle, port: serverPort(handle) };
 }
 
+async function startDisconnectTestServer() {
+	let releaseTool!: () => void;
+	let markStarted!: () => void;
+	const toolStarted = new Promise<void>((resolve) => {
+		markStarted = resolve;
+	});
+	const toolRelease = new Promise<void>((resolve) => {
+		releaseTool = resolve;
+	});
+	const createHangingServer = async () => {
+		const server = new McpServer({ name: "test-server", version: "1.0.0" });
+		server.registerTool(
+			"mock-tool",
+			{ description: "A mocked tool" },
+			async () => {
+				markStarted();
+				await toolRelease;
+				return { content: [{ type: "text", text: "mock result" }] };
+			},
+		);
+		return server;
+	};
+	const started = await startStreamableHttpServer(
+		{ transport: "http", host: "127.0.0.1", port: 0 },
+		"test-key",
+		createHangingServer,
+	);
+	handles.push(started);
+	return { ...started, port: serverPort(started), toolStarted, releaseTool };
+}
+
 async function initialize(port: number, headers: Record<string, string> = {}) {
 	return call(
 		port,
@@ -229,6 +260,97 @@ describe("Streamable HTTP server", () => {
 		).toBe(404);
 	});
 
+	it("evicts a session after a disconnected request", async () => {
+		const { port, toolStarted, releaseTool } =
+			await startDisconnectTestServer();
+		const initialized = await initialize(port);
+		const sessionId = String(initialized.headers["mcp-session-id"]);
+		const payload = JSON.stringify({
+			jsonrpc: "2.0",
+			id: 2,
+			method: "tools/call",
+			params: { name: "mock-tool", arguments: {} },
+		});
+		const disconnected = request({
+			host: "127.0.0.1",
+			port,
+			path: "/mcp",
+			method: "POST",
+			headers: {
+				Accept: "application/json, text/event-stream",
+				"Content-Type": "application/json",
+				"mcp-session-id": sessionId,
+			},
+		});
+		disconnected.once("error", () => {});
+		disconnected.end(payload);
+		await toolStarted;
+		disconnected.destroy();
+
+		await vi.waitFor(async () => {
+			const aftermath = await call(
+				port,
+				"POST",
+				{ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
+				{ "mcp-session-id": sessionId },
+			);
+			expect(aftermath.statusCode).toBe(404);
+		});
+		releaseTool();
+	});
+
+	it("aborts active session execution when DELETE closes the transport", async () => {
+		let sessionSignal: AbortSignal | undefined;
+		const createAbortAwareServer = async ({
+			lifecycleSignal,
+		}: {
+			apiKey: string;
+			lifecycleSignal?: AbortSignal;
+		}) => {
+			sessionSignal = lifecycleSignal;
+			const server = new McpServer({ name: "abort-aware", version: "1.0.0" });
+			server.registerTool(
+				"mock-tool",
+				{ description: "A mocked tool" },
+				async () => {
+					await new Promise<void>((resolve) =>
+						lifecycleSignal?.addEventListener("abort", () => resolve(), {
+							once: true,
+						}),
+					);
+					return { content: [{ type: "text", text: "aborted" }] };
+				},
+			);
+			return server;
+		};
+		const handle = await startStreamableHttpServer(
+			{ transport: "http", host: "127.0.0.1", port: 0 },
+			"test-key",
+			createAbortAwareServer,
+		);
+		handles.push(handle);
+		const port = serverPort(handle);
+		const initialized = await initialize(port);
+		const sessionId = String(initialized.headers["mcp-session-id"]);
+		const pendingCall = call(
+			port,
+			"POST",
+			{
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/call",
+				params: { name: "mock-tool", arguments: {} },
+			},
+			{ "mcp-session-id": sessionId },
+		).catch(() => undefined);
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+		await expect(
+			call(port, "DELETE", undefined, { "mcp-session-id": sessionId }),
+		).resolves.toMatchObject({ statusCode: 200 });
+		expect(sessionSignal?.aborted).toBe(true);
+		void pendingCall;
+	});
+
 	it("requires bearer authentication for wildcard binds", async () => {
 		process.env.HEVY_MCP_HTTP_BEARER_TOKEN = "http-test-token";
 		try {
@@ -269,6 +391,22 @@ describe("Streamable HTTP server", () => {
 
 		const oversized = await call(port, "POST", "x".repeat(1_048_577));
 		expect(oversized.statusCode).toBe(413);
+	});
+
+	it("returns structured errors when an MCP session fails during startup", async () => {
+		const handle = await startStreamableHttpServer(
+			{ transport: "http", host: "127.0.0.1", port: 0 },
+			"test-key",
+			async () => {
+				throw new Error("private startup detail");
+			},
+		);
+		handles.push(handle);
+
+		const result = await initialize(serverPort(handle));
+		expect(result.statusCode).toBe(500);
+		expect(result.body).toContain('"outcome":"terminal_failure"');
+		expect(result.body).not.toContain("private startup detail");
 	});
 
 	it("rejects a DNS-rebinding Host header and closes active sessions", async () => {

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -301,6 +301,10 @@ describe("Streamable HTTP server", () => {
 
 	it("aborts active session execution when DELETE closes the transport", async () => {
 		let sessionSignal: AbortSignal | undefined;
+		let markStarted!: () => void;
+		const toolStarted = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
 		const createAbortAwareServer = async ({
 			lifecycleSignal,
 		}: {
@@ -313,6 +317,7 @@ describe("Streamable HTTP server", () => {
 				"mock-tool",
 				{ description: "A mocked tool" },
 				async () => {
+					markStarted();
 					await new Promise<void>((resolve) =>
 						lifecycleSignal?.addEventListener("abort", () => resolve(), {
 							once: true,
@@ -343,7 +348,7 @@ describe("Streamable HTTP server", () => {
 			},
 			{ "mcp-session-id": sessionId },
 		).catch(() => undefined);
-		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+		await toolStarted;
 		await expect(
 			call(port, "DELETE", undefined, { "mcp-session-id": sessionId }),
 		).resolves.toMatchObject({ statusCode: 200 });

--- a/packages/node/src/utils/streamable-http.ts
+++ b/packages/node/src/utils/streamable-http.ts
@@ -6,7 +6,10 @@ import {
 	type ServerResponse,
 } from "node:http";
 import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
-import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import {
+	createExecutionProjection,
+	createSafeErrorDiagnostic,
+} from "@hevy-mcp/core";
 import type { NodeCliOptions } from "./arguments.js";
 import {
 	runWithMcpSessionContext,
@@ -29,12 +32,14 @@ export interface OwnedMcpServer {
 
 export type McpServerFactory = (params: {
 	apiKey: string;
+	lifecycleSignal?: AbortSignal;
 }) => Promise<OwnedMcpServer>;
 
 interface HttpSession {
 	transport: HttpTransport;
 	server: OwnedMcpServer;
 	context: McpSessionContext;
+	lifecycleController: AbortController;
 	responses: Set<ServerResponse>;
 	closed: boolean;
 }
@@ -122,6 +127,24 @@ function writeJson(res: ServerResponse, status: number, message: string): void {
 	res.statusCode = status;
 	res.setHeader("Content-Type", "application/json");
 	res.end(JSON.stringify({ error: message }));
+}
+
+function writeExecutionJson(
+	res: ServerResponse,
+	status: number,
+	message: string,
+	error: unknown,
+): void {
+	if (res.headersSent) return;
+	const diagnostic = createSafeErrorDiagnostic(error);
+	const execution = createExecutionProjection(diagnostic);
+	res.statusCode = status;
+	res.setHeader("Content-Type", "application/json");
+	res.end(
+		JSON.stringify({
+			error: { message, ...execution },
+		}),
+	);
 }
 
 function readBody(request: IncomingMessage): Promise<unknown> {
@@ -235,7 +258,7 @@ export async function startStreamableHttpServer(
 				return;
 			}
 			console.error(`HTTP request failed: ${safeDiagnostic(error)}`);
-			writeJson(response, 500, "Internal server error.");
+			writeExecutionJson(response, 500, "Internal server error.", error);
 		});
 	});
 
@@ -251,6 +274,12 @@ export async function startStreamableHttpServer(
 		for (const response of session.responses) {
 			if (!response.writableEnded) response.destroy();
 		}
+		// The SDK transport closes response streams, but its stateful close path
+		// does not abort the request signal already handed to MCP handlers. Abort
+		// the session-owned lifecycle signal first so active Hevy calls stop too.
+		session.lifecycleController.abort(
+			new DOMException("MCP session closed", "AbortError"),
+		);
 
 		const results = await Promise.allSettled([
 			Promise.resolve().then(() => session.transport.close()),
@@ -284,6 +313,25 @@ export async function startStreamableHttpServer(
 		);
 		if (errors.length > 0) throw aggregateErrors(errors, "MCP cleanup failed.");
 		return;
+	}
+
+	function trackSessionResponse(
+		session: HttpSession,
+		response: ServerResponse,
+	): void {
+		session.responses.add(response);
+		response.once("close", () => {
+			session.responses.delete(response);
+			// A destroyed response means the client disconnected before the
+			// exchange completed. The SDK does not expose a request-scoped signal
+			// for this transport, so evict and close the whole session rather than
+			// leaving an aborted session reusable or poisoning future requests.
+			if (!response.writableEnded && !session.closed) {
+				void closeSession(session).catch((error: unknown) => {
+					cleanupErrors.push(error);
+				});
+			}
+		});
 	}
 
 	async function handleRequest(
@@ -331,6 +379,7 @@ export async function startStreamableHttpServer(
 			let session: HttpSession | undefined;
 			let mcpServer: OwnedMcpServer | undefined;
 			let connected = false;
+			const lifecycleController = new AbortController();
 			const transport = new NodeStreamableHTTPServerTransport({
 				sessionIdGenerator: randomUUID,
 				onsessioninitialized: (id) => {
@@ -345,22 +394,28 @@ export async function startStreamableHttpServer(
 				}
 			};
 			try {
-				mcpServer = await createMcpServer({ apiKey });
+				mcpServer = await createMcpServer({
+					apiKey,
+					lifecycleSignal: lifecycleController.signal,
+				});
 				session = {
 					transport,
 					server: mcpServer,
 					context,
+					lifecycleController,
 					responses: new Set(),
 					closed: false,
 				};
 				await mcpServer.connect(transport);
 				connected = true;
-				session.responses.add(response);
-				response.once("close", () => session?.responses.delete(response));
+				trackSessionResponse(session, response);
 				await runWithMcpSessionContext(context, () =>
 					transport.handleRequest(request, response, body),
 				);
 			} catch (error) {
+				lifecycleController.abort(
+					new DOMException("MCP session startup failed", "AbortError"),
+				);
 				console.error(`HTTP session request failed: ${safeDiagnostic(error)}`);
 				let cleanupError: unknown;
 				try {
@@ -381,7 +436,7 @@ export async function startStreamableHttpServer(
 					console.error(`HTTP cleanup failed: ${safeDiagnostic(cleanupError)}`);
 				}
 				if (!response.writableEnded)
-					writeJson(response, 500, "Internal server error.");
+					writeExecutionJson(response, 500, "Internal server error.", error);
 			}
 			return;
 		}
@@ -396,8 +451,7 @@ export async function startStreamableHttpServer(
 			return;
 		}
 		if (request.method !== "DELETE") {
-			session.responses.add(response);
-			response.once("close", () => session.responses.delete(response));
+			trackSessionResponse(session, response);
 		}
 		await runWithMcpSessionContext(session.context, () =>
 			session.transport.handleRequest(request, response, body),

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -231,6 +231,11 @@ describe("createNodeToolObserver", () => {
 			"http.response.status_code": 503,
 			"http.request.method": "GET",
 			"hevy.api.endpoint": "/v1/workouts",
+			"hevy.api.outcome": "terminal_failure",
+			"hevy.api.phase": "before-dispatch",
+			"hevy.api.operation_safety": "read",
+			"hevy.api.commit_state": "not_sent",
+			"hevy.api.safe_to_retry": false,
 		});
 		expect(testDoubles.span.setAttribute).toHaveBeenCalledWith(
 			"error.type",

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -5,6 +5,7 @@ import type {
 	ToolObservationScope,
 	ToolObserver,
 } from "@hevy-mcp/core";
+import { createExecutionProjection } from "@hevy-mcp/core";
 import {
 	toolDuration,
 	toolErrors,
@@ -19,6 +20,7 @@ import {
 	recordMcpToolInvocation,
 } from "./mcp-session-observability.js";
 import type { McpClientMetricAttributes } from "./mcp-session-observability.js";
+import { projectExecutionAttributes } from "./execution-telemetry.js";
 import { Sentry, recordTelemetryException, tracer } from "./telemetry.js";
 
 type AttributeValue = string | number | boolean;
@@ -151,6 +153,9 @@ function setSafeErrorAttributes(
 ): string {
 	const diagnostic = completion.error;
 	const errorType = completion.errorType ?? "UNKNOWN_ERROR";
+	const execution = projectExecutionAttributes(
+		createExecutionProjection(diagnostic),
+	);
 	if (diagnostic) {
 		span.addEvent("mcp.tool.failure", {
 			"mcp.tool.name": invocation.name,
@@ -166,7 +171,11 @@ function setSafeErrorAttributes(
 			...(diagnostic.endpoint
 				? { "hevy.api.endpoint": diagnostic.endpoint }
 				: {}),
+			...execution,
 		});
+	}
+	for (const [key, value] of Object.entries(execution)) {
+		span.setAttribute(key, value);
 	}
 	span.setAttribute("error.type", errorType);
 	return errorType;
@@ -309,19 +318,29 @@ export function createNodeToolObserver(): ToolObserver {
 											...(nextCompletion.error?.endpoint
 												? { "hevy.api.endpoint": nextCompletion.error.endpoint }
 												: {}),
+											...projectExecutionAttributes(
+												createExecutionProjection(nextCompletion.error),
+											),
 										},
 										activeSpan,
 									),
 								);
 							}
 							if (nextCompletion.outcome === "returned_error") {
+								const execution = projectExecutionAttributes(
+									nextCompletion.errorOutcome,
+								);
 								activeSpan.addEvent("mcp.tool.failure", {
 									"mcp.tool.name": invocation.name,
 									"error.type": "UNKNOWN_ERROR",
 									"error.category": "McpToolReturnedError",
 									"error.code": "MCP_TOOL_RETURNED_ERROR",
+									...execution,
 								});
 								activeSpan.setAttribute("error.type", "UNKNOWN_ERROR");
+								for (const [key, value] of Object.entries(execution)) {
+									activeSpan.setAttribute(key, value);
+								}
 								bestEffort(() =>
 									recordTelemetryException(
 										new Error(nextCompletion.error?.category ?? "UnknownError"),
@@ -349,6 +368,7 @@ export function createNodeToolObserver(): ToolObserver {
 											...(nextCompletion.error?.endpoint
 												? { "hevy.api.endpoint": nextCompletion.error.endpoint }
 												: {}),
+											...execution,
 										},
 										activeSpan,
 									),

--- a/packages/worker/src/execution-response.test.ts
+++ b/packages/worker/src/execution-response.test.ts
@@ -33,4 +33,40 @@ describe("execution response helpers", () => {
 			},
 		});
 	});
+
+	it("maps a cancelled HevyHttpError to HTTP 499", async () => {
+		const error = new HevyHttpError("cancelled", {
+			method: "POST",
+			endpoint: "/v1/workouts",
+			outcome: "cancelled",
+		});
+
+		const outcome = executionOutcome(error, 502);
+
+		expect(outcome.status).toBe(499);
+		expect(outcome.execution).toMatchObject({ outcome: "cancelled" });
+
+		const response = executionResponse(error, "Request cancelled", outcome);
+		expect(response.status).toBe(499);
+		expect(await response.json()).toMatchObject({
+			error: {
+				message: "Request cancelled",
+				outcome: "cancelled",
+			},
+		});
+	});
+
+	it("preserves the supplied fallback status for an ordinary error", async () => {
+		const error = new Error("ordinary failure");
+		const outcome = executionOutcome(error, 502);
+
+		expect(outcome.status).toBe(502);
+		expect(executionStatus(error, 502)).toBe(502);
+
+		const response = executionResponse(error, "Request failed", outcome);
+		expect(response.status).toBe(502);
+		expect(await response.json()).toMatchObject({
+			error: { message: "Request failed" },
+		});
+	});
 });

--- a/packages/worker/src/execution-response.test.ts
+++ b/packages/worker/src/execution-response.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { HevyHttpError } from "@hevy-mcp/hevy-client";
+import {
+	executionOutcome,
+	executionResponse,
+	executionStatus,
+} from "./execution-response.js";
+
+describe("execution response helpers", () => {
+	it("computes status and projection once for a deadline outcome", async () => {
+		const error = new HevyHttpError("deadline", {
+			method: "GET",
+			endpoint: "/v1/user/info",
+			outcome: "deadline_exceeded",
+		});
+		const outcome = executionOutcome(error, 502);
+
+		expect(outcome).toMatchObject({
+			status: 504,
+			execution: {
+				outcome: "deadline_exceeded",
+				safe_to_retry: false,
+			},
+		});
+		expect(executionStatus(error, 502)).toBe(504);
+
+		const response = executionResponse(error, "Request timed out", outcome);
+		expect(response.status).toBe(504);
+		expect(await response.json()).toMatchObject({
+			error: {
+				message: "Request timed out",
+				outcome: "deadline_exceeded",
+			},
+		});
+	});
+});

--- a/packages/worker/src/execution-response.ts
+++ b/packages/worker/src/execution-response.ts
@@ -1,0 +1,28 @@
+import {
+	createExecutionProjection,
+	createSafeErrorDiagnostic,
+} from "@hevy-mcp/core";
+
+/**
+ * Render one privacy-safe execution projection for Worker HTTP adapters.
+ * Callers choose the transport-specific status and message; the outcome
+ * fields always come from the shared core/client taxonomy.
+ */
+export function executionResponse(
+	error: unknown,
+	message: string,
+	status: number,
+): Response {
+	const execution = createExecutionProjection(createSafeErrorDiagnostic(error));
+	return new Response(JSON.stringify({ error: { message, ...execution } }), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+export function executionStatus(error: unknown, fallback: number): number {
+	const outcome = createSafeErrorDiagnostic(error).outcome;
+	if (outcome === "deadline_exceeded") return 504;
+	if (outcome === "cancelled") return 499;
+	return fallback;
+}

--- a/packages/worker/src/execution-response.ts
+++ b/packages/worker/src/execution-response.ts
@@ -1,7 +1,24 @@
-import {
-	createExecutionProjection,
-	createSafeErrorDiagnostic,
-} from "@hevy-mcp/core";
+import { createExecutionErrorProjection } from "@hevy-mcp/core";
+
+export interface ExecutionOutcome {
+	readonly execution: ReturnType<typeof createExecutionErrorProjection>;
+	readonly status: number;
+}
+
+/** Compute one bounded projection and transport status for a failure. */
+export function executionOutcome(
+	error: unknown,
+	fallback: number,
+): ExecutionOutcome {
+	const execution = createExecutionErrorProjection(error);
+	const status =
+		execution.outcome === "deadline_exceeded"
+			? 504
+			: execution.outcome === "cancelled"
+				? 499
+				: fallback;
+	return { execution, status };
+}
 
 /**
  * Render one privacy-safe execution projection for Worker HTTP adapters.
@@ -11,18 +28,21 @@ import {
 export function executionResponse(
 	error: unknown,
 	message: string,
-	status: number,
+	statusOrOutcome: number | ExecutionOutcome,
 ): Response {
-	const execution = createExecutionProjection(createSafeErrorDiagnostic(error));
-	return new Response(JSON.stringify({ error: { message, ...execution } }), {
-		status,
-		headers: { "Content-Type": "application/json" },
-	});
+	const outcome =
+		typeof statusOrOutcome === "number"
+			? executionOutcome(error, statusOrOutcome)
+			: statusOrOutcome;
+	return new Response(
+		JSON.stringify({ error: { message, ...outcome.execution } }),
+		{
+			status: outcome.status,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
 }
 
 export function executionStatus(error: unknown, fallback: number): number {
-	const outcome = createSafeErrorDiagnostic(error).outcome;
-	if (outcome === "deadline_exceeded") return 504;
-	if (outcome === "cancelled") return 499;
-	return fallback;
+	return executionOutcome(error, fallback).status;
 }

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -279,7 +279,7 @@ describe("authorize endpoint", () => {
 		expect(completeAuthorization).not.toHaveBeenCalled();
 	});
 
-	it("returns a structured 502 when Hevy is unavailable", async () => {
+	it("re-renders the form when Hevy validation is unavailable", async () => {
 		const result = await handleAuthorizePost(
 			authorizePostRequest({
 				oauth_request: encodeAuthRequest(sampleAuthRequest),
@@ -288,21 +288,18 @@ describe("authorize endpoint", () => {
 			{},
 			createFakeHelpers(),
 			createDependencies({
-				validateApiKey: vi.fn().mockResolvedValue("unavailable"),
+				validateApiKey: vi.fn().mockRejectedValue(new Error("upstream outage")),
 			}),
 		);
+
 		expect(result.status).toBe(502);
-		expect(await result.json()).toMatchObject({
-			error: {
-				outcome: "terminal_failure",
-				phase: "before-dispatch",
-				commit_state: "not_sent",
-				safe_to_retry: false,
-			},
-		});
+		expect(result.headers.get("content-type")).toContain("text/html");
+		expect(await result.text()).toContain(
+			"Unable to validate the Hevy API key",
+		);
 	});
 
-	it("returns a structured 500 when OAuth validation has a configuration error", async () => {
+	it("re-renders the form when OAuth validation has a configuration error", async () => {
 		const result = await handleAuthorizePost(
 			authorizePostRequest({
 				oauth_request: encodeAuthRequest(sampleAuthRequest),
@@ -316,12 +313,8 @@ describe("authorize endpoint", () => {
 		);
 
 		expect(result.status).toBe(500);
-		expect(await result.json()).toMatchObject({
-			error: {
-				message: "Worker configuration error",
-				outcome: "terminal_failure",
-			},
-		});
+		expect(result.headers.get("content-type")).toContain("text/html");
+		expect(await result.text()).toContain("Worker configuration error");
 	});
 
 	it("rejects submissions without a usable auth request", async () => {
@@ -382,14 +375,8 @@ describe("authorize endpoint", () => {
 		controller.abort(new DOMException("request cancelled", "AbortError"));
 		const result = await pending;
 		expect(result.status).toBe(499);
-		expect(await result.json()).toMatchObject({
-			error: {
-				outcome: "cancelled",
-				phase: "before-dispatch",
-				commit_state: "not_sent",
-				safe_to_retry: false,
-			},
-		});
+		expect(result.headers.get("content-type")).toContain("text/html");
+		expect(await result.text()).toContain("Request cancelled");
 	});
 
 	it("preserves an OAuth validation deadline outcome", async () => {
@@ -417,9 +404,8 @@ describe("authorize endpoint", () => {
 		);
 		const result = await pending;
 		expect(result.status).toBe(504);
-		expect(await result.json()).toMatchObject({
-			error: { outcome: "deadline_exceeded", safe_to_retry: false },
-		});
+		expect(result.headers.get("content-type")).toContain("text/html");
+		expect(await result.text()).toContain("Request deadline exceeded");
 	});
 });
 

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -76,10 +76,14 @@ function createDependencies(
 	};
 }
 
-function authorizePostRequest(fields: Record<string, string>): Request {
+function authorizePostRequest(
+	fields: Record<string, string>,
+	signal?: AbortSignal,
+): Request {
 	return new Request("https://worker.example/authorize", {
 		method: "POST",
 		body: new URLSearchParams(fields),
+		signal,
 	});
 }
 
@@ -242,7 +246,12 @@ describe("authorize endpoint", () => {
 
 		expect(result.status).toBe(302);
 		expect(result.headers.get("location")).toContain("code=abc");
-		expect(validateApiKey).toHaveBeenCalledWith("secret-key", {});
+		expect(validateApiKey).toHaveBeenCalledWith(
+			"secret-key",
+			{},
+			expect.any(AbortSignal),
+			expect.any(Number),
+		);
 		expect(completeAuthorization).toHaveBeenCalledTimes(1);
 		const options = completeAuthorization.mock.calls[0]?.[0];
 		expect(options?.request).toEqual(sampleAuthRequest);
@@ -270,7 +279,7 @@ describe("authorize endpoint", () => {
 		expect(completeAuthorization).not.toHaveBeenCalled();
 	});
 
-	it("re-renders with 502 when Hevy is unavailable", async () => {
+	it("returns a structured 502 when Hevy is unavailable", async () => {
 		const result = await handleAuthorizePost(
 			authorizePostRequest({
 				oauth_request: encodeAuthRequest(sampleAuthRequest),
@@ -283,7 +292,36 @@ describe("authorize endpoint", () => {
 			}),
 		);
 		expect(result.status).toBe(502);
-		expect(await result.text()).toContain("temporarily unavailable");
+		expect(await result.json()).toMatchObject({
+			error: {
+				outcome: "terminal_failure",
+				phase: "before-dispatch",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
+	});
+
+	it("returns a structured 500 when OAuth validation has a configuration error", async () => {
+		const result = await handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "some-key",
+			}),
+			{},
+			createFakeHelpers(),
+			createDependencies({
+				validateApiKey: vi.fn().mockResolvedValue("config-error"),
+			}),
+		);
+
+		expect(result.status).toBe(500);
+		expect(await result.json()).toMatchObject({
+			error: {
+				message: "Worker configuration error",
+				outcome: "terminal_failure",
+			},
+		});
 	});
 
 	it("rejects submissions without a usable auth request", async () => {
@@ -314,6 +352,74 @@ describe("authorize endpoint", () => {
 		);
 		expect(result.status).toBe(400);
 		expect(validateApiKey).not.toHaveBeenCalled();
+	});
+
+	it("projects an aborted OAuth validation as cancellation", async () => {
+		const controller = new AbortController();
+		const validateApiKey = vi.fn(
+			(_apiKey: string, _env: object, signal?: AbortSignal) =>
+				new Promise<"valid">((_resolve, reject) => {
+					signal?.addEventListener(
+						"abort",
+						() => reject(new DOMException("request cancelled", "AbortError")),
+						{ once: true },
+					);
+				}),
+		);
+		const pending = handleAuthorizePost(
+			authorizePostRequest(
+				{
+					oauth_request: encodeAuthRequest(sampleAuthRequest),
+					hevy_api_key: "some-key",
+				},
+				controller.signal,
+			),
+			{},
+			createFakeHelpers(),
+			createDependencies({ validateApiKey }),
+		);
+		await vi.waitFor(() => expect(validateApiKey).toHaveBeenCalledOnce());
+		controller.abort(new DOMException("request cancelled", "AbortError"));
+		const result = await pending;
+		expect(result.status).toBe(499);
+		expect(await result.json()).toMatchObject({
+			error: {
+				outcome: "cancelled",
+				phase: "before-dispatch",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
+	});
+
+	it("preserves an OAuth validation deadline outcome", async () => {
+		const pending = handleAuthorizePost(
+			authorizePostRequest({
+				oauth_request: encodeAuthRequest(sampleAuthRequest),
+				hevy_api_key: "some-key",
+			}),
+			{},
+			createFakeHelpers(),
+			createDependencies({
+				validateApiKey: vi.fn().mockRejectedValue(
+					new HevyHttpError("deadline", {
+						method: "GET",
+						endpoint: "/v1/user/info",
+						code: "HEVY_DEADLINE_EXCEEDED",
+						phase: "dispatch",
+						operationSafety: "read",
+						commitState: "not_sent",
+						safeToRetry: false,
+						outcome: "deadline_exceeded",
+					}),
+				),
+			}),
+		);
+		const result = await pending;
+		expect(result.status).toBe(504);
+		expect(await result.json()).toMatchObject({
+			error: { outcome: "deadline_exceeded", safe_to_retry: false },
+		});
 	});
 });
 

--- a/packages/worker/src/worker-oauth.ts
+++ b/packages/worker/src/worker-oauth.ts
@@ -6,7 +6,7 @@ import {
 import { z } from "zod";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
 import { DEFAULT_API_TIMEOUT_MS } from "@hevy-mcp/hevy-client";
-import { executionResponse, executionStatus } from "./execution-response.js";
+import { executionOutcome, executionResponse } from "./execution-response.js";
 
 const MCP_PATH = "/mcp";
 const AUTHORIZE_PATH = "/authorize";
@@ -25,11 +25,10 @@ export const OAUTH_ACCESS_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
 export const OAUTH_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 /** Outcome of checking a Hevy API key against the upstream Hevy API. */
-export type HevyApiKeyValidation =
-	| "valid"
-	| "invalid"
-	| "unavailable"
-	| "config-error";
+export type HevyApiKeyValidation = "valid" | "invalid";
+type HevyOAuthValidation = HevyApiKeyValidation | "config-error";
+
+const WORKER_CONFIGURATION_ERROR = "Worker configuration error";
 
 /**
  * Hevy-specific behavior injected by the Worker entrypoint so this module
@@ -41,7 +40,7 @@ export interface HevyOAuthDependencies<Env> {
 		env: Env,
 		signal?: AbortSignal,
 		deadline?: number,
-	): Promise<HevyApiKeyValidation>;
+	): Promise<HevyOAuthValidation>;
 	serveMcp(
 		request: Request,
 		env: Env,
@@ -274,6 +273,58 @@ function authorizeErrorResponse(message: string, status: number): Response {
 	);
 }
 
+interface ValidationFailure {
+	message: string;
+	status: number;
+	readonly outcome: ReturnType<typeof executionOutcome>;
+}
+
+function validationFailure(
+	error: unknown,
+	request: Request,
+): ValidationFailure {
+	const outcome = executionOutcome(error, request.signal.aborted ? 499 : 502);
+	const executionOutcomeName = outcome.execution.outcome;
+	return {
+		message:
+			executionOutcomeName === "deadline_exceeded"
+				? "Request deadline exceeded"
+				: executionOutcomeName === "cancelled" || request.signal.aborted
+					? "Request cancelled"
+					: "Unable to validate the Hevy API key",
+		status: outcome.status,
+		outcome,
+	};
+}
+
+function renderValidationFailure(
+	error: unknown,
+	request: Request,
+	rerender: (message: string, status: number) => Response,
+): Response {
+	const failure = validationFailure(error, request);
+	return rerender(failure.message, failure.status);
+}
+
+function jsonValidationFailure(error: unknown, request: Request): Response {
+	const failure = validationFailure(error, request);
+	return executionResponse(error, failure.message, failure.outcome);
+}
+
+function authorizeConfigErrorResponse(
+	rerender: (message: string, status: number) => Response,
+): Response {
+	return rerender(WORKER_CONFIGURATION_ERROR, 500);
+}
+
+function jsonConfigErrorResponse(): Response {
+	return executionResponse(
+		new TypeError(WORKER_CONFIGURATION_ERROR),
+		WORKER_CONFIGURATION_ERROR,
+		500,
+	);
+}
+
 export async function handleAuthorizeGet(
 	request: Request,
 	helpers: OAuthHelpers,
@@ -344,7 +395,7 @@ export async function handleAuthorizePost<Env>(
 	const apiKey = typeof apiKeyEntry === "string" ? apiKeyEntry.trim() : "";
 	if (!apiKey) return rerender("Enter your Hevy API key.", 400);
 
-	let validation: HevyApiKeyValidation;
+	let validation: HevyOAuthValidation;
 	try {
 		validation = await dependencies.validateApiKey(
 			apiKey,
@@ -353,32 +404,10 @@ export async function handleAuthorizePost<Env>(
 			deadline,
 		);
 	} catch (error) {
-		const outcome = createSafeErrorDiagnostic(error).outcome;
-		return executionResponse(
-			error,
-			outcome === "deadline_exceeded"
-				? "Request deadline exceeded"
-				: outcome === "cancelled" || request.signal.aborted
-					? "Request cancelled"
-					: "Unable to validate the Hevy API key",
-			request.signal.aborted
-				? 499
-				: executionStatus(error, outcome === "deadline_exceeded" ? 504 : 502),
-		);
+		return renderValidationFailure(error, request, rerender);
 	}
 	if (validation === "config-error") {
-		return executionResponse(
-			new TypeError("Worker configuration error"),
-			"Worker configuration error",
-			500,
-		);
-	}
-	if (validation === "unavailable") {
-		return executionResponse(
-			new Error("Hevy API is temporarily unavailable"),
-			"Hevy is temporarily unavailable. Please try again in a moment.",
-			502,
-		);
+		return authorizeConfigErrorResponse(rerender);
 	}
 	if (validation === "invalid") {
 		return rerender(
@@ -442,7 +471,7 @@ async function handleAuthorizedMcpRequest<Env>(
 		typeof props?.hevyApiKey === "string" ? props.hevyApiKey : null;
 	if (!apiKey) return oauthUnauthorizedResponse(request);
 
-	let validation: HevyApiKeyValidation;
+	let validation: HevyOAuthValidation;
 	try {
 		validation = await dependencies.validateApiKey(
 			apiKey,
@@ -451,34 +480,12 @@ async function handleAuthorizedMcpRequest<Env>(
 			deadline,
 		);
 	} catch (error) {
-		const outcome = createSafeErrorDiagnostic(error).outcome;
-		return executionResponse(
-			error,
-			outcome === "deadline_exceeded"
-				? "Request deadline exceeded"
-				: outcome === "cancelled" || request.signal.aborted
-					? "Request cancelled"
-					: "Unable to validate the Hevy API key",
-			request.signal.aborted
-				? 499
-				: executionStatus(error, outcome === "deadline_exceeded" ? 504 : 502),
-		);
+		return jsonValidationFailure(error, request);
 	}
 	if (validation === "config-error") {
-		return executionResponse(
-			new TypeError("Worker configuration error"),
-			"Worker configuration error",
-			500,
-		);
+		return jsonConfigErrorResponse();
 	}
 	if (validation === "invalid") return oauthUnauthorizedResponse(request);
-	if (validation === "unavailable") {
-		return executionResponse(
-			new Error("Hevy API is temporarily unavailable"),
-			"Hevy API is temporarily unavailable",
-			502,
-		);
-	}
 	return dependencies.serveMcp(request, env, apiKey, deadline);
 }
 

--- a/packages/worker/src/worker-oauth.ts
+++ b/packages/worker/src/worker-oauth.ts
@@ -5,11 +5,16 @@ import {
 } from "@cloudflare/workers-oauth-provider";
 import { z } from "zod";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import { DEFAULT_API_TIMEOUT_MS } from "@hevy-mcp/hevy-client";
+import { executionResponse, executionStatus } from "./execution-response.js";
 
 const MCP_PATH = "/mcp";
 const AUTHORIZE_PATH = "/authorize";
 const TOKEN_PATH = "/token";
 const REGISTER_PATH = "/register";
+
+/** One absolute budget shared by validation and MCP execution per Worker request. */
+export const WORKER_INVOCATION_TIMEOUT_MS = DEFAULT_API_TIMEOUT_MS;
 
 // OAuth token issuance is persisted in KV. A one-hour access token can cause
 // clients to refresh several times per day, and every refresh writes both the
@@ -31,8 +36,18 @@ export type HevyApiKeyValidation =
  * stays focused on the OAuth flow itself.
  */
 export interface HevyOAuthDependencies<Env> {
-	validateApiKey(apiKey: string, env: Env): Promise<HevyApiKeyValidation>;
-	serveMcp(request: Request, env: Env, apiKey: string): Promise<Response>;
+	validateApiKey(
+		apiKey: string,
+		env: Env,
+		signal?: AbortSignal,
+		deadline?: number,
+	): Promise<HevyApiKeyValidation>;
+	serveMcp(
+		request: Request,
+		env: Env,
+		apiKey: string,
+		deadline?: number,
+	): Promise<Response>;
 }
 
 /** Grant props stored (encrypted) by the OAuth provider for each grant. */
@@ -295,6 +310,7 @@ export async function handleAuthorizePost<Env>(
 	helpers: OAuthHelpers,
 	dependencies: HevyOAuthDependencies<Env>,
 ): Promise<Response> {
+	const deadline = Date.now() + WORKER_INVOCATION_TIMEOUT_MS;
 	let form: FormData;
 	try {
 		form = await request.formData();
@@ -328,12 +344,38 @@ export async function handleAuthorizePost<Env>(
 	const apiKey = typeof apiKeyEntry === "string" ? apiKeyEntry.trim() : "";
 	if (!apiKey) return rerender("Enter your Hevy API key.", 400);
 
-	const validation = await dependencies.validateApiKey(apiKey, env);
+	let validation: HevyApiKeyValidation;
+	try {
+		validation = await dependencies.validateApiKey(
+			apiKey,
+			env,
+			request.signal,
+			deadline,
+		);
+	} catch (error) {
+		const outcome = createSafeErrorDiagnostic(error).outcome;
+		return executionResponse(
+			error,
+			outcome === "deadline_exceeded"
+				? "Request deadline exceeded"
+				: outcome === "cancelled" || request.signal.aborted
+					? "Request cancelled"
+					: "Unable to validate the Hevy API key",
+			request.signal.aborted
+				? 499
+				: executionStatus(error, outcome === "deadline_exceeded" ? 504 : 502),
+		);
+	}
 	if (validation === "config-error") {
-		return new Response("Worker configuration error", { status: 500 });
+		return executionResponse(
+			new TypeError("Worker configuration error"),
+			"Worker configuration error",
+			500,
+		);
 	}
 	if (validation === "unavailable") {
-		return rerender(
+		return executionResponse(
+			new Error("Hevy API is temporarily unavailable"),
 			"Hevy is temporarily unavailable. Please try again in a moment.",
 			502,
 		);
@@ -393,23 +435,51 @@ async function handleAuthorizedMcpRequest<Env>(
 	ctx: object,
 	dependencies: HevyOAuthDependencies<Env>,
 ): Promise<Response> {
+	const deadline = Date.now() + WORKER_INVOCATION_TIMEOUT_MS;
 	const props = (ctx as { props?: Partial<HevyGrantProps> } | null | undefined)
 		?.props;
 	const apiKey =
 		typeof props?.hevyApiKey === "string" ? props.hevyApiKey : null;
 	if (!apiKey) return oauthUnauthorizedResponse(request);
 
-	const validation = await dependencies.validateApiKey(apiKey, env);
+	let validation: HevyApiKeyValidation;
+	try {
+		validation = await dependencies.validateApiKey(
+			apiKey,
+			env,
+			request.signal,
+			deadline,
+		);
+	} catch (error) {
+		const outcome = createSafeErrorDiagnostic(error).outcome;
+		return executionResponse(
+			error,
+			outcome === "deadline_exceeded"
+				? "Request deadline exceeded"
+				: outcome === "cancelled" || request.signal.aborted
+					? "Request cancelled"
+					: "Unable to validate the Hevy API key",
+			request.signal.aborted
+				? 499
+				: executionStatus(error, outcome === "deadline_exceeded" ? 504 : 502),
+		);
+	}
 	if (validation === "config-error") {
-		return new Response("Worker configuration error", { status: 500 });
+		return executionResponse(
+			new TypeError("Worker configuration error"),
+			"Worker configuration error",
+			500,
+		);
 	}
 	if (validation === "invalid") return oauthUnauthorizedResponse(request);
 	if (validation === "unavailable") {
-		return new Response("Hevy API is temporarily unavailable", {
-			status: 502,
-		});
+		return executionResponse(
+			new Error("Hevy API is temporarily unavailable"),
+			"Hevy API is temporarily unavailable",
+			502,
+		);
 	}
-	return dependencies.serveMcp(request, env, apiKey);
+	return dependencies.serveMcp(request, env, apiKey, deadline);
 }
 
 /**

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -474,7 +474,12 @@ describe("real stateless SDK transport", () => {
 		expect(result.status).toBe(200);
 		expect(validationOptions?.signal).toBeInstanceOf(AbortSignal);
 		expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
-		expect(validationOptions?.deadline).toEqual(requestOptions?.deadline);
+		expect(validationOptions?.deadline).toBeLessThan(
+			requestOptions?.deadline ?? Number.POSITIVE_INFINITY,
+		);
+		expect(requestOptions?.deadline).toBeGreaterThan(
+			(validationOptions?.deadline ?? 0) + 5_000 - 100,
+		);
 		expect(validationOptions?.deadline).toBeGreaterThan(Date.now());
 	});
 
@@ -520,7 +525,7 @@ describe("real stateless SDK transport", () => {
 			error: {
 				outcome: "cancelled",
 				phase: "before-dispatch",
-				commit_state: "not_sent",
+				commit_state: "unknown",
 				safe_to_retry: false,
 			},
 		});

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -295,11 +295,32 @@ describe("Cloudflare Worker routes and CORS", () => {
 			const unavailable = createWorkerHandler({
 				createValidationClient: () =>
 					createMockClient({
-						getUserInfo: vi.fn().mockRejectedValue(new TypeError("network")),
+						getUserInfo: vi.fn().mockRejectedValue(
+							new HevyHttpError("HTTP 503", {
+								status: 503,
+								method: "GET",
+								endpoint: "/v1/user/info",
+								phase: "response-headers",
+								operationSafety: "read",
+								commitState: "not_sent",
+								safeToRetry: false,
+								outcome: "terminal_failure",
+							}),
+						),
 					}),
 			});
 			expect((await invalid(mcpRequest({}), {})).status).toBe(401);
-			expect((await unavailable(mcpRequest({}), {})).status).toBe(502);
+			const unavailableResponse = await unavailable(mcpRequest({}), {});
+			expect(unavailableResponse.status).toBe(502);
+			expect(await unavailableResponse.json()).toMatchObject({
+				error: {
+					status: 503,
+					outcome: "terminal_failure",
+					phase: "response-headers",
+					commit_state: "not_sent",
+					safe_to_retry: false,
+				},
+			});
 		},
 	);
 	it("logs safe structured request outcomes", async () => {
@@ -416,6 +437,118 @@ describe("real stateless SDK transport", () => {
 		expect(createTransport.mock.results[0]?.value).not.toBe(
 			createTransport.mock.results[1]?.value,
 		);
+	});
+
+	it("shares one absolute deadline across validation and MCP execution", async () => {
+		let validationOptions:
+			| { signal?: AbortSignal; deadline?: number }
+			| undefined;
+		let requestOptions: { signal?: AbortSignal; deadline?: number } | undefined;
+		const validationClient = createMockClient({
+			getUserInfo: vi.fn().mockImplementation((options) => {
+				validationOptions = options;
+				return Promise.resolve({ data: { id: "validated" } });
+			}),
+		});
+		const requestClient = createMockClient({
+			getUserInfo: vi.fn().mockImplementation((options) => {
+				requestOptions = options;
+				return Promise.resolve({ data: { id: "requested" } });
+			}),
+		});
+		const handler = createWorkerHandler({
+			createValidationClient: () => validationClient,
+			createRequestClient: () => requestClient,
+		});
+
+		const result = await handler(
+			mcpRequest({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: "get-user-info", arguments: {} },
+			}),
+			{},
+		);
+
+		expect(result.status).toBe(200);
+		expect(validationOptions?.signal).toBeInstanceOf(AbortSignal);
+		expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+		expect(validationOptions?.deadline).toEqual(requestOptions?.deadline);
+		expect(validationOptions?.deadline).toBeGreaterThan(Date.now());
+	});
+
+	it("projects a cancelled Worker request as cancellation, not a terminal failure", async () => {
+		const controller = new AbortController();
+		let validationSignal: AbortSignal | undefined;
+		type UserInfoResult = Awaited<ReturnType<HevyClient["getUserInfo"]>>;
+		const validationGetUserInfo = vi.fn(
+			(
+				options?: Parameters<HevyClient["getUserInfo"]>[0],
+			): Promise<UserInfoResult> => {
+				validationSignal = options?.signal;
+				return new Promise((_resolve, reject) => {
+					options?.signal?.addEventListener(
+						"abort",
+						() => reject(new DOMException("request cancelled", "AbortError")),
+						{ once: true },
+					);
+				});
+			},
+		);
+		const validationClient = createMockClient({
+			getUserInfo: validationGetUserInfo,
+		});
+		const handler = createWorkerHandler({
+			createValidationClient: () => validationClient,
+		});
+		const request = new Request("https://worker.example/mcp", {
+			method: "POST",
+			headers: validHeaders,
+			body: JSON.stringify({}),
+			signal: controller.signal,
+		});
+		const pending = handler(request, {});
+		await vi.waitFor(() =>
+			expect(validationGetUserInfo).toHaveBeenCalledOnce(),
+		);
+		expect(validationSignal).toBe(request.signal);
+		controller.abort(new DOMException("request cancelled", "AbortError"));
+		const result = await pending;
+		expect(result.status).toBe(499);
+		expect(await result.json()).toMatchObject({
+			error: {
+				outcome: "cancelled",
+				phase: "before-dispatch",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
+	});
+
+	it("preserves a validation deadline outcome", async () => {
+		const handler = createWorkerHandler({
+			createValidationClient: () =>
+				createMockClient({
+					getUserInfo: vi.fn().mockRejectedValue(
+						new HevyHttpError("deadline", {
+							method: "GET",
+							endpoint: "/v1/user/info",
+							code: "HEVY_DEADLINE_EXCEEDED",
+							phase: "dispatch",
+							operationSafety: "read",
+							commitState: "not_sent",
+							safeToRetry: false,
+							outcome: "deadline_exceeded",
+						}),
+					),
+				}),
+		});
+		const result = await handler(mcpRequest({}), {});
+		expect(result.status).toBe(504);
+		expect(await result.json()).toMatchObject({
+			error: { outcome: "deadline_exceeded", safe_to_retry: false },
+		});
 	});
 
 	it("forwards request-client logs through the connected MCP server", async () => {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -20,7 +20,7 @@ import {
 	isOAuthEnabled,
 	WORKER_INVOCATION_TIMEOUT_MS,
 } from "./worker-oauth.js";
-import { executionResponse, executionStatus } from "./execution-response.js";
+import { executionResponse } from "./execution-response.js";
 
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
@@ -38,6 +38,9 @@ export const DEFAULT_ALLOWED_ORIGINS = [
 	"https://vscode.dev", // VS Code for the Web
 	"https://github.dev", // github.dev web editor
 ] as const;
+
+/** Reserve most of the invocation budget for MCP execution after validation. */
+const WORKER_VALIDATION_TIMEOUT_MS = 5_000;
 
 export interface WorkerEnv {
 	// Trusted deployment/test binding; invalid values fail closed before auth.
@@ -210,7 +213,7 @@ function createDefaultValidationClient(
 		apiKey,
 		baseUrl,
 		maxGetRetries: 0,
-		timeoutMs: WORKER_INVOCATION_TIMEOUT_MS,
+		timeoutMs: WORKER_VALIDATION_TIMEOUT_MS,
 	});
 }
 
@@ -293,7 +296,14 @@ async function validateHevyApiKey(
 	options?: HevyRequestOptions,
 ): Promise<HevyApiKeyValidation> {
 	try {
-		await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo(options);
+		const validationDeadline = Math.min(
+			options?.deadline ?? Number.POSITIVE_INFINITY,
+			Date.now() + WORKER_VALIDATION_TIMEOUT_MS,
+		);
+		await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo({
+			...options,
+			deadline: validationDeadline,
+		});
 		return "valid";
 	} catch (error) {
 		if (options?.signal?.aborted) throw error;
@@ -335,7 +345,7 @@ async function serveMcpRequest(
 		return executionHttpResponse(
 			error,
 			"Unable to process MCP request",
-			executionStatus(error, 500),
+			500,
 			null,
 		);
 	}
@@ -399,7 +409,7 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 			return executionHttpResponse(
 				error,
 				"Unable to validate the Hevy API key",
-				executionStatus(error, 502),
+				502,
 				origin,
 			);
 		}
@@ -407,14 +417,6 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 			return response("Unauthorized", 401, origin, {
 				"WWW-Authenticate": "Bearer",
 			});
-		}
-		if (validation !== "valid") {
-			return executionHttpResponse(
-				new Error("Hevy API is temporarily unavailable"),
-				"Hevy API is temporarily unavailable",
-				502,
-				origin,
-			);
 		}
 
 		return withCors(

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -10,6 +10,7 @@ import {
 	createHevyClient,
 	isHevyHttpError,
 	type HevyClient,
+	type HevyRequestOptions,
 } from "@hevy-mcp/hevy-client";
 import {
 	createHevyOAuthProvider,
@@ -17,12 +18,13 @@ import {
 	type HevyApiKeyValidation,
 	type HevyOAuthWorker,
 	isOAuthEnabled,
+	WORKER_INVOCATION_TIMEOUT_MS,
 } from "./worker-oauth.js";
+import { executionResponse, executionStatus } from "./execution-response.js";
 
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
 const HEVY_API_BASE_URL = "https://api.hevyapp.com";
-const AUTH_VALIDATION_TIMEOUT_MS = 5_000;
 const CORS_ALLOWED_HEADERS =
 	"Authorization, Content-Type, Accept, MCP-Protocol-Version";
 const CORS_ALLOWED_METHODS = "POST, OPTIONS";
@@ -61,6 +63,8 @@ interface WorkerDependencies {
 	) => HevyClient;
 	createServer?: (
 		createClient: CreateHevyMcpServerOptions["createClient"],
+		lifecycleSignal?: AbortSignal,
+		executionDeadline?: number,
 	) => McpServer;
 	createTransport?: () => WebStandardStreamableHTTPServerTransport;
 }
@@ -206,7 +210,7 @@ function createDefaultValidationClient(
 		apiKey,
 		baseUrl,
 		maxGetRetries: 0,
-		timeoutMs: AUTH_VALIDATION_TIMEOUT_MS,
+		timeoutMs: WORKER_INVOCATION_TIMEOUT_MS,
 	});
 }
 
@@ -220,8 +224,14 @@ function createDefaultRequestClient(
 
 function createDefaultServer(
 	createClient: CreateHevyMcpServerOptions["createClient"],
+	lifecycleSignal?: AbortSignal,
+	executionDeadline?: number,
 ): McpServer {
-	return createHevyMcpServer({ createClient });
+	return createHevyMcpServer({
+		createClient,
+		lifecycleSignal,
+		executionDeadline,
+	});
 }
 
 function createDefaultTransport(): WebStandardStreamableHTTPServerTransport {
@@ -254,6 +264,15 @@ function logOAuthResponse(
 	});
 }
 
+function executionHttpResponse(
+	error: unknown,
+	message: string,
+	status: number,
+	origin: string | null,
+): Response {
+	return withCors(executionResponse(error, message, status), origin);
+}
+
 function resolveWorkerDependencies(
 	dependencies: WorkerDependencies,
 ): ResolvedWorkerDependencies {
@@ -271,18 +290,23 @@ async function validateHevyApiKey(
 	apiKey: string,
 	hevyApiBaseUrl: string,
 	createValidationClient: ResolvedWorkerDependencies["createValidationClient"],
+	options?: HevyRequestOptions,
 ): Promise<HevyApiKeyValidation> {
 	try {
-		await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo();
+		await createValidationClient(apiKey, hevyApiBaseUrl).getUserInfo(options);
 		return "valid";
 	} catch (error) {
+		if (options?.signal?.aborted) throw error;
+		if (isHevyHttpError(error) && error.outcome === "deadline_exceeded") {
+			throw error;
+		}
 		if (
 			isHevyHttpError(error) &&
 			(error.status === 401 || error.status === 403)
 		) {
 			return "invalid";
 		}
-		return "unavailable";
+		throw error;
 	}
 }
 
@@ -291,10 +315,14 @@ async function serveMcpRequest(
 	apiKey: string,
 	hevyApiBaseUrl: string,
 	dependencies: ResolvedWorkerDependencies,
+	deadline: number,
 ): Promise<Response> {
 	try {
-		const server = dependencies.createServer(({ onLog }) =>
-			dependencies.createRequestClient(apiKey, hevyApiBaseUrl, onLog),
+		const server = dependencies.createServer(
+			({ onLog }) =>
+				dependencies.createRequestClient(apiKey, hevyApiBaseUrl, onLog),
+			request.signal,
+			deadline,
 		);
 		const transport = dependencies.createTransport();
 		transport.onerror = (error) => {
@@ -304,7 +332,12 @@ async function serveMcpRequest(
 		return await transport.handleRequest(request);
 	} catch (error) {
 		logWorkerFailure("mcp-request-processing", error);
-		return new Response("Unable to process MCP request", { status: 500 });
+		return executionHttpResponse(
+			error,
+			"Unable to process MCP request",
+			executionStatus(error, 500),
+			null,
+		);
 	}
 }
 
@@ -350,22 +383,48 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 			});
 		}
 
-		const validation = await validateHevyApiKey(
-			apiKey,
-			hevyApiBaseUrl,
-			resolved.createValidationClient,
-		);
+		const deadline = Date.now() + WORKER_INVOCATION_TIMEOUT_MS;
+		let validation: HevyApiKeyValidation;
+		try {
+			validation = await validateHevyApiKey(
+				apiKey,
+				hevyApiBaseUrl,
+				resolved.createValidationClient,
+				{
+					signal: request.signal,
+					deadline,
+				},
+			);
+		} catch (error) {
+			return executionHttpResponse(
+				error,
+				"Unable to validate the Hevy API key",
+				executionStatus(error, 502),
+				origin,
+			);
+		}
 		if (validation === "invalid") {
 			return response("Unauthorized", 401, origin, {
 				"WWW-Authenticate": "Bearer",
 			});
 		}
 		if (validation !== "valid") {
-			return response("Hevy API is temporarily unavailable", 502, origin);
+			return executionHttpResponse(
+				new Error("Hevy API is temporarily unavailable"),
+				"Hevy API is temporarily unavailable",
+				502,
+				origin,
+			);
 		}
 
 		return withCors(
-			await serveMcpRequest(request, apiKey, hevyApiBaseUrl, resolved),
+			await serveMcpRequest(
+				request,
+				apiKey,
+				hevyApiBaseUrl,
+				resolved,
+				deadline,
+			),
 			origin,
 		);
 	};
@@ -375,7 +434,7 @@ function createWorkerOAuthProvider(
 	resolved: ResolvedWorkerDependencies,
 ): HevyOAuthWorker<WorkerEnv> {
 	return createHevyOAuthProvider<WorkerEnv>({
-		validateApiKey: async (apiKey, env) => {
+		validateApiKey: async (apiKey, env, signal, deadline) => {
 			let hevyApiBaseUrl: string;
 			try {
 				hevyApiBaseUrl = resolveHevyApiBaseUrl(env.HEVY_API_BASE_URL);
@@ -386,16 +445,26 @@ function createWorkerOAuthProvider(
 				apiKey,
 				hevyApiBaseUrl,
 				resolved.createValidationClient,
+				{
+					signal,
+					deadline: deadline ?? Date.now() + WORKER_INVOCATION_TIMEOUT_MS,
+				},
 			);
 		},
-		serveMcp: async (request, env, apiKey) => {
+		serveMcp: async (request, env, apiKey, deadline) => {
 			let hevyApiBaseUrl: string;
 			try {
 				hevyApiBaseUrl = resolveHevyApiBaseUrl(env.HEVY_API_BASE_URL);
 			} catch {
 				return new Response("Worker configuration error", { status: 500 });
 			}
-			return serveMcpRequest(request, apiKey, hevyApiBaseUrl, resolved);
+			return serveMcpRequest(
+				request,
+				apiKey,
+				hevyApiBaseUrl,
+				resolved,
+				deadline ?? Date.now() + WORKER_INVOCATION_TIMEOUT_MS,
+			);
 		},
 	});
 }

--- a/tests/integration/worker-http.integration.test.ts
+++ b/tests/integration/worker-http.integration.test.ts
@@ -533,7 +533,17 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 		);
 
 		expect(response.status).toBe(502);
-		expect(await response.text()).toBe("Hevy API is temporarily unavailable");
+		const body = await response.json();
+		expect(body).toMatchObject({
+			error: {
+				outcome: "terminal_failure",
+				phase: "response-content",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+			},
+		});
+		expect(JSON.stringify(body)).not.toContain(REDIRECT_API_KEY);
 		expect(hevyRequests).toEqual([
 			expect.objectContaining({
 				apiKey: REDIRECT_API_KEY,


### PR DESCRIPTION
## Primary changes

- Adds one runtime-neutral execution-control contract for cancellation signals, absolute deadlines, request phases, mutation commit state, retry safety, and stable outcomes.
- Propagates that contract through the generated-client facade, fetch dispatch, response-body reads, retry/backoff, pagination, caches, composite operations, MCP tools/resources, CLI, Node HTTP, Cloudflare Worker, and OAuth Worker paths.
- Makes HTTP method safety authoritative so non-idempotent writes cannot be made retryable by caller metadata.
- Adds structured privacy-safe failure projections and shared telemetry attributes across adapters.
- Evicts disconnected Node sessions, aborts active work during shutdown, and makes retry waits/timers cancellation-aware.
- Splits attempt execution and retry transition logic into focused helpers and centralizes Node execution-attribute projection.
- Adds a cascading minor Changeset for all five affected packages.

## Reviewer walkthrough

- Review `packages/hevy-client/src/execution.ts` and `packages/hevy-client/src/hevy-client-kubb.ts` for caller cancellation and deadline propagation, request phases, commit state, HTTP-method-derived retry safety, and retry/backoff behavior.
- Review `packages/core/src/execution.ts`, the tool/resource runtime, caches, composite operations, and error-policy files for shared execution scopes, cancellation-aware caching, and privacy-safe MCP outcomes.
- Review `packages/node/src/utils/graceful-shutdown.ts`, `streamable-http.ts`, and the telemetry/observer modules for disconnect eviction, shutdown aborts, and execution attributes.
- Review `packages/worker/src/worker.ts`, `worker-oauth.ts`, `execution-response.ts`, and the CLI entrypoints for adapter-specific status/JSON projections while retaining the shared outcome contract.
- Review the co-located tests, integration coverage, and `.changeset/quiet-execution-outcomes.md` for fault coverage and coordinated release metadata.

## Correctness and invariants

Execution control and failure semantics previously varied by layer. This made deadlines, disconnects, retry decisions, and user-visible outcomes difficult to reason about end to end.

- Each invocation carries one cancellation signal and absolute deadline through fetch, response-body consumption, pagination, caches, composite work, MCP tools/resources, CLI, and Worker paths; retry waits and shutdown/disconnect cancellation honor the same controls.
- HTTP method safety is authoritative for retry decisions: non-idempotent writes are never automatically retried, and uncertain mutation outcomes remain `safe_to_retry: false` with unknown commit state.
- MCP, CLI, Node HTTP, Cloudflare Worker, OAuth, and telemetry projections use the same privacy-safe outcome taxonomy without exposing raw errors or credentials.
- Canceled concurrent work cannot contaminate shared cache results, and disconnected Node sessions are evicted while active execution is aborted.

## Testing and QA

- `npm run build`
- `npm run check`
- `npm run check:types`
- `npm run check:changeset`
- `npm run test:pr`
  - 742 unit tests
  - 17 mocked MCP tests
  - 52 contract tests
  - 44 stdio tests
  - 2 Worker-runtime tests
  - 10 Worker HTTP tests
  - Node and CLI package smoke tests
  - 45 CLI tests
- Final independent Standards review: PASS, zero findings
- Final independent issue-spec review: PASS, zero findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added invocation-scoped cancellation and absolute deadlines across CLI, MCP, API, and Worker requests.
  * Added structured, privacy-safe error details for cancellation, timeouts, request phases, commit state, and retry safety.
  * Added graceful shutdown handling for active operations and disconnected sessions.
* **Bug Fixes**
  * Improved retry behavior and diagnostics based on operation safety and execution state.
  * Prevented canceled concurrent requests from affecting other requests or cached results.
  * Added appropriate HTTP responses for canceled and deadline-exceeded requests.
* **Observability**
  * Added execution outcome details to spans, metrics, failure events, and structured CLI errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #871
