### PR TITLE
fix: preserve useful MCP process diagnostics

### DIFF
--- a/.changeset/proud-books-cover.md
+++ b/.changeset/proud-books-cover.md
@@ -1,5 +1,10 @@
 ---
+"@chrisdoc/hevy-cli": patch
+"@hevy-mcp/core": patch
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/worker": patch
 "hevy-mcp": patch
 ---
 
-Improve diagnostic details for MCP process and lifecycle telemetry
+Improve diagnostic details for MCP process, lifecycle, and Hevy API telemetry

--- a/.changeset/proud-books-cover.md
+++ b/.changeset/proud-books-cover.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Improve diagnostic details for MCP process and lifecycle telemetry

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -22,6 +22,7 @@ import {
 	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	HevyHttpError,
+	getHevyResponseErrorMessage,
 	isHevyHttpError,
 } from "./hevy-http-error.js";
 import {
@@ -95,6 +96,7 @@ export interface HevyRequestObservation {
 		readonly status?: number;
 		readonly code?: string;
 		readonly category?: "HevyHttpError" | "NetworkError";
+		readonly responseMessage?: string;
 	};
 }
 
@@ -858,6 +860,7 @@ function transitionAfterAttemptFailure(
 				: safeToRetry && !retryExhausted
 					? "retryable_failure"
 					: "terminal_failure";
+	const responseErrorMessage = getHevyResponseErrorMessage(error);
 	const observation: HevyRequestObservation = {
 		method: options.method,
 		endpoint: options.endpoint,
@@ -877,6 +880,9 @@ function transitionAfterAttemptFailure(
 					? error.code
 					: undefined,
 			category: error.status === undefined ? "NetworkError" : "HevyHttpError",
+			...(responseErrorMessage
+				? { responseMessage: responseErrorMessage }
+				: {}),
 		},
 	};
 	finishRequestObservation(options.observationScope, observation);

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -5,6 +5,7 @@ import {
 	HEVY_REQUEST_ABORTED_ERROR_CODE,
 	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
 	HevyHttpError,
+	getHevyResponseErrorMessage,
 } from "./hevy-http-error.js";
 import { createExecutionSignal, isAbortLike } from "./execution.js";
 function response(data: unknown, status = 200): Response {
@@ -105,6 +106,28 @@ describe("@hevy-mcp/hevy-client", () => {
 		});
 	});
 
