### PR TITLE
perf: reduce OpenTelemetry metric volume

### DIFF
--- a/.changeset/quiet-metrics-volume.md
+++ b/.changeset/quiet-metrics-volume.md
@@ -1,0 +1,7 @@
+---
+"hevy-mcp": patch
+---
+
+Reduce Node telemetry volume by exporting metrics every 30 seconds, removing
+result-shape dimensions from tool-duration metrics, and normalizing dynamic API
+endpoint labels while retaining the detailed trace attributes.

--- a/packages/node/src/utils/hevy-client-observability.test.ts
+++ b/packages/node/src/utils/hevy-client-observability.test.ts
@@ -117,6 +117,59 @@ describe("createNodeHevyClientOptions", () => {
 		);
 	});
 
+	it("normalizes dynamic endpoint labels without hiding trace diagnostics", () => {
+		const options = createNodeHevyClientOptions();
+
+		observe(options, {
+			method: "GET",
+			endpoint: "/v1/workouts/workout-secret",
+			status: 200,
+			durationMs: 12,
+			retryCount: 0,
+			outcome: "success",
+		});
+
+		expect(testDoubles.startSpan).toHaveBeenCalledWith("hevy.api.GET", {
+			attributes: expect.objectContaining({
+				"hevy.api.endpoint": "/v1/workouts/workout-secret",
+			}),
+		});
+		expect(testDoubles.apiCallsAdd).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({
+				endpoint: "/v1/workouts/:workoutId",
+			}),
+		);
+		expect(testDoubles.apiDurationRecord).toHaveBeenCalledWith(
+			12,
+			expect.objectContaining({
+				endpoint: "/v1/workouts/:workoutId",
+			}),
+		);
+	});
+
+	it("uses an unknown metric endpoint for unrecognized paths", () => {
+		const options = createNodeHevyClientOptions();
+
+		observe(options, {
+			method: "GET",
+			endpoint: "/v1/private-resource/secret-id",
+			status: 200,
+			durationMs: 12,
+			retryCount: 0,
+			outcome: "success",
+		});
+
+		expect(testDoubles.apiCallsAdd).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ endpoint: "unknown" }),
+		);
+		expect(testDoubles.apiDurationRecord).toHaveBeenCalledWith(
+			12,
+			expect.objectContaining({ endpoint: "unknown" }),
+		);
+	});
+
 	it("runs request work and retry waits under the API span context", async () => {
 		const options = createNodeHevyClientOptions();
 		const scope = options.onRequestStart?.({

--- a/packages/node/src/utils/hevy-client-observability.ts
+++ b/packages/node/src/utils/hevy-client-observability.ts
@@ -15,6 +15,34 @@ import {
 } from "./mcp-session-observability.js";
 import { tracer } from "./telemetry.js";
 
+const SAFE_STATIC_ENDPOINTS = new Set([
+	"/v1/body_measurements",
+	"/v1/exercise_templates",
+	"/v1/routine_folders",
+	"/v1/routines",
+	"/v1/user/info",
+	"/v1/workouts",
+	"/v1/workouts/count",
+	"/v1/workouts/events",
+]);
+const SAFE_DYNAMIC_ENDPOINTS = [
+	["/v1/body_measurements/", "/v1/body_measurements/:date"],
+	["/v1/exercise_history/", "/v1/exercise_history/:exerciseTemplateId"],
+	["/v1/exercise_templates/", "/v1/exercise_templates/:exerciseTemplateId"],
+	["/v1/routine_folders/", "/v1/routine_folders/:folderId"],
+	["/v1/routines/", "/v1/routines/:routineId"],
+	["/v1/workouts/", "/v1/workouts/:workoutId"],
+] as const;
+
+function normalizeHevyMetricEndpoint(endpoint: string): string {
+	const path = endpoint.split("?")[0] ?? "";
+	if (SAFE_STATIC_ENDPOINTS.has(path)) return path;
+	return (
+		SAFE_DYNAMIC_ENDPOINTS.find(([prefix]) => path.startsWith(prefix))?.[1] ??
+		"unknown"
+	);
+}
+
 function safeErrorAttributes(observation: HevyRequestObservation): {
 	error_category?: string;
 	error_code?: string;
@@ -93,9 +121,10 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 		onRequestComplete(observation) {
 			const retryCountBucket = bucketCount(observation.retryCount);
 			const errorAttributes = safeErrorAttributes(observation);
+			const metricEndpoint = normalizeHevyMetricEndpoint(observation.endpoint);
 			apiCalls.add(1, {
 				method: observation.method,
-				endpoint: observation.endpoint,
+				endpoint: metricEndpoint,
 				status_code: observation.status,
 				retry_count_bucket: retryCountBucket,
 				outcome: observation.outcome,
@@ -107,7 +136,7 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 			});
 			apiDuration.record(observation.durationMs, {
 				method: observation.method,
-				endpoint: observation.endpoint,
+				endpoint: metricEndpoint,
 				retry_count_bucket: retryCountBucket,
 				outcome: observation.outcome,
 				transport: getCurrentMcpTransport(),

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -305,7 +305,7 @@ describe("telemetry initialization", () => {
 		expect(testDoubles.periodicExportingMetricReader).toHaveBeenCalledWith(
 			expect.objectContaining({
 				exporter: expect.anything(),
-				exportIntervalMillis: 10_000,
+				exportIntervalMillis: 30_000,
 			}),
 		);
 		expect(testDoubles.meterProvider).toHaveBeenCalledWith(

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -302,7 +302,7 @@ if (telemetryEnabled) {
 						},
 						temporalityPreference: AggregationTemporalityPreference.DELTA,
 					}),
-					exportIntervalMillis: 10_000,
+					exportIntervalMillis: 30_000,
 				}),
 			],
 		});

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -179,9 +179,15 @@ describe("createNodeToolObserver", () => {
 				tool_name: "get-workouts",
 				outcome: "success",
 				is_error: "false",
-				"mcp.tool.result.content_count_bucket": "2-10",
-				"mcp.tool.result.item_count_bucket": "11-50",
 			}),
+		);
+		const durationAttributes = testDoubles.toolDurationRecord.mock
+			.calls[0]?.[1] as Record<string, unknown>;
+		expect(durationAttributes).not.toHaveProperty(
+			"mcp.tool.result.content_count_bucket",
+		);
+		expect(durationAttributes).not.toHaveProperty(
+			"mcp.tool.result.item_count_bucket",
 		);
 		expect(testDoubles.recordMcpToolFailure).not.toHaveBeenCalled();
 		expect(testDoubles.span.end).toHaveBeenCalledOnce();

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -144,29 +144,6 @@ function setResultAttributes(span: Span, completion: SafeToolCompletion): void {
 	}
 }
 
-function resultMetricAttributes(
-	completion: SafeToolCompletion,
-): Record<string, string | boolean> {
-	const result = completion.result;
-	if (!result) return {};
-	const attributes: Record<string, string | boolean> = {
-		"mcp.tool.result.has_structured_content": result.hasStructuredContent,
-		"mcp.tool.result.content_count_bucket": result.contentCountBucket,
-	};
-	const summary = result.summary;
-	if (summary?.itemCountBucket) {
-		attributes["mcp.tool.result.item_count_bucket"] = summary.itemCountBucket;
-	}
-	if (summary?.exerciseCountBucket) {
-		attributes["mcp.tool.result.exercise_count_bucket"] =
-			summary.exerciseCountBucket;
-	}
-	if (summary?.setCountBucket) {
-		attributes["mcp.tool.result.set_count_bucket"] = summary.setCountBucket;
-	}
-	return attributes;
-}
-
 function setSafeErrorAttributes(
 	span: Span,
 	invocation: SafeToolInvocation,
@@ -396,7 +373,6 @@ export function createNodeToolObserver(): ToolObserver {
 						bestEffort(() =>
 							toolDuration.record(durationMs, {
 								...metrics,
-								...resultMetricAttributes(nextCompletion),
 								is_error: String(isError),
 								outcome: nextCompletion.outcome,
 							}),


### PR DESCRIPTION
## Summary

- reduce the Node metric export interval from 10s to 30s while preserving force-flush behavior
- remove result-shape dimensions from the tool-duration histogram; detailed result attributes remain on traces
- normalize dynamic Hevy API endpoint labels for metrics while retaining raw trace diagnostics
- add a patch changeset for `hevy-mcp`

## Validation

- full `npm run build`
- full `npm run check`
- full `npm run check:types`
- full `npm run check:changeset`
- full `npm run test:pr`
- focused telemetry suite: 34 tests passed
- `git diff --check`

## Follow-up

This is the first source-instrumentation slice of the metrics-volume plan. Collector filtering, Grafana review, and staged live measurement remain separate follow-up work. No production deployment is included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Reduced telemetry volume by exporting metrics every 30 seconds instead of every 10 seconds.
  - Simplified tool-duration metrics by excluding result content and item counts.
  - Standardized API endpoint labels for more consistent metrics while retaining detailed trace information.
  - Unrecognized API paths are now grouped under an `unknown` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->