### PR TITLE
chore: pin node and npm with mise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,19 @@ Git hooks enabled. Fix hook failures instead of bypassing them.
 - Use the GitHub MCP server for GitHub operations. Use `gh` only when the
   GitHub MCP server cannot complete the operation because of a token problem.
 
+## Runtime and package manager
+
+Use mise for Node.js and npm. The repository pins Node.js 24 and npm 12 in
+`mise.toml`; install the pinned tools before running development commands:
+
+```bash
+mise install
+```
+
+Run Node.js and npm commands through mise so they do not fall back to system
+installations. Use `mise exec -- npm ...`, `mise exec -- npx ...`, and
+`mise exec -- node ...` in setup, validation, and troubleshooting commands.
+
 ## Repository shape and boundaries
 
 The root is a private workspace orchestrator and has no runtime `src/` tree.
@@ -75,10 +88,10 @@ Treat every file under `packages/hevy-client/src/generated/` as generated
 output. Change the OpenAPI source or the Kubb configuration, then regenerate:
 
 ```bash
-npm run openapi          # refreshes the upstream spec; needs network access
-npm run build:client
-npm run check:openapi
-npm run check:generated
+mise exec -- npm run openapi          # refreshes the upstream spec; needs network access
+mise exec -- npm run build:client
+mise exec -- npm run check:openapi
+mise exec -- npm run check:generated
 ```
 
 Review the complete generated diff. Consumers use the curated
@@ -165,12 +178,12 @@ For source changes, run the narrow relevant lane and the unit suite. Before a
 pull request, use the repository baseline from `CONTRIBUTING.md`:
 
 ```bash
-npm run check
-npm run check:types
-npm run build
-npm run test:pr
-npm run test:performance
-npm run check:changeset
+mise exec -- npm run check
+mise exec -- npm run check:types
+mise exec -- npm run build
+mise exec -- npm run test:pr
+mise exec -- npm run test:performance
+mise exec -- npm run check:changeset
 ```
 
 Useful focused checks include:

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,6 @@
 [tools]
+node = "24"
+npm = "12.0.2"
 hk = "1.51.0"
 kiota = "latest"
 pinact = "latest"


### PR DESCRIPTION
## Primary changes
- Pin Node.js 24 and npm 12.0.2 in mise.toml
- Document mise-first Node.js/npm usage in AGENTS.md
- Update documented setup and validation commands to use mise exec

## Testing and QA
- mise exec -- node --version
- mise exec -- npm --version
- mise exec -- npm run check
- mise exec -- npm run check:types
- mise exec -- npm run build
- mise exec -- npm run test:unit (847 tests passed)
- mise exec -- npm run check:changeset

No runtime package changes; no release changeset required.

## Reviewer walkthrough

- `mise.toml` pins Node.js 24 and npm 12.0.2 alongside the repository's existing tools.
- `AGENTS.md` adds the mise-first workflow and updates OpenAPI and validation examples to run Node.js and npm commands through `mise exec`.

## Correctness and invariants

- Documented Node.js, npm, and npx commands use the pinned mise-managed toolchain rather than ambient system installations.
- The change is limited to contributor documentation and tool-version configuration; it does not alter runtime packages, application behavior, or release contents.

## Summary by Sourcery

Pin Node.js and npm versions via mise and document mise-first usage for development workflows.

Build:
- Pin Node.js 24 and npm 12.0.2 in `mise.toml` to standardize the runtime and package manager across environments.

Documentation:
- Document mise-based Node.js and npm usage, including installing pinned tools and running commands via `mise exec`.

Chores:
- Update documented npm commands to run through `mise exec` to avoid falling back to system installations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized project workflows to use the configured Node.js and npm versions.
  * Added Node.js 24 and npm 12.0.2 to the development tool configuration.
  * Updated contributor guidance and validation instructions to reflect the standardized commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Pin Node.js 24 and npm 12.0.2 using mise, and update documentation to enforce mise for all Node.js and npm command execution.

Main changes:
- Added node and npm version pins to mise.toml configuration file
- Updated AGENTS.md with mise runtime setup instructions and rationale for tool pinning
- Replaced bare npm commands with `mise exec --` wrappers in all documentation examples

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

