### PR TITLE
feat(operations): route routine listing through shared operation

### DIFF
--- a/.changeset/routines-list-operation.md
+++ b/.changeset/routines-list-operation.md
@@ -1,0 +1,9 @@
+---
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Add a typed routines list operation and use it from Core and the CLI.

--- a/packages/cli/src/commands/index.test.ts
+++ b/packages/cli/src/commands/index.test.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable typescript/unbound-method */
 import type { HevyClient } from "@hevy-mcp/hevy-client";
+import type { HevyOperations } from "@hevy-mcp/operations";
 import { describe, expect, it, vi } from "vitest";
 import type { CliArgs } from "../arguments.js";
 import { ApiResponseError } from "../errors.js";
@@ -79,6 +80,50 @@ const options = (data: unknown): CliArgs["options"] => ({
 });
 
 describe("execute command/API mappings", () => {
+	it("uses the injected routines list operation while retaining the page envelope", async () => {
+		const api = client();
+		const executeList = vi.fn().mockResolvedValue({
+			items: [{ id: "r1", title: "Push", exercises: [] }],
+			page: 2,
+			pageCount: 3,
+		});
+		const operations = {
+			routines: { list: { execute: executeList } },
+		} as unknown as HevyOperations;
+
+		await expect(
+			execute(
+				args("routines", "list", [], { page: "2" }),
+				api,
+				undefined,
+				undefined,
+				operations,
+			),
+		).resolves.toEqual({
+			page: 2,
+			page_count: 3,
+			routines: [{ id: "r1", title: "Push", exercises: [] }],
+		});
+		expect(executeList).toHaveBeenCalledWith({ page: 2, pageSize: 5 });
+		expect(api.getRoutines).not.toHaveBeenCalled();
+
+		executeList.mockResolvedValue({
+			items: [],
+			page: 2,
+			pageCount: undefined,
+			expected404Outcome: "end_of_list",
+		});
+		await expect(
+			execute(
+				args("routines", "list", [], { page: "2" }),
+				api,
+				undefined,
+				undefined,
+				operations,
+			),
+		).resolves.toEqual({ page: 2, page_count: 0, routines: [] });
+	});
+
 	it.each([
 		["user", undefined, [], "getUserInfo"],
 		["workouts", "list", [], "getWorkouts"],

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -182,7 +182,7 @@ async function executeWorkoutEvents({ args, client }: CommandContext) {
 	};
 }
 
-async function executeWorkouts(context: CommandContext): CommandResult {
+function executeWorkouts(context: CommandContext): CommandResult {
 	switch (context.args.subcommand) {
 		case "list":
 			return executeWorkoutList(context);
@@ -280,7 +280,7 @@ async function executeRoutineUpdate({
 	};
 }
 
-async function executeRoutines(context: CommandContext): CommandResult {
+function executeRoutines(context: CommandContext): CommandResult {
 	switch (context.args.subcommand) {
 		case "list":
 			return executeRoutineList(context);
@@ -362,7 +362,7 @@ async function executeExerciseSearch({ args, client }: CommandContext) {
 	};
 }
 
-async function executeExercises(context: CommandContext): CommandResult {
+function executeExercises(context: CommandContext): CommandResult {
 	switch (context.args.subcommand) {
 		case "create":
 			return executeExerciseCreate(context);
@@ -446,7 +446,7 @@ async function executeMeasurementUpdate({
 	return { body_measurement: measurement };
 }
 
-async function executeMeasurements(context: CommandContext): CommandResult {
+function executeMeasurements(context: CommandContext): CommandResult {
 	switch (context.args.subcommand) {
 		case "list":
 			return executeMeasurementList(context);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -180,8 +180,23 @@ export async function execute(
 				args,
 				getV1RoutinesQueryParamsSchema,
 			);
+			const result = await operations.routines.list.execute({
+				page,
+				pageSize,
+			});
+			if (result.expected404Outcome === "end_of_list") {
+				return pageEnvelope(
+					{ page: result.page, page_count: result.pageCount ?? 0 },
+					"routines",
+					result.items,
+				);
+			}
 			return list(
-				body(await client.getRoutines({ page, pageSize })),
+				{
+					page: result.page,
+					page_count: result.pageCount,
+					routines: result.items,
+				},
 				"routines",
 				"routines",
 				page,

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -89,6 +89,486 @@ function mutationData(args: CliArgs): string {
 	return value;
 }
 
+type CommandContext = {
+	args: CliArgs;
+	client: HevyClient;
+	now: () => Date;
+	readDataSource: DataSourceReader;
+	operations: HevyOperations;
+};
+
+type CommandResult = Promise<unknown>;
+
+async function executeWorkoutList({
+	args,
+	operations,
+}: CommandContext): Promise<unknown> {
+	const { page, pageSize } = parsePagination(args);
+	const result = await operations.workouts.list.execute({ page, pageSize });
+	if (result.expected404Outcome === "end_of_list")
+		return pageEnvelope(
+			{ page: result.page, page_count: result.pageCount ?? 0 },
+			"workouts",
+			result.items,
+		);
+	return list(
+		{
+			page: result.page,
+			page_count: result.pageCount,
+			workouts: result.items,
+		},
+		"workouts",
+		"workouts",
+		page,
+	);
+}
+
+async function executeWorkoutGet({ args, client }: CommandContext) {
+	const workoutId = parseWorkoutId(args.positionals[0]);
+	return { workout: await client.getWorkout(workoutId) };
+}
+
+async function executeWorkoutCreate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		workoutInputSchema,
+		readDataSource,
+	);
+	return { workout: await client.createWorkout(input) };
+}
+
+async function executeWorkoutUpdate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		replaceWorkoutInputSchema,
+		readDataSource,
+	);
+	const workoutId = parseWorkoutId(args.positionals[0]);
+	if (input.workout_id !== workoutId)
+		throw new UsageError("Workout ID does not match --data.workout_id");
+	const response = await client.updateWorkout(workoutId, {
+		workout: input.workout,
+	});
+	return { workout_id: workoutId, workout: response };
+}
+
+async function executeWorkoutCount({ client }: CommandContext) {
+	const count = body(await client.getWorkoutCount()).workout_count;
+	if (typeof count !== "number" || !Number.isInteger(count) || count < 0)
+		throw new ApiResponseError("The API returned an invalid workout count");
+	return { workout_count: count };
+}
+
+async function executeWorkoutEvents({ args, client }: CommandContext) {
+	const options = parseWorkoutEventsOptions(args);
+	return {
+		...list(
+			body(await client.getWorkoutEvents(options)),
+			"events",
+			"events",
+			options.page,
+		),
+		since: options.since,
+	};
+}
+
+async function executeWorkouts(context: CommandContext): CommandResult {
+	switch (context.args.subcommand) {
+		case "list":
+			return executeWorkoutList(context);
+		case "get":
+			return executeWorkoutGet(context);
+		case "create":
+			return executeWorkoutCreate(context);
+		case "update":
+			return executeWorkoutUpdate(context);
+		case "count":
+			return executeWorkoutCount(context);
+		case "events":
+			return executeWorkoutEvents(context);
+		default:
+			throw new UsageError("Unknown command; run hevy --help");
+	}
+}
+
+async function executeRoutineList({
+	args,
+	operations,
+}: CommandContext): Promise<unknown> {
+	const { page, pageSize } = parsePagination(
+		args,
+		getV1RoutinesQueryParamsSchema,
+	);
+	const result = await operations.routines.list.execute({ page, pageSize });
+	if (result.expected404Outcome === "end_of_list")
+		return pageEnvelope(
+			{ page: result.page, page_count: result.pageCount ?? 0 },
+			"routines",
+			result.items,
+		);
+	return list(
+		{
+			page: result.page,
+			page_count: result.pageCount,
+			routines: result.items,
+		},
+		"routines",
+		"routines",
+		page,
+	);
+}
+
+async function executeRoutineGet({ args, client }: CommandContext) {
+	const routineId = parseRoutineId(args.positionals[0]);
+	return { routine: await client.getRoutineById(routineId) };
+}
+
+async function executeRoutineCreate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		createRoutineInputSchema,
+		readDataSource,
+	);
+	const { payload, usesRepRanges } = buildRoutinePayload(
+		input.routine,
+		"create",
+	);
+	const response = await client.createRoutine({ routine: payload });
+	return { routine: response, uses_rep_ranges: usesRepRanges };
+}
+
+async function executeRoutineUpdate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		updateRoutineInputSchema,
+		readDataSource,
+	);
+	const routineId = parseRoutineId(args.positionals[0]);
+	if (input.routine_id !== routineId)
+		throw new UsageError("Routine ID does not match --data.routine_id");
+	const { payload, usesRepRanges } = buildRoutinePayload(
+		input.routine,
+		"update",
+	);
+	const response = await client.updateRoutine(routineId, {
+		routine: payload,
+	});
+	return {
+		routine_id: routineId,
+		routine: response,
+		uses_rep_ranges: usesRepRanges,
+	};
+}
+
+async function executeRoutines(context: CommandContext): CommandResult {
+	switch (context.args.subcommand) {
+		case "list":
+			return executeRoutineList(context);
+		case "get":
+			return executeRoutineGet(context);
+		case "create":
+			return executeRoutineCreate(context);
+		case "update":
+			return executeRoutineUpdate(context);
+		default:
+			throw new UsageError("Unknown command; run hevy --help");
+	}
+}
+
+async function executeExerciseCreate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		exerciseTemplateInputSchema,
+		readDataSource,
+	);
+	return { exercise_template: await client.createExerciseTemplate(input) };
+}
+
+async function executeExerciseGet({ args, client }: CommandContext) {
+	const exerciseId = parseExerciseId(args.positionals[0]);
+	return { exercise_template: await client.getExerciseTemplate(exerciseId) };
+}
+
+async function executeExerciseHistory({ args, client }: CommandContext) {
+	const exerciseId = parseExerciseHistoryId(args.positionals[0]);
+	const options = parseExerciseHistoryOptions(args);
+	return {
+		exercise_template_id: exerciseId,
+		exercise_history:
+			(await client.getExerciseHistory(exerciseId, options)).exercise_history ??
+			[],
+	};
+}
+
+async function executeExerciseSearch({ args, client }: CommandContext) {
+	const query = parseSearchQuery(args.positionals[0]);
+	const maxPages = parseSearchMaxPages(args);
+	const matches: unknown[] = [];
+	let pages_scanned = 0;
+	let page_count = 1;
+	while (pages_scanned < page_count && pages_scanned < maxPages) {
+		const requestedPage = pages_scanned + 1;
+		const result = body(
+			await client.getExerciseTemplates({ page: requestedPage, pageSize: 100 }),
+		);
+		page_count = result.page_count as number;
+		if (
+			!Number.isInteger(page_count) ||
+			page_count < 0 ||
+			(result.page !== undefined && result.page !== requestedPage) ||
+			(page_count > 0 && page_count < requestedPage)
+		)
+			throw new ApiResponseError(
+				"The API returned invalid pagination metadata",
+			);
+		pages_scanned += 1;
+		if (page_count === 0) break;
+		for (const item of Array.isArray(result.exercise_templates)
+			? result.exercise_templates
+			: [])
+			if (text(body(item).title).toLocaleLowerCase().includes(query))
+				matches.push(item);
+	}
+	return {
+		query,
+		matches,
+		pages_scanned,
+		complete: pages_scanned >= page_count,
+	};
+}
+
+async function executeExercises(context: CommandContext): CommandResult {
+	switch (context.args.subcommand) {
+		case "create":
+			return executeExerciseCreate(context);
+		case "get":
+			return executeExerciseGet(context);
+		case "history":
+			return executeExerciseHistory(context);
+		case "search":
+			return executeExerciseSearch(context);
+		default:
+			throw new UsageError("Unknown command; run hevy --help");
+	}
+}
+
+async function executeMeasurementList({
+	args,
+	client,
+}: CommandContext): Promise<unknown> {
+	const { page, pageSize } = parsePagination(
+		args,
+		getV1BodyMeasurementsQueryParamsSchema,
+	);
+	return list(
+		body(await client.getBodyMeasurements({ page, pageSize })),
+		"body_measurements",
+		"body_measurements",
+		page,
+	);
+}
+
+async function executeMeasurementGet({ args, client }: CommandContext) {
+	const date = parseMeasurementDate(args.positionals[0]);
+	return { body_measurement: await client.getBodyMeasurement(date) };
+}
+
+async function executeMeasurementCreate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		createBodyMeasurementDataSchema,
+		readDataSource,
+	);
+	const date = parseMeasurementDate(args.positionals[0] ?? input.date);
+	if (input.date !== date)
+		throw new UsageError("Measurement date does not match --data.date");
+	const { date: _date, ...fields } = input;
+	const wireFields = buildMeasurementPayload(fields);
+	await client.createBodyMeasurement({ date, ...wireFields });
+	return { body_measurement: { date, ...wireFields } };
+}
+
+async function executeMeasurementUpdate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		updateBodyMeasurementDataSchema,
+		readDataSource,
+	);
+	const date = parseMeasurementDate(args.positionals[0] ?? input.date);
+	if (input.date !== date)
+		throw new UsageError("Measurement date does not match --data.date");
+	const parsed = existingBodyMeasurementSchema.safeParse(
+		await client.getBodyMeasurement(date),
+	);
+	if (!parsed.success || parsed.data.date !== date)
+		throw new ApiResponseError("The API returned an invalid body measurement");
+	const { date: _date, ...changes } = input;
+	const { payload, measurement } = mergeMeasurementPayload(
+		parsed.data,
+		changes,
+	);
+	await client.updateBodyMeasurement(date, payload);
+	return { body_measurement: measurement };
+}
+
+async function executeMeasurements(context: CommandContext): CommandResult {
+	switch (context.args.subcommand) {
+		case "list":
+			return executeMeasurementList(context);
+		case "get":
+			return executeMeasurementGet(context);
+		case "create":
+			return executeMeasurementCreate(context);
+		case "update":
+			return executeMeasurementUpdate(context);
+		default:
+			throw new UsageError("Unknown command; run hevy --help");
+	}
+}
+
+async function executeFolderCreate({
+	args,
+	client,
+	readDataSource,
+}: CommandContext) {
+	requireMutationConfirmation(args);
+	const input = await loadMutationInput(
+		mutationData(args),
+		routineFolderInputSchema,
+		readDataSource,
+	);
+	return { routine_folder: await client.createRoutineFolder(input) };
+}
+
+async function collectSummaryWorkouts(
+	client: HevyClient,
+	from: Date,
+	to: Date,
+) {
+	let pageNumber = 1;
+	let pageCount = 1;
+	let pagesScanned = 0;
+	const workouts: Body[] = [];
+	let stoppedEarly = false;
+	while (pageNumber <= pageCount) {
+		const result = body(
+			await client.getWorkouts({ page: pageNumber, pageSize: 10 }),
+		);
+		pageCount = result.page_count as number;
+		if (
+			!Number.isInteger(pageCount) ||
+			pageCount < 0 ||
+			(result.page !== undefined && result.page !== pageNumber) ||
+			(pageCount > 0 && pageCount < pageNumber)
+		)
+			throw new ApiResponseError(
+				"The API returned invalid pagination metadata",
+			);
+		pagesScanned += 1;
+		if (pageCount === 0) break;
+		const items = Array.isArray(result.workouts)
+			? result.workouts.map(body)
+			: [];
+		for (const workout of items) {
+			const timestamp = Date.parse(text(workout.start_time));
+			if (Number.isNaN(timestamp))
+				throw new ApiResponseError(
+					"The API returned a workout with an invalid timestamp",
+				);
+			if (timestamp >= from.getTime() && timestamp <= to.getTime())
+				workouts.push(workout);
+		}
+		const oldest = items.at(-1)?.start_time;
+		if (oldest && Date.parse(text(oldest)) < from.getTime()) {
+			stoppedEarly = true;
+			break;
+		}
+		pageNumber += 1;
+	}
+	return { workouts, pageNumber, pageCount, pagesScanned, stoppedEarly };
+}
+
+function summarizeWorkouts(workouts: readonly Body[]) {
+	let exerciseCount = 0;
+	let setCount = 0;
+	let totalVolumeKg = 0;
+	let totalDurationSeconds = 0;
+	for (const workout of workouts) {
+		const start = Date.parse(text(workout.start_time));
+		const end = Date.parse(text(workout.end_time));
+		if (!Number.isNaN(start) && !Number.isNaN(end))
+			totalDurationSeconds += Math.max(0, (end - start) / 1000);
+		const exercises = array(workout.exercises);
+		exerciseCount += exercises.length;
+		for (const exercise of exercises)
+			for (const set of array(body(exercise).sets)) {
+				setCount += 1;
+				const item = body(set);
+				if (typeof item.weight_kg === "number" && typeof item.reps === "number")
+					totalVolumeKg += item.weight_kg * item.reps;
+			}
+	}
+	return { exerciseCount, setCount, totalVolumeKg, totalDurationSeconds };
+}
+
+async function executeSummary({ args, client, now }: CommandContext) {
+	const weeks = parseWeeks(args);
+	const to = now();
+	const from = new Date(to.getTime() - weeks * 7 * 24 * 60 * 60 * 1000);
+	const collection = await collectSummaryWorkouts(client, from, to);
+	const totals = summarizeWorkouts(collection.workouts);
+	return {
+		weeks,
+		start_date: from.toISOString(),
+		end_date: to.toISOString(),
+		workout_count: collection.workouts.length,
+		total_duration_seconds: totals.totalDurationSeconds,
+		exercise_count: totals.exerciseCount,
+		set_count: totals.setCount,
+		total_volume_kg: totals.totalVolumeKg,
+		pages_scanned: collection.pagesScanned,
+		complete:
+			collection.stoppedEarly ||
+			collection.pageNumber > collection.pageCount ||
+			collection.pagesScanned === collection.pageCount,
+	};
+}
+
 export async function execute(
 	args: CliArgs,
 	client: HevyClient,
@@ -96,372 +576,21 @@ export async function execute(
 	readDataSource: DataSourceReader = defaultDataSourceReader,
 	operations: HevyOperations = createOperations(client),
 ): Promise<unknown> {
-	const command = args.command;
-	const sub = args.subcommand;
-	if (command === "user" && !sub) return { user: await client.getUserInfo() };
-	if (command === "workouts") {
-		if (sub === "list") {
-			const { page, pageSize } = parsePagination(args);
-			const result = await operations.workouts.list.execute({
-				page,
-				pageSize,
-			});
-			if (result.expected404Outcome === "end_of_list") {
-				return pageEnvelope(
-					{ page: result.page, page_count: result.pageCount ?? 0 },
-					"workouts",
-					result.items,
-				);
-			}
-			return list(
-				{
-					page: result.page,
-					page_count: result.pageCount,
-					workouts: result.items,
-				},
-				"workouts",
-				"workouts",
-				page,
-			);
-		}
-		if (sub === "get") {
-			const workoutId = parseWorkoutId(args.positionals[0]);
-			return {
-				workout: await client.getWorkout(workoutId),
-			};
-		}
-		if (sub === "create") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				workoutInputSchema,
-				readDataSource,
-			);
-			const response = await client.createWorkout(input);
-			return { workout: response };
-		}
-		if (sub === "update") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				replaceWorkoutInputSchema,
-				readDataSource,
-			);
-			const workoutId = parseWorkoutId(args.positionals[0]);
-			if (input.workout_id !== workoutId)
-				throw new UsageError("Workout ID does not match --data.workout_id");
-			const response = await client.updateWorkout(workoutId, {
-				workout: input.workout,
-			});
-			return { workout_id: workoutId, workout: response };
-		}
-		if (sub === "count") {
-			const count = body(await client.getWorkoutCount()).workout_count;
-			if (typeof count !== "number" || !Number.isInteger(count) || count < 0)
-				throw new ApiResponseError("The API returned an invalid workout count");
-			return { workout_count: count };
-		}
-		if (sub === "events") {
-			const options = parseWorkoutEventsOptions(args);
-			return {
-				...list(
-					body(await client.getWorkoutEvents(options)),
-					"events",
-					"events",
-					options.page,
-				),
-				since: options.since,
-			};
-		}
-	}
-	if (command === "routines") {
-		if (sub === "list") {
-			const { page, pageSize } = parsePagination(
-				args,
-				getV1RoutinesQueryParamsSchema,
-			);
-			const result = await operations.routines.list.execute({
-				page,
-				pageSize,
-			});
-			if (result.expected404Outcome === "end_of_list") {
-				return pageEnvelope(
-					{ page: result.page, page_count: result.pageCount ?? 0 },
-					"routines",
-					result.items,
-				);
-			}
-			return list(
-				{
-					page: result.page,
-					page_count: result.pageCount,
-					routines: result.items,
-				},
-				"routines",
-				"routines",
-				page,
-			);
-		}
-		if (sub === "get") {
-			const routineId = parseRoutineId(args.positionals[0]);
-			return {
-				routine: await client.getRoutineById(routineId),
-			};
-		}
-		if (sub === "create") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				createRoutineInputSchema,
-				readDataSource,
-			);
-			const { payload, usesRepRanges } = buildRoutinePayload(
-				input.routine,
-				"create",
-			);
-			const response = await client.createRoutine({ routine: payload });
-			return { routine: response, uses_rep_ranges: usesRepRanges };
-		}
-		if (sub === "update") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				updateRoutineInputSchema,
-				readDataSource,
-			);
-			const routineId = parseRoutineId(args.positionals[0]);
-			if (input.routine_id !== routineId)
-				throw new UsageError("Routine ID does not match --data.routine_id");
-			const { payload, usesRepRanges } = buildRoutinePayload(
-				input.routine,
-				"update",
-			);
-			const response = await client.updateRoutine(routineId, {
-				routine: payload,
-			});
-			return {
-				routine_id: routineId,
-				routine: response,
-				uses_rep_ranges: usesRepRanges,
-			};
-		}
-	}
-	if (command === "exercises") {
-		if (sub === "create") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				exerciseTemplateInputSchema,
-				readDataSource,
-			);
-			const response = await client.createExerciseTemplate(input);
-			return { exercise_template: response };
-		}
-		if (sub === "get") {
-			const exerciseId = parseExerciseId(args.positionals[0]);
-			return {
-				exercise_template: await client.getExerciseTemplate(exerciseId),
-			};
-		}
-		if (sub === "history") {
-			const exerciseId = parseExerciseHistoryId(args.positionals[0]);
-			const options = parseExerciseHistoryOptions(args);
-			return {
-				exercise_template_id: exerciseId,
-				exercise_history:
-					(await client.getExerciseHistory(exerciseId, options))
-						.exercise_history ?? [],
-			};
-		}
-		if (sub === "search") {
-			const query = parseSearchQuery(args.positionals[0]);
-			const maxPages = parseSearchMaxPages(args);
-			const matches: unknown[] = [];
-			let pages_scanned = 0;
-			let page_count = 1;
-			while (pages_scanned < page_count && pages_scanned < maxPages) {
-				const requestedPage = pages_scanned + 1;
-				const result = body(
-					await client.getExerciseTemplates({
-						page: requestedPage,
-						pageSize: 100,
-					}),
-				);
-				page_count = result.page_count as number;
-				if (
-					!Number.isInteger(page_count) ||
-					page_count < 0 ||
-					(result.page !== undefined && result.page !== requestedPage) ||
-					(page_count > 0 && page_count < requestedPage)
-				)
-					throw new ApiResponseError(
-						"The API returned invalid pagination metadata",
-					);
-				pages_scanned += 1;
-				if (page_count === 0) break;
-				for (const item of Array.isArray(result.exercise_templates)
-					? result.exercise_templates
-					: [])
-					if (text(body(item).title).toLocaleLowerCase().includes(query))
-						matches.push(item);
-			}
-			return {
-				query,
-				matches,
-				pages_scanned,
-				complete: pages_scanned >= page_count,
-			};
-		}
-	}
-	if (command === "measurements") {
-		if (sub === "list") {
-			const { page, pageSize } = parsePagination(
-				args,
-				getV1BodyMeasurementsQueryParamsSchema,
-			);
-			return list(
-				body(await client.getBodyMeasurements({ page, pageSize })),
-				"body_measurements",
-				"body_measurements",
-				page,
-			);
-		}
-		if (sub === "get") {
-			const date = parseMeasurementDate(args.positionals[0]);
-			return {
-				body_measurement: await client.getBodyMeasurement(date),
-			};
-		}
-		if (sub === "create") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				createBodyMeasurementDataSchema,
-				readDataSource,
-			);
-			const date = parseMeasurementDate(args.positionals[0] ?? input.date);
-			if (input.date !== date)
-				throw new UsageError("Measurement date does not match --data.date");
-			const { date: _date, ...fields } = input;
-			const wireFields = buildMeasurementPayload(fields);
-			await client.createBodyMeasurement({ date, ...wireFields });
-			return { body_measurement: { date, ...wireFields } };
-		}
-		if (sub === "update") {
-			requireMutationConfirmation(args);
-			const input = await loadMutationInput(
-				mutationData(args),
-				updateBodyMeasurementDataSchema,
-				readDataSource,
-			);
-			const date = parseMeasurementDate(args.positionals[0] ?? input.date);
-			if (input.date !== date)
-				throw new UsageError("Measurement date does not match --data.date");
-			const parsed = existingBodyMeasurementSchema.safeParse(
-				await client.getBodyMeasurement(date),
-			);
-			if (!parsed.success || parsed.data.date !== date)
-				throw new ApiResponseError(
-					"The API returned an invalid body measurement",
-				);
-			const { date: _date, ...changes } = input;
-			const { payload, measurement } = mergeMeasurementPayload(
-				parsed.data,
-				changes,
-			);
-			await client.updateBodyMeasurement(date, payload);
-			return { body_measurement: measurement };
-		}
-	}
-	if (command === "folders" && sub === "create") {
-		requireMutationConfirmation(args);
-		const input = await loadMutationInput(
-			mutationData(args),
-			routineFolderInputSchema,
-			readDataSource,
-		);
-		const response = await client.createRoutineFolder(input);
-		return { routine_folder: response };
-	}
-	if (command === "summary") {
-		const weeks = parseWeeks(args);
-		const to = now();
-		const from = new Date(to.getTime() - weeks * 7 * 24 * 60 * 60 * 1000);
-		let pageNumber = 1;
-		let pageCount = 1;
-		let pagesScanned = 0;
-		const workouts: Body[] = [];
-		let stoppedEarly = false;
-		while (pageNumber <= pageCount) {
-			const result = body(
-				await client.getWorkouts({ page: pageNumber, pageSize: 10 }),
-			);
-			pageCount = result.page_count as number;
-			if (
-				!Number.isInteger(pageCount) ||
-				pageCount < 0 ||
-				(result.page !== undefined && result.page !== pageNumber) ||
-				(pageCount > 0 && pageCount < pageNumber)
-			)
-				throw new ApiResponseError(
-					"The API returned invalid pagination metadata",
-				);
-			pagesScanned += 1;
-			if (pageCount === 0) break;
-			const items = Array.isArray(result.workouts)
-				? result.workouts.map(body)
-				: [];
-			for (const workout of items) {
-				const timestamp = Date.parse(text(workout.start_time));
-				if (Number.isNaN(timestamp))
-					throw new ApiResponseError(
-						"The API returned a workout with an invalid timestamp",
-					);
-				if (timestamp >= from.getTime() && timestamp <= to.getTime())
-					workouts.push(workout);
-			}
-			const oldest = items.at(-1)?.start_time;
-			if (oldest && Date.parse(text(oldest)) < from.getTime()) {
-				stoppedEarly = true;
-				break;
-			}
-			pageNumber += 1;
-		}
-		let exerciseCount = 0,
-			setCount = 0,
-			totalVolumeKg = 0,
-			totalDurationSeconds = 0;
-		for (const workout of workouts) {
-			const start = Date.parse(text(workout.start_time));
-			const end = Date.parse(text(workout.end_time));
-			if (!Number.isNaN(start) && !Number.isNaN(end))
-				totalDurationSeconds += Math.max(0, (end - start) / 1000);
-			const exercises = array(workout.exercises);
-			exerciseCount += exercises.length;
-			for (const exercise of exercises)
-				for (const set of array(body(exercise).sets)) {
-					setCount += 1;
-					const item = body(set);
-					if (
-						typeof item.weight_kg === "number" &&
-						typeof item.reps === "number"
-					)
-						totalVolumeKg += item.weight_kg * item.reps;
-				}
-		}
-		return {
-			weeks,
-			start_date: from.toISOString(),
-			end_date: to.toISOString(),
-			workout_count: workouts.length,
-			total_duration_seconds: totalDurationSeconds,
-			exercise_count: exerciseCount,
-			set_count: setCount,
-			total_volume_kg: totalVolumeKg,
-			pages_scanned: pagesScanned,
-			complete:
-				stoppedEarly || pageNumber > pageCount || pagesScanned === pageCount,
-		};
-	}
+	const context: CommandContext = {
+		args,
+		client,
+		now,
+		readDataSource,
+		operations,
+	};
+	if (args.command === "user" && !args.subcommand)
+		return { user: await client.getUserInfo() };
+	if (args.command === "workouts") return executeWorkouts(context);
+	if (args.command === "routines") return executeRoutines(context);
+	if (args.command === "exercises") return executeExercises(context);
+	if (args.command === "measurements") return executeMeasurements(context);
+	if (args.command === "folders" && args.subcommand === "create")
+		return executeFolderCreate(context);
+	if (args.command === "summary") return executeSummary(context);
 	throw new UsageError("Unknown command; run hevy --help");
 }

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -1,6 +1,8 @@
 /* oxlint-disable typescript/unbound-method */
 import type { McpServer } from "@modelcontextprotocol/server";
 import type { HevyClient } from "@hevy-mcp/hevy-client";