+	it("extracts only a bounded API response error message", () => {
+		const message = "  Hevy rejected the workout  ";
+		const error = new HevyHttpError("generic request failure", {
+			method: "POST",
+			endpoint: "/v1/workouts",
+			data: { error: message, secret: "response-body-field" },
+		});
+
+		expect(getHevyResponseErrorMessage(error)).toBe(
+			"Hevy rejected the workout",
+		);
+		expect(
+			getHevyResponseErrorMessage(
+				new HevyHttpError("generic", {
+					method: "GET",
+					endpoint: "/v1/user/info",
+					data: { message: "x".repeat(3_000) },
+				}),
+			),
+		).toHaveLength(2_048);
+	});
+
 	it("emits bounded events without raw response or exception data", async () => {
 		const onLog = vi.fn(() => {
 			throw new Error("observer-secret");
@@ -129,6 +152,31 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(eventText).not.toContain("body");
 		expect(eventText).not.toContain("observer-secret");
 		expect(onLog).toHaveBeenCalled();
+	});
+	it("propagates the API response error message without the response body", async () => {
+		const responseMessage = "Hevy rejected this workout";
+		const observations: unknown[] = [];
+		const client = createHevyClient({
+			apiKey: "api-key-secret",
+			fetch: vi
+				.fn()
+				.mockResolvedValue(
+					response(
+						{ error: responseMessage, internal: "response-body-secret" },
+						422,
+					),
+				),
+			maxGetRetries: 0,
+			onRequestComplete: (observation) => observations.push(observation),
+		});
+
+		await expect(client.getUserInfo()).rejects.toBeInstanceOf(HevyHttpError);
+		expect(observations).toEqual([
+			expect.objectContaining({
+				error: expect.objectContaining({ responseMessage }),
+			}),
+		]);
+		expect(JSON.stringify(observations)).not.toContain("response-body-secret");
 	});
 	it("times out while consuming a response body", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());

--- a/packages/hevy-client/src/hevy-http-error.ts
+++ b/packages/hevy-client/src/hevy-http-error.ts
@@ -25,6 +25,39 @@ export interface HevyHttpErrorOptions {
 	outcome?: HevyExecutionOutcome;
 }
 
+const MAX_RESPONSE_ERROR_MESSAGE_LENGTH = 2_048;
+
+function normalizeResponseErrorMessage(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const message = value.trim();
+	return message.length > 0
+		? message.slice(0, MAX_RESPONSE_ERROR_MESSAGE_LENGTH)
+		: undefined;
+}
+
+/** Extract only a bounded message field from an API error response. */
+export function getHevyResponseErrorMessage(
+	error: unknown,
+): string | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const candidate = error as { data?: unknown; name?: unknown };
+	if (candidate.name !== "HevyHttpError") return undefined;
+	const data = candidate.data;
+	const direct = normalizeResponseErrorMessage(data);
+	if (direct) return direct;
+	if (!data || typeof data !== "object" || Array.isArray(data)) {
+		return undefined;
+	}
+
+	for (const key of ["error", "message", "detail"] as const) {
+		const message = normalizeResponseErrorMessage(
+			(data as Record<string, unknown>)[key],
+		);
+		if (message) return message;
+	}
+	return undefined;
+}
+
 export interface HevyExecutionMetadata {
 	phase?: HevyRequestPhase;
 	operationSafety?: HevyOperationSafety;

--- a/packages/hevy-client/src/index.ts
+++ b/packages/hevy-client/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from "./execution.js";
 export {
 	HevyHttpError,
+	getHevyResponseErrorMessage,
 	isHevyHttpError,
 	type HevyExecutionMetadata,
 	type HevyHttpErrorOptions,

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -486,16 +486,17 @@ ten-character HMAC-SHA-256 pseudonym from it solely for cross-span
 correlation. The pseudonym is attached to spans only, never used as a metric
 dimension, and is not intended for per-user behavior histories.
 
-The privacy allowlist contains service/version/transport; fixed tool feature,
-read/write kind, operation, and short-lived tool name; bounded
-outcome/error/count/retry/duration/session/cache/workflow values; normalized API
-method/endpoint/status; shape-only key names, presence, count, and boolean
-fields; sanitized client/protocol tokens; and the span-only pseudonym. It
-explicitly prohibits raw prompts, tool argument values, tool result content,
-request bodies, API keys, raw identifiers/queries/exact dates,
-workout/routine/folder/template/body-measurement content, names/titles/
-descriptions/notes, measurement values, arbitrary client metadata, and
-unnormalized endpoint paths.
+Structured tool telemetry remains bounded: it contains service/version/
+transport; fixed tool feature, read/write kind, operation, and short-lived tool
+name; bounded outcome/error/count/retry/duration/session/cache/workflow values;
+normalized API method/endpoint/status; shape-only key names, presence, count,
+and boolean fields; sanitized client/protocol tokens; and the span-only
+pseudonym. Process and server-lifecycle exception events intentionally retain
+the original normalized type, up to 2 KiB of exception message, and up to 16
+KiB of stack for debugging. Disable telemetry if that diagnostic detail is not
+acceptable. The exception adapter does not add raw prompts, tool argument
+values, tool result content, request/response bodies, API keys, or
+authorization headers.
 
 ## Security and mutations
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -493,10 +493,11 @@ normalized API method/endpoint/status; shape-only key names, presence, count,
 and boolean fields; sanitized client/protocol tokens; and the span-only
 pseudonym. Process and server-lifecycle exception events intentionally retain
 the original normalized type, up to 2 KiB of exception message, and up to 16
-KiB of stack for debugging. Disable telemetry if that diagnostic detail is not
-acceptable. The exception adapter does not add raw prompts, tool argument
-values, tool result content, request/response bodies, API keys, or
-authorization headers.
+KiB of stack for debugging. Hevy API failure spans also retain the bounded
+allowlisted response error message when the API returns one. Disable telemetry
+if that diagnostic detail is not acceptable. The exception/API adapter does
+not add raw prompts, tool argument values, tool result content, full
+request/response bodies, API keys, or authorization headers.
 
 ## Security and mutations
 

--- a/packages/node/src/index.test.ts
+++ b/packages/node/src/index.test.ts
@@ -44,6 +44,7 @@ const testDoubles = vi.hoisted(() => {
 		installProcessExceptionTracking: vi.fn(() => vi.fn()),
 		flushTelemetry: vi.fn().mockResolvedValue(undefined),
 		recordTelemetryException: vi.fn(),
+		recordSentryTelemetryException: vi.fn(),
 		serverStartups: { add: vi.fn() },
 		installGracefulShutdown: vi.fn(),
 		instrumentTransport: vi.fn(() => ({ kind: "stdio-transport" })),
@@ -75,6 +76,7 @@ vi.mock("./utils/telemetry.js", () => ({
 	serviceVersion: "3.4.1",
 	setTelemetryUser: testDoubles.setTelemetryUser,
 	recordTelemetryException: testDoubles.recordTelemetryException,
+	recordSentryTelemetryException: testDoubles.recordSentryTelemetryException,
 	installProcessExceptionTracking: testDoubles.installProcessExceptionTracking,
 }));
 
@@ -488,6 +490,7 @@ describe("Node package entrypoint", () => {
 			expect.objectContaining({
 				"error.type": "MCP_SERVER_BUILD_ERROR",
 				"error.category": "McpServerBuildFailure",
+				"mcp.termination.reason": "startup_failure",
 			}),
 			testDoubles.span,
 		);
@@ -641,6 +644,14 @@ describe("Node package entrypoint", () => {
 
 		expect(testDoubles.recordSessionTermination).toHaveBeenCalledWith(
 			"connect_failure",
+		);
+		expect(testDoubles.recordTelemetryException).toHaveBeenCalledWith(
+			expect.any(Error),
+			expect.objectContaining({
+				"mcp.failure.phase": "connect",
+				"mcp.termination.reason": "connect_failure",
+			}),
+			testDoubles.span,
 		);
 		expect(testDoubles.span.setStatus).toHaveBeenCalledWith({
 			code: SpanStatusCode.ERROR,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -5,6 +5,7 @@ import {
 	flushTelemetry,
 	installProcessExceptionTracking,
 	recordTelemetryException,
+	recordSentryTelemetryException,
 	tracer,
 	serviceName,
 	serviceVersion,
@@ -147,6 +148,11 @@ type LifecycleFailurePhase =
 	| "connect"
 	| "run";
 
+type LifecycleTerminationReason =
+	| "startup_failure"
+	| "connect_failure"
+	| "runtime_failure";
+
 const LIFECYCLE_FAILURE_TAXONOMY: Record<
 	LifecycleFailurePhase,
 	{ errorType: string; errorCategory: string }
@@ -176,11 +182,13 @@ const LIFECYCLE_FAILURE_TAXONOMY: Record<
 function createLifecycleFailureAttributes(
 	error: unknown,
 	phase: LifecycleFailurePhase,
+	terminationReason: LifecycleTerminationReason,
 ): Record<string, string | number | boolean> {
 	const diagnostic = createSafeErrorDiagnostic(error);
 	const taxonomy = LIFECYCLE_FAILURE_TAXONOMY[phase];
 	return {
 		"mcp.failure.phase": phase,
+		"mcp.termination.reason": terminationReason,
 		"error.type": taxonomy.errorType,
 		"error.category": taxonomy.errorCategory,
 		...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
@@ -198,10 +206,16 @@ function recordLifecycleFailure(
 	span: Span,
 	error: unknown,
 	phase: LifecycleFailurePhase,
+	terminationReason: LifecycleTerminationReason,
 ): void {
-	const attributes = createLifecycleFailureAttributes(error, phase);
+	const attributes = createLifecycleFailureAttributes(
+		error,
+		phase,
+		terminationReason,
+	);
 	span.addEvent("mcp.lifecycle.failure", attributes);
 	recordTelemetryException(error, attributes, span);
+	recordSentryTelemetryException("MCP lifecycle failure", error, attributes);
 }
 async function validateApiKey(apiKey: string, signal?: AbortSignal) {
 	// Keep the startup probe separate from the normal MCP-aware client. The
@@ -276,7 +290,7 @@ function buildServer(
 				span.setStatus({ code: SpanStatusCode.OK });
 				return server;
 			} catch (e) {
-				recordLifecycleFailure(span, e, "build");
+				recordLifecycleFailure(span, e, "build", "startup_failure");
 				span.setStatus({ code: SpanStatusCode.ERROR });
 				throw e;
 			} finally {
@@ -362,7 +376,12 @@ export async function runStdioServer() {
 							connectSucceeded = true;
 							connectSpan.setStatus({ code: SpanStatusCode.OK });
 						} catch (e) {
-							recordLifecycleFailure(connectSpan, e, "connect");
+							recordLifecycleFailure(
+								connectSpan,
+								e,
+								"connect",
+								"connect_failure",
+							);
 							connectSpan.setStatus({ code: SpanStatusCode.ERROR });
 							throw e;
 						} finally {
@@ -389,7 +408,12 @@ export async function runStdioServer() {
 				span.setStatus({ code: SpanStatusCode.OK });
 			} catch (e) {
 				if (!connectAttempted || connectSucceeded) {
-					recordLifecycleFailure(span, e, "run");
+					recordLifecycleFailure(
+						span,
+						e,
+						"run",
+						connectSucceeded ? "runtime_failure" : "startup_failure",
+					);
 				}
 				recordMcpSessionTermination(
 					connectAttempted ? "connect_failure" : "startup_failure",
@@ -473,7 +497,12 @@ export async function runServer(): Promise<void> {
 				});
 				span.setStatus({ code: SpanStatusCode.OK });
 			} catch (error) {
-				recordLifecycleFailure(span, error, "run");
+				recordLifecycleFailure(
+					span,
+					error,
+					"run",
+					listening ? "runtime_failure" : "startup_failure",
+				);
 				recordMcpSessionTermination(listening ? "unknown" : "startup_failure");
 				span.setStatus({ code: SpanStatusCode.ERROR });
 				cleanupProcessExceptionTracking();

--- a/packages/node/src/utils/hevy-client-observability.test.ts
+++ b/packages/node/src/utils/hevy-client-observability.test.ts
@@ -258,6 +258,38 @@ describe("createNodeHevyClientOptions", () => {
 			"error.code": "HEVY_RETRY_EXHAUSTED",
 		});
 	});
+	it("records API response error messages on spans, not metric labels", () => {
+		const responseMessage = "Hevy rejected the workout";
+		const options = createNodeHevyClientOptions();
+
+		observe(options, {
+			method: "POST",
+			endpoint: "/v1/workouts",
+			status: 422,
+			durationMs: 25,
+			retryCount: 0,
+			outcome: "terminal_failure",
+			error: {
+				category: "HevyHttpError",
+				responseMessage,
+			},
+		});
+
+		expect(testDoubles.span.setAttribute).toHaveBeenCalledWith(
+			"hevy.api.error_message",
+			responseMessage,
+		);
+		expect(testDoubles.span.addEvent).toHaveBeenCalledWith(
+			"hevy.api.failure",
+			expect.objectContaining({ "error.message": responseMessage }),
+		);
+		expect(
+			JSON.stringify([
+				testDoubles.apiCallsAdd.mock.calls,
+				testDoubles.apiDurationRecord.mock.calls,
+			]),
+		).not.toContain(responseMessage);
+	});
 	it("records retry waits and cache lifecycle metadata on dedicated spans", () => {
 		const options = createNodeHevyClientOptions();
 		const retryScope = options.onRetryWait?.({

--- a/packages/node/src/utils/hevy-client-observability.ts
+++ b/packages/node/src/utils/hevy-client-observability.ts
@@ -56,6 +56,12 @@ function safeErrorAttributes(observation: HevyRequestObservation): {
 	};
 }
 
+function getApiErrorMessage(
+	observation: HevyRequestObservation,
+): string | undefined {
+	return observation.error?.responseMessage;
+}
+
 function startApiSpan(start: HevyRequestStart) {
 	const sessionId = getCurrentMcpSessionId();
 	return tracer.startSpan(`hevy.api.${start.method}`, {
@@ -71,6 +77,7 @@ function startApiSpan(start: HevyRequestStart) {
 }
 function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 	const errorAttributes = safeErrorAttributes(observation);
+	const errorMessage = getApiErrorMessage(observation);
 	if (observation.status > 0) {
 		span.setAttribute("http.response.status_code", observation.status);
 	}
@@ -85,6 +92,9 @@ function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 	for (const [key, value] of Object.entries(errorAttributes)) {
 		span.setAttribute(key, value);
 	}
+	if (errorMessage) {
+		span.setAttribute("hevy.api.error_message", errorMessage);
+	}
 	span.setStatus({
 		code:
 			observation.outcome === "success" || observation.outcome === "expected"
@@ -97,6 +107,7 @@ function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 			...(errorAttributes.error_code
 				? { "error.code": errorAttributes.error_code }
 				: {}),
+			...(errorMessage ? { "error.message": errorMessage } : {}),
 		});
 	}
 	span.end();
@@ -161,6 +172,9 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 				status: observation.status || null,
 				retryCountBucket,
 				outcome: observation.outcome,
+				...(getApiErrorMessage(observation)
+					? { "hevy.api.error_message": getApiErrorMessage(observation) }
+					: {}),
 				...errorAttributes,
 			});
 		},

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -22,6 +22,10 @@ const testDoubles = vi.hoisted(() => {
 		sentryInit: vi.fn(() => ({ _isSentryClient: true })),
 		sentryFlush: vi.fn().mockResolvedValue(true),
 		sentrySetUser: vi.fn(),
+		sentrySetTag: vi.fn(),
+		sentrySetContext: vi.fn(),
+		sentrySetFingerprint: vi.fn(),
+		sentryCaptureMessage: vi.fn(),
 		validateOpenTelemetrySetup: vi.fn(),
 		sentrySpanProcessor: vi.fn(),
 		sentryPropagator: vi.fn(),
@@ -53,6 +57,14 @@ vi.mock("@sentry/node", () => ({
 	init: testDoubles.sentryInit,
 	flush: testDoubles.sentryFlush,
 	setUser: testDoubles.sentrySetUser,
+	withScope: vi.fn((callback: (scope: unknown) => void) =>
+		callback({
+			setTag: testDoubles.sentrySetTag,
+			setContext: testDoubles.sentrySetContext,
+			setFingerprint: testDoubles.sentrySetFingerprint,
+		}),
+	),
+	captureMessage: testDoubles.sentryCaptureMessage,
 	validateOpenTelemetrySetup: testDoubles.validateOpenTelemetrySetup,
 	SentryContextManager: testDoubles.sentryContextManager,
 }));
@@ -269,11 +281,26 @@ describe("telemetry initialization", () => {
 			"exception",
 			expect.objectContaining({
 				"exception.type": "Error",
+				"exception.category": "Error",
+				"exception.code": "ECONNREFUSED",
+				"exception.message": "uncaught",
 				"exception.source": "uncaughtException",
 				"mcp.failure.phase": "uncaught_exception",
 				"error.type": "MCP_PROCESS_EXCEPTION",
 				"error.category": "McpProcessFailure",
 				"error.code": "ECONNREFUSED",
+				"mcp.failure.reason": "transport_failure",
+			}),
+		);
+		expect(testDoubles.sentryCaptureMessage).toHaveBeenCalledWith(
+			"MCP process uncaughtException failure",
+			"error",
+		);
+		expect(testDoubles.sentrySetContext).toHaveBeenCalledWith(
+			"mcpException",
+			expect.objectContaining({
+				category: "Error",
+				message: "uncaught",
 			}),
 		);
 		expect(testDoubles.activeSpan.setAttributes).toHaveBeenCalledWith(
@@ -500,13 +527,17 @@ describe("telemetry initialization", () => {
 		expect(setAttribute).toHaveBeenCalledWith("user.hash", "abcdef0123");
 	});
 
-	it("exports only bounded exception attributes", async () => {
+	it("exports bounded debug exception attributes", async () => {
 		vi.resetModules();
 		const mod = await import("./telemetry.js");
 		const secret = "secret-exception-message";
 		const path = "/home/private/hevy-mcp/packages/node/src/index.ts";
 		const error = new Error(secret);
 		error.stack = `Error: ${secret}\n    at main (${path}:10:2)`;
+		Object.assign(error, {
+			authorization: "bearer-secret",
+			body: "response-body-secret",
+		});
 
 		mod.recordTelemetryException(error, {
 			"mcp.failure.phase": "run",
@@ -515,19 +546,63 @@ describe("telemetry initialization", () => {
 		});
 
 		expect(testDoubles.activeSpan.recordException).not.toHaveBeenCalled();
-		expect(testDoubles.activeSpan.addEvent).toHaveBeenCalledWith("exception", {
-			"exception.type": "Error",
-			"mcp.failure.phase": "run",
-			"error.type": "MCP_SERVER_RUN_ERROR",
-			"error.category": "McpServerRunFailure",
-		});
+		expect(testDoubles.activeSpan.addEvent).toHaveBeenCalledWith(
+			"exception",
+			expect.objectContaining({
+				"exception.type": "Error",
+				"exception.category": "Error",
+				"exception.message": secret,
+				"exception.stacktrace": error.stack,
+				"mcp.failure.phase": "run",
+				"error.type": "MCP_SERVER_RUN_ERROR",
+				"error.category": "McpServerRunFailure",
+			}),
+		);
 		const exported = JSON.stringify({
 			events: testDoubles.activeSpan.addEvent.mock.calls,
 			attributes: testDoubles.activeSpan.setAttributes.mock.calls,
 		});
-		expect(exported).not.toContain(secret);
-		expect(exported).not.toContain(path);
-		expect(exported).not.toContain("exception.message");
-		expect(exported).not.toContain("exception.stacktrace");
+		expect(exported).toContain(secret);
+		expect(exported).toContain(path);
+		expect(exported).toContain("exception.message");
+		expect(exported).toContain("exception.stacktrace");
+		expect(exported).not.toContain("bearer-secret");
+		expect(exported).not.toContain("response-body-secret");
+	});
+
+	it("keeps Sentry diagnostics equivalent to OTel diagnostics", async () => {
+		vi.resetModules();
+		const mod = await import("./telemetry.js");
+		const error = new TypeError("invalid runtime state");
+		error.stack =
+			"TypeError: invalid runtime state\n    at run (/app/index.ts:4:2)";
+		const attributes = {
+			"mcp.failure.phase": "uncaught_exception",
+			"error.type": "MCP_PROCESS_EXCEPTION",
+			"error.category": "McpProcessFailure",
+		};
+
+		mod.recordSentryTelemetryException(
+			"MCP process uncaughtException failure",
+			error,
+			attributes,
+		);
+
+		expect(testDoubles.sentryCaptureMessage).toHaveBeenCalledWith(
+			"MCP process uncaughtException failure",
+			"error",
+		);
+		expect(testDoubles.sentrySetTag).toHaveBeenCalledWith(
+			"exception.type",
+			"TypeError",
+		);
+		expect(testDoubles.sentrySetContext).toHaveBeenCalledWith(
+			"mcpException",
+			expect.objectContaining({
+				category: "TypeError",
+				message: "invalid runtime state",
+				stack: error.stack,
+			}),
+		);
 	});
 });

--- a/packages/node/src/utils/telemetry.test.ts
+++ b/packages/node/src/utils/telemetry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HevyHttpError } from "@hevy-mcp/hevy-client";
 
 const originalEnv = { ...process.env };
 
@@ -604,5 +605,30 @@ describe("telemetry initialization", () => {
 				stack: error.stack,
 			}),
 		);
+	});
+
+	it("captures the Hevy API response error message", async () => {
+		vi.resetModules();
+		const mod = await import("./telemetry.js");
+		const responseMessage = "Hevy rejected the workout";
+		const error = new HevyHttpError("generic request failure", {
+			status: 422,
+			method: "POST",
+			endpoint: "/v1/workouts",
+			data: { error: responseMessage, internal: "response-body-secret" },
+		});
+
+		mod.recordTelemetryException(error, {
+			"mcp.failure.phase": "run",
+			"error.type": "MCP_SERVER_RUN_ERROR",
+			"error.category": "McpServerRunFailure",
+		});
+
+		const exported = JSON.stringify({
+			events: testDoubles.activeSpan.addEvent.mock.calls,
+			attributes: testDoubles.activeSpan.setAttributes.mock.calls,
+		});
+		expect(exported).toContain(responseMessage);
+		expect(exported).not.toContain("response-body-secret");
 	});
 });

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -27,6 +27,7 @@ import {
 	AggregationTemporalityPreference,
 	OTLPMetricExporter,
 } from "@opentelemetry/exporter-metrics-otlp-http";
+import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import {
 	AlwaysOnSampler,
@@ -58,76 +59,163 @@ const PROCESS_FAILURE_TAXONOMY = {
 	unhandledRejection: "unhandled_rejection",
 } as const;
 
-const SAFE_EXCEPTION_TYPES = new Set([
+type TelemetryAttributeValue = string | number | boolean;
+type TelemetryAttributes = Record<string, TelemetryAttributeValue>;
+
+const MAX_EXCEPTION_MESSAGE_LENGTH = 2_048;
+const MAX_EXCEPTION_STACK_LENGTH = 16_384;
+const SAFE_NAMED_EXCEPTION_TYPES = new Set([
 	"AggregateError",
 	"DOMException",
 	"Error",
 	"EvalError",
 	"HevyHttpError",
+	"ProtocolError",
 	"RangeError",
 	"ReferenceError",
 	"SyntaxError",
 	"TypeError",
 	"URIError",
-	"ProtocolError",
 	"ZodError",
 ]);
-const SAFE_EXCEPTION_CODES = new Set([
-	"EAI_AGAIN",
-	"ECONNABORTED",
-	"ECONNREFUSED",
-	"ECONNRESET",
-	"ENETUNREACH",
-	"ENOTFOUND",
-	"ERR_NETWORK",
-	"ERR_SOCKET_TIMEOUT",
-	"ETIMEDOUT",
-	"HEVY_INVALID_ENDPOINT",
-	"HEVY_REQUEST_ABORTED",
-	"HEVY_RETRY_EXHAUSTED",
-]);
 
-function normalizeTelemetryError(error: unknown): { name: string } {
+function getDebugExceptionMessage(error: unknown): string | undefined {
+	if (error instanceof Error && typeof error.message === "string") {
+		return error.message.slice(0, MAX_EXCEPTION_MESSAGE_LENGTH);
+	}
+	if (typeof error === "string") {
+		return error.slice(0, MAX_EXCEPTION_MESSAGE_LENGTH);
+	}
+	return undefined;
+}
+
+function getDebugExceptionStack(error: unknown): string | undefined {
+	return error instanceof Error && typeof error.stack === "string"
+		? error.stack.slice(0, MAX_EXCEPTION_STACK_LENGTH)
+		: undefined;
+}
+
+function getFailureReason(
+	error: unknown,
+	attributes: TelemetryAttributes,
+): string {
+	const category = String(attributes["error.category"] ?? "");
+	if (category.includes("Sdk")) return "sdk_failure";
+	if (category.includes("Transport")) return "transport_failure";
+	if (category.includes("Server")) return "runtime_failure";
+
+	const diagnostic = createSafeErrorDiagnostic(error);
+	if (diagnostic.code?.startsWith("ECONN") || diagnostic.code === "EAI_AGAIN") {
+		return "transport_failure";
+	}
+	if (diagnostic.category === "HevyHttpError") return "transport_failure";
+	if (diagnostic.category === "UnknownError") return "unknown_runtime_error";
+	return "application_failure";
+}
+
+function getNormalizedExceptionType(
+	error: unknown,
+	diagnosticCategory: string,
+): string {
+	if (diagnosticCategory !== "Error" && diagnosticCategory !== "UnknownError") {
+		return diagnosticCategory;
+	}
 	const candidate =
 		error instanceof Error && typeof error.name === "string"
 			? error.name
 			: undefined;
-	const name =
-		candidate && SAFE_EXCEPTION_TYPES.has(candidate)
-			? candidate
-			: "UnknownError";
-	return { name };
+	return candidate && SAFE_NAMED_EXCEPTION_TYPES.has(candidate)
+		? candidate
+		: diagnosticCategory;
 }
 
-function getSafeExceptionCode(error: unknown): string | undefined {
-	if (!error || typeof error !== "object" || !("code" in error))
-		return undefined;
-	const code = error.code;
-	return typeof code === "string" && SAFE_EXCEPTION_CODES.has(code)
-		? code
-		: undefined;
+function getExceptionAttributes(
+	error: unknown,
+	attributes: TelemetryAttributes,
+): TelemetryAttributes {
+	const diagnostic = createSafeErrorDiagnostic(error);
+	const message = getDebugExceptionMessage(error);
+	const stack = getDebugExceptionStack(error);
+	const exceptionType = getNormalizedExceptionType(error, diagnostic.category);
+	return {
+		"exception.type": exceptionType,
+		"exception.category": diagnostic.category,
+		...(diagnostic.code ? { "exception.code": diagnostic.code } : {}),
+		...(message ? { "exception.message": message } : {}),
+		...(stack ? { "exception.stacktrace": stack } : {}),
+		...(attributes["mcp.failure.phase"]
+			? { "mcp.failure.reason": getFailureReason(error, attributes) }
+			: {}),
+	};
 }
 
 export function recordTelemetryException(
 	error: unknown,
-	attributes?: Record<string, string | number | boolean>,
+	attributes?: TelemetryAttributes,
 	span?: ApiSpan,
 ): void {
 	if (!telemetryEnabled) return;
 	try {
 		const target = span ?? trace.getActiveSpan();
 		if (!target) return;
-		const normalized = normalizeTelemetryError(error);
+		const exceptionAttributes = getExceptionAttributes(error, attributes ?? {});
 		target.addEvent("exception", {
 			...attributes,
-			"exception.type": normalized.name,
+			...exceptionAttributes,
 		});
-		target.setAttribute("exception.type", normalized.name);
-		target.setAttribute("error.category", normalized.name);
+		target.setAttributes(exceptionAttributes);
+		target.setAttribute(
+			"error.category",
+			exceptionAttributes["exception.category"],
+		);
 		if (attributes) target.setAttributes(attributes);
 		target.setStatus({ code: SpanStatusCode.ERROR });
 	} catch {
 		// Telemetry failures must never affect MCP behavior.
+	}
+}
+
+/**
+ * Record the same bounded lifecycle/process diagnostic in Sentry.
+ *
+ * The message and stack are intentionally retained for debugging while the
+ * event itself remains generic. Credentials, request arguments, and response
+ * bodies are not added by this adapter.
+ */
+export function recordSentryTelemetryException(
+	event: string,
+	error: unknown,
+	attributes: TelemetryAttributes,
+): void {
+	if (!telemetryEnabled) return;
+	try {
+		const diagnostic = createSafeErrorDiagnostic(error);
+		const exceptionAttributes = getExceptionAttributes(error, attributes);
+		Sentry.withScope((scope) => {
+			for (const [key, value] of Object.entries({
+				...attributes,
+				...exceptionAttributes,
+			})) {
+				if (key === "exception.message" || key === "exception.stacktrace") {
+					continue;
+				}
+				scope.setTag(key, String(value));
+			}
+			scope.setContext("mcpException", {
+				...diagnostic,
+				message: exceptionAttributes["exception.message"],
+				stack: exceptionAttributes["exception.stacktrace"],
+			});
+			scope.setFingerprint([
+				"mcp-telemetry-exception",
+				String(attributes["mcp.failure.phase"] ?? event),
+				diagnostic.category,
+				String(diagnostic.code ?? "none"),
+			]);
+			Sentry.captureMessage(event, "error");
+		});
+	} catch {
+		// Sentry failures must never affect MCP behavior.
 	}
 }
 
@@ -145,17 +233,19 @@ export function installProcessExceptionTracking(
 				{ attributes: { "mcp.span.category": "process" } },
 				(span) => {
 					try {
-						const code = getSafeExceptionCode(error);
-						recordTelemetryException(
+						const diagnostic = createSafeErrorDiagnostic(error);
+						const attributes = {
+							"exception.source": source,
+							"mcp.failure.phase": PROCESS_FAILURE_TAXONOMY[source],
+							"error.type": "MCP_PROCESS_EXCEPTION",
+							"error.category": "McpProcessFailure",
+							...(diagnostic.code ? { "error.code": diagnostic.code } : {}),
+						};
+						recordTelemetryException(error, attributes, span);
+						recordSentryTelemetryException(
+							`MCP process ${source} failure`,
 							error,
-							{
-								"exception.source": source,
-								"mcp.failure.phase": PROCESS_FAILURE_TAXONOMY[source],
-								"error.type": "MCP_PROCESS_EXCEPTION",
-								"error.category": "McpProcessFailure",
-								...(code ? { "error.code": code } : {}),
-							},
-							span,
+							attributes,
 						);
 					} finally {
 						span.end();

--- a/packages/node/src/utils/telemetry.ts
+++ b/packages/node/src/utils/telemetry.ts
@@ -28,6 +28,7 @@ import {
 	OTLPMetricExporter,
 } from "@opentelemetry/exporter-metrics-otlp-http";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import { getHevyResponseErrorMessage } from "@hevy-mcp/hevy-client";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import {
 	AlwaysOnSampler,
@@ -80,6 +81,8 @@ const SAFE_NAMED_EXCEPTION_TYPES = new Set([
 ]);
 
 function getDebugExceptionMessage(error: unknown): string | undefined {
+	const responseMessage = getHevyResponseErrorMessage(error);
+	if (responseMessage) return responseMessage;
 	if (error instanceof Error && typeof error.message === "string") {
 		return error.message.slice(0, MAX_EXCEPTION_MESSAGE_LENGTH);
 	}


### PR DESCRIPTION
## Summary

- preserve normalized exception type, category, code, message, and bounded stack context on process exception spans;
- emit equivalent process and lifecycle diagnostics to Sentry and OpenTelemetry;
- add explicit lifecycle termination reasons for startup, connect, and runtime failures;
- capture bounded allowlisted Hevy API response error messages on API failure spans/events and direct process/lifecycle exception telemetry;
- keep raw request/response bodies, credentials, and high-cardinality API messages out of metrics;
- document the more diagnostic telemetry posture and the existing `HEVY_MCP_TELEMETRY=0` opt-out.

Closes #915

## Diagnostics posture

Per follow-up direction, process and lifecycle telemetry retains up to 2 KiB of exception message and 16 KiB of stack context when telemetry is enabled. Hevy API failures additionally retain only a trimmed, bounded message from the response's allowlisted `error`, `message`, or `detail` field. The adapter does not add API keys, authorization headers, MCP arguments, or full request/response bodies.

## Validation

- `npm run build`
- `npm run check`
- `npm run check:types`
- `npm run test:unit` (852 passed)
- `npm run test:stdio` (44 passed)
- `npm run check:changeset`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details for failed API requests, including clearer messages when available.
  * Added more precise diagnostics for startup, connection, and runtime failures.

* **Improvements**
  * Enhanced monitoring information for API and application failures while limiting message length and excluding sensitive data.
  * Improved consistency of diagnostic information across supported monitoring systems.

* **Documentation**
  * Clarified telemetry privacy practices, including exclusions for prompts, tool data, request/response bodies, API keys, and authorization headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->