+import type { HevyOperations } from "@hevy-mcp/operations";
+import type { ToolExecutionContext } from "../execution.js";
 import { HevyHttpError } from "@hevy-mcp/hevy-client";
 import { describe, expect, it, vi } from "vitest";
 import { getResultTelemetry } from "../utils/result-telemetry.js";
@@ -8,10 +10,19 @@ import { createToolRuntime } from "./tool-runtime.js";
 import { registerToolDefinition } from "./define-tool.js";
 import { routineToolDefinitions } from "./routines.js";
 
-function register(client: HevyClient | null) {
+function register(
+	client: HevyClient | null,
+	operations?: HevyOperations,
+	execution?: ToolExecutionContext,
+) {
 	const tool = vi.fn();
 	const server = { tool, registerTool: tool } as unknown as McpServer;
-	const runtime = createToolRuntime({ client, catalog: {} as never });
+	const runtime = createToolRuntime({
+		client,
+		operations,
+		execution,
+		catalog: {} as never,
+	});
 	for (const definition of routineToolDefinitions)
 		registerToolDefinition(server, runtime, definition);
 	return tool;
@@ -78,6 +89,39 @@ describe("routine tools", () => {
 		await handler(tool, "get-routine")({ routine_id: "r1" });
 		expect(client.getRoutines).toHaveBeenCalledWith({ page: 2, pageSize: 5 });
 		expect(client.getRoutineById).toHaveBeenCalledWith("r1");
+	});
+
+	it("uses the injected routines list operation and execution context", async () => {
+		const execute = vi.fn().mockResolvedValue({
+			items: [{ id: "r1", title: "Push", exercises: [] }],
+			page: 2,
+			pageCount: 3,
+		});
+		const operations = {
+			routines: { list: { execute } },
+		} as unknown as HevyOperations;
+		const execution: ToolExecutionContext = {
+			signal: new AbortController().signal,
+			deadline: Date.now() + 5_000,
+		};
+		const tool = register(null, operations, execution);
+
+		const response = await handler(
+			tool,
+			"get-routines",
+		)({
+			page: 2,
+			page_size: 5,
+		});
+
+		expect(execute).toHaveBeenCalledWith({ page: 2, pageSize: 5 }, execution);
+		expect(response).toMatchObject({
+			structuredContent: {
+				routines: [{ id: "r1", title: "Push" }],
+				page: 2,
+				page_count: 3,
+			},
+		});
 	});
 
 	it("parses a routine whose exercise rest_seconds is an integer", async () => {

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -1,8 +1,8 @@
 import type {
-	GetV1Routines200,
 	GetV1RoutinesRoutineid200,
 	PostV1Routines201,
 	PutV1RoutinesRoutineid200,
+	Routine,
 } from "@hevy-mcp/hevy-client/types";
 import {
 	createRoutineResponse,
@@ -24,20 +24,16 @@ import {
 } from "./input-schemas.js";
 import { buildRoutinePayload } from "./mutation-semantics.js";
 import type { ToolDefinition } from "./define-tool.js";
+import type { ToolRuntime } from "./tool-runtime.js";
 import type { PaginatedToolResult } from "../utils/response-contracts.js";
-import {
-	isExpectedListPageNotFound,
-	isExpectedReadNotFound,
-} from "../utils/hevy-error-policy.js";
+import { isExpectedReadNotFound } from "../utils/hevy-error-policy.js";
 
 const getRoutinesSchema = paginationShape({
 	defaultPageSize: 5,
 	maxPageSize: 10,
 });
 
-type GetRoutinesResult = PaginatedToolResult<
-	NonNullable<GetV1Routines200["routines"]>[number]
->;
+type GetRoutinesResult = PaginatedToolResult<Routine>;
 const getRoutinesDefinition: ToolDefinition<
 	typeof getRoutinesSchema,
 	GetRoutinesResult
@@ -52,20 +48,10 @@ const getRoutinesDefinition: ToolDefinition<
 	outputSchema: routinesResponse.outputSchema,
 	annotations: readOnlyAnnotations("Get Routines"),
 	responseContract: routinesResponse,
-	execute: async (runtime, { page, page_size }) => {
-		try {
-			const data: GetV1Routines200 = await runtime.getClient().getRoutines({
-				page,
-				pageSize: page_size,
-			});
-			return { items: data?.routines ?? [], page, pageCount: data?.page_count };
-		} catch (error) {
-			if (isExpectedListPageNotFound(error, page)) {
-				return { items: [], page, expected404Outcome: "end_of_list" };
-			}
-			throw error;
-		}
-	},
+	execute: async (runtime: ToolRuntime, { page, page_size }) =>
+		runtime
+			.getOperations()
+			.routines.list.execute({ page, pageSize: page_size }, runtime.execution),
 };
 
 const getRoutineSchema = { routine_id: nonEmptyId } as const;

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -48,7 +48,7 @@ const getRoutinesDefinition: ToolDefinition<
 	outputSchema: routinesResponse.outputSchema,
 	annotations: readOnlyAnnotations("Get Routines"),
 	responseContract: routinesResponse,
-	execute: async (runtime: ToolRuntime, { page, page_size }) =>
+	execute: (runtime: ToolRuntime, { page, page_size }) =>
 		runtime
 			.getOperations()
 			.routines.list.execute({ page, pageSize: page_size }, runtime.execution),

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -1,9 +1,23 @@
 import type { HevyClient } from "@hevy-mcp/hevy-client";
 import {
+	createRoutinesListOperation,
+	type RoutinesListOperation,
+} from "./routines.js";
+import {
 	createWorkoutsListOperation,
 	type WorkoutsListOperation,
 } from "./workouts.js";
 
+export {
+	createRoutinesListOperation,
+	isRoutinesListEndOfList,
+	routinesListDescriptor,
+	type RoutinesListAdapter,
+	type RoutinesListDescriptor,
+	type RoutinesListInput,
+	type RoutinesListOperation,
+	type RoutinesListOutput,
+} from "./routines.js";
 export {
 	createWorkoutsListOperation,
 	isWorkoutsListEndOfList,
@@ -16,6 +30,9 @@ export {
 } from "./workouts.js";
 
 export interface HevyOperations {
+	readonly routines: {
+		readonly list: RoutinesListOperation;
+	};
 	readonly workouts: {
 		readonly list: WorkoutsListOperation;
 	};
@@ -23,6 +40,9 @@ export interface HevyOperations {
 
 export function createOperations(client: HevyClient): HevyOperations {
 	return {
+		routines: {
+			list: createRoutinesListOperation(client),
+		},
 		workouts: {
 			list: createWorkoutsListOperation(client),
 		},

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -1,0 +1,148 @@
+import type { HevyClient, HevyExecutionOptions } from "@hevy-mcp/hevy-client";
+import { HevyHttpError } from "@hevy-mcp/hevy-client";
+import type { GetV1Routines200 } from "@hevy-mcp/hevy-client/types";
+import { describe, expect, it } from "vitest";
+import {
+	createRoutinesListOperation,
+	type RoutinesListAdapter,
+} from "./routines.js";
+
+interface InMemoryRoutinesAdapter extends RoutinesListAdapter {
+	readonly requests: Array<{
+		readonly params: Parameters<HevyClient["getRoutines"]>[0];
+		readonly options: Parameters<HevyClient["getRoutines"]>[1];
+	}>;
+}
+
+function createInMemoryAdapter(
+	responses: readonly (GetV1Routines200 | Error)[],
+): InMemoryRoutinesAdapter {
+	let responseIndex = 0;
+	const requests: InMemoryRoutinesAdapter["requests"] = [];
+	return {
+		requests,
+		async getRoutines(params, options) {
+			requests.push({ params, options });
+			const response = responses[responseIndex++] ?? { routines: [] };
+			if (response instanceof Error) throw response;
+			return response;
+		},
+	};
+}
+
+function notFound(endpoint = "/v1/routines") {
+	return new HevyHttpError("not found", {
+		status: 404,
+		method: "GET",
+		endpoint,
+		outcome: "expected",
+	});
+}
+
+describe("routines.list operation", () => {
+	it("describes a read and normalizes the curated client page", async () => {
+		const adapter = createInMemoryAdapter([
+			{
+				page: 2,
+				page_count: 4,
+				routines: [{ id: "r1", title: "Push", exercises: [] }],
+			},
+		]);
+		const operation = createRoutinesListOperation(adapter);
+		const signal = new AbortController().signal;
+		const options: HevyExecutionOptions = {
+			signal,
+			deadline: Date.now() + 5_000,
+		};
+
+		await expect(
+			operation.execute({ page: 2, pageSize: 10 }, options),
+		).resolves.toEqual({
+			items: [{ id: "r1", title: "Push", exercises: [] }],
+			page: 2,
+			pageCount: 4,
+		});
+		expect(operation.descriptor).toEqual({
+			id: "routines.list",
+			safety: "read",
+		});
+		expect(adapter.requests).toEqual([
+			{
+				params: { page: 2, pageSize: 10 },
+				options,
+			},
+		]);
+	});
+
+	it("normalizes a missing routines field to an empty list", async () => {
+		const operation = createRoutinesListOperation(
+			createInMemoryAdapter([{ page: 1, page_count: 1 }]),
+		);
+
+		await expect(operation.execute({ page: 1, pageSize: 5 })).resolves.toEqual({
+			items: [],
+			page: 1,
+			pageCount: 1,
+		});
+	});
+
+	it("treats a later-page 404 as the end of the list", async () => {
+		const operation = createRoutinesListOperation(
+			createInMemoryAdapter([notFound()]),
+		);
+
+		await expect(operation.execute({ page: 3, pageSize: 5 })).resolves.toEqual({
+			items: [],
+			page: 3,
+			pageCount: undefined,
+			expected404Outcome: "end_of_list",
+		});
+	});
+
+	it("does not hide a first-page or unrelated 404", async () => {
+		const firstPageOperation = createRoutinesListOperation(
+			createInMemoryAdapter([notFound()]),
+		);
+		await expect(
+			firstPageOperation.execute({ page: 1, pageSize: 5 }),
+		).rejects.toBeInstanceOf(HevyHttpError);
+
+		const unrelatedOperation = createRoutinesListOperation(
+			createInMemoryAdapter([notFound("/v1/workouts")]),
+		);
+		await expect(
+			unrelatedOperation.execute({ page: 2, pageSize: 5 }),
+		).rejects.toBeInstanceOf(HevyHttpError);
+	});
+
+	it("rejects when response page differs from requested page", async () => {
+		const operation = createRoutinesListOperation(
+			createInMemoryAdapter([
+				{
+					page: 3,
+					page_count: 5,
+					routines: [],
+				},
+			]),
+		);
+
+		await expect(operation.execute({ page: 2, pageSize: 10 })).rejects.toThrow(
+			"Routines page mismatch: requested page 2 but received page 3",
+		);
+	});
+
+	it("propagates mutation errors", async () => {
+		const error = new HevyHttpError("not found", {
+			status: 404,
+			method: "POST",
+			endpoint: "/v1/routines",
+		});
+		const operation = createRoutinesListOperation(
+			createInMemoryAdapter([error]),
+		);
+
+		await expect(operation.execute({ page: 2, pageSize: 5 })).rejects.toBe(
+			error,
+		);
+	});
+});

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -21,11 +21,11 @@ function createInMemoryAdapter(
 	const requests: InMemoryRoutinesAdapter["requests"] = [];
 	return {
 		requests,
-		async getRoutines(params, options) {
+		getRoutines(params, options) {
 			requests.push({ params, options });
 			const response = responses[responseIndex++] ?? { routines: [] };
-			if (response instanceof Error) throw response;
-			return response;
+			if (response instanceof Error) return Promise.reject(response);
+			return Promise.resolve(response);
 		},
 	};
 }

--- a/packages/operations/src/routines.ts
+++ b/packages/operations/src/routines.ts
@@ -1,0 +1,105 @@
+import type {
+	HevyClient,
+	HevyExecutionOptions,
+	HevyHttpError,
+	HevyOperationSafety,
+} from "@hevy-mcp/hevy-client";
+import type { GetV1Routines200, Routine } from "@hevy-mcp/hevy-client/types";
+import {
+	canonicalEndpointIdentity,
+	expectedGet404Outcome,
+	isHevyHttpError,
+} from "@hevy-mcp/hevy-client";
+
+export interface RoutinesListInput {
+	readonly page: number;
+	readonly pageSize: number;
+}
+
+export interface RoutinesListOutput {
+	readonly items: Routine[];
+	readonly page: number;
+	readonly pageCount?: number;
+	readonly expected404Outcome?: "end_of_list";
+}
+
+export type RoutinesListAdapter = Pick<HevyClient, "getRoutines">;
+
+export interface RoutinesListDescriptor {
+	readonly id: "routines.list";
+	readonly safety: Extract<HevyOperationSafety, "read">;
+}
+
+export const routinesListDescriptor: RoutinesListDescriptor = {
+	id: "routines.list",
+	safety: "read",
+};
+
+export interface RoutinesListOperation {
+	readonly descriptor: RoutinesListDescriptor;
+	execute(
+		input: RoutinesListInput,
+		options?: HevyExecutionOptions,
+	): Promise<RoutinesListOutput>;
+}
+
+function isExpectedEndOfList(error: unknown, page: number): boolean {
+	return (
+		page > 1 &&
+		isHevyHttpError(error) &&
+		canonicalEndpointIdentity(error.endpoint) === "/v1/routines" &&
+		expectedGet404Outcome(error.endpoint, error.method, error.status, page) ===
+			"end_of_list"
+	);
+}
+
+function normalizeRoutinesPage(
+	response: GetV1Routines200,
+	input: RoutinesListInput,
+): RoutinesListOutput {
+	if (response.page !== undefined && response.page !== input.page) {
+		throw new Error(
+			`Routines page mismatch: requested page ${input.page} but received page ${response.page}`,
+		);
+	}
+	return {
+		items: response.routines ?? [],
+		page: response.page ?? input.page,
+		pageCount: response.page_count,
+	};
+}
+
+export function createRoutinesListOperation(
+	adapter: RoutinesListAdapter,
+): RoutinesListOperation {
+	return {
+		descriptor: routinesListDescriptor,
+		async execute(input, options) {
+			try {
+				const params = { page: input.page, pageSize: input.pageSize };
+				const response =
+					options === undefined
+						? await adapter.getRoutines(params)
+						: await adapter.getRoutines(params, options);
+				return normalizeRoutinesPage(response, input);
+			} catch (error) {
+				if (isExpectedEndOfList(error, input.page)) {
+					return {
+						items: [],
+						page: input.page,
+						pageCount: undefined,
+						expected404Outcome: "end_of_list",
+					};
+				}
+				throw error;
+			}
+		},
+	};
+}
+
+export function isRoutinesListEndOfList(
+	error: unknown,
+	page: number,
+): error is HevyHttpError {
+	return isExpectedEndOfList(error, page);
+}


### PR DESCRIPTION
## Summary

- Add a typed `routines.list` operation to the runtime-neutral operations kernel.
- Move Core `get-routines` and CLI `routines list` orchestration onto that shared operation.
- Preserve pagination envelopes, execution propagation, page mismatch validation, and later-page end-of-list semantics.
- Add operation/Core/CLI regression coverage and the operations consumer Changeset cascade.

## Stack position

This PR is stacked on the endpoint-policy implementation in [#944](https://github.com/chrisdoc/hevy-mcp/pull/944), which is stacked on architecture review publication [#940](https://github.com/chrisdoc/hevy-mcp/pull/940).

This is the first bounded vertical slice for [#872](https://github.com/chrisdoc/hevy-mcp/issues/872) and intentionally does not migrate routine mutations, search/discovery, or other domains.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run check:boundaries`
- `mise exec -- npm run test:unit` — 858 tests
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Route routine listing through a shared typed operation in the operations layer and update Core and CLI to consume it while preserving existing pagination semantics.

New Features:
- Introduce a typed routines.list operation in the runtime-neutral operations kernel to encapsulate routine listing behavior.

Enhancements:
- Update Core routine tooling to use the shared routines.list operation instead of calling the Hevy client directly.
- Update CLI routines list command to consume the shared routines.list operation while preserving page envelopes and end-of-list handling.

Tests:
- Add unit tests for the routines.list operation covering pagination normalization, 404 end-of-list detection, page mismatch handling, and error propagation.
- Extend Core tool and CLI command tests to verify integration with the injected routines.list operation and execution context.

Chores:
- Add a Changeset entry for the new routines list operation and its adoption across operations, Core, worker, CLI, and the root package.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Move the routines listing logic into a shared operation to standardize data access across the CLI and Core packages.

Main changes:
- Implemented RoutinesListOperation in @hevy-mcp/operations with page normalization and 404 handling
- Refactored get-routines tool in Core to utilize the shared RoutinesListOperation
- Updated CLI commands to route routine listing through the shared operation layer

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
