### PR TITLE
refactor(node): centralize process lifecycle

### DIFF
--- a/.changeset/bright-node-lifecycle.md
+++ b/.changeset/bright-node-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Share the private Node process lifecycle owner across stdio and HTTP startup paths.

--- a/packages/node/src/runtime.ts
+++ b/packages/node/src/runtime.ts
@@ -1,28 +1,14 @@
 // Telemetry must be initialized before any other imports so that
 // OpenTelemetry and Sentry are ready before application code runs.
-import {
-	captureFailure,
-	flushTelemetry,
-	installProcessExceptionTracking,
-	tracer,
-	serviceName,
-	serviceVersion,
-} from "./utils/telemetry.js";
+import { tracer, serviceName, serviceVersion } from "./utils/telemetry.js";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { serverStartups } from "./utils/metrics.js";
-
-import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { SpanStatusCode } from "@opentelemetry/api";
 import { z } from "zod";
 import { createHevyMcpServer, mergeAbortSignals } from "@hevy-mcp/core";
 import { createHevyClient, isHevyHttpError } from "@hevy-mcp/hevy-client";
-import {
-	assertApiKey,
-	MissingHevyApiKeyError,
-	parseConfig,
-} from "./utils/config.js";
+import { assertApiKey, parseConfig } from "./utils/config.js";
 import { parseNodeCliOptions, type NodeTransport } from "./utils/arguments.js";
 import { startStreamableHttpServer } from "./utils/streamable-http.js";
-import { installGracefulShutdown } from "./utils/graceful-shutdown.js";
 import {
 	createNodeCacheObserver,
 	createNodeHevyClientOptions,
@@ -34,7 +20,11 @@ import {
 	resolveSessionTerminationCategory,
 } from "./utils/mcp-session-observability.js";
 import { installSdkErrorTracking } from "./utils/sdk-observability.js";
-import { scheduleUpdateCheck } from "./utils/version-check.js";
+import {
+	INVALID_API_KEY_MESSAGE,
+	recordLifecycleFailure,
+	runNodeLifecycle,
+} from "./utils/node-lifecycle.js";
 
 const name = serviceName;
 const version = serviceVersion;
@@ -79,8 +69,6 @@ function getCliAction(args: string[]): "start" | "version" | "help" {
 const HEVY_API_BASEURL = "https://api.hevyapp.com";
 const STARTUP_PROBE_TIMEOUT_MS = 5_000;
 
-const INVALID_API_KEY_MESSAGE =
-	"HEVY_API_KEY is invalid or expired. Please check your API key in the Hevy app under Settings > API Key.";
 const API_KEY_VALIDATION_WARNING =
 	"Warning: HEVY_API_KEY could not be validated during startup. Startup will continue; check your network connection and Hevy API availability.";
 const SAFE_NETWORK_ERROR_CODES = new Set([
@@ -138,79 +126,6 @@ function getSafeValidationDiagnostic(error: unknown): string | undefined {
 	return typeof code === "string" && SAFE_NETWORK_ERROR_CODES.has(code)
 		? code
 		: undefined;
-}
-type LifecycleFailurePhase =
-	| "config"
-	| "api_key_validation"
-	| "build"
-	| "connect"
-	| "run";
-
-const LIFECYCLE_FAILURE_TAXONOMY: Record<
-	LifecycleFailurePhase,
-	{ errorType: string; errorCategory: string }
-> = {
-	config: {
-		errorType: "MCP_SERVER_CONFIG_ERROR",
-		errorCategory: "McpServerConfigFailure",
-	},
-	api_key_validation: {
-		errorType: "MCP_API_KEY_VALIDATION_ERROR",
-		errorCategory: "McpApiKeyValidationFailure",
-	},
-	build: {
-		errorType: "MCP_SERVER_BUILD_ERROR",
-		errorCategory: "McpServerBuildFailure",
-	},
-	connect: {
-		errorType: "MCP_TRANSPORT_CONNECT_ERROR",
-		errorCategory: "McpTransportConnectFailure",
-	},
-	run: {
-		errorType: "MCP_SERVER_RUN_ERROR",
-		errorCategory: "McpServerRunFailure",
-	},
-};
-
-type LifecycleTerminationReason =
-	| "connect_failure"
-	| "runtime_failure"
-	| "startup_failure";
-
-function isExpectedLifecycleFailure(error: unknown): boolean {
-	return (
-		error instanceof MissingHevyApiKeyError ||
-		(error instanceof Error && error.message === INVALID_API_KEY_MESSAGE)
-	);
-}
-
-function createLifecycleFailureAttributes(
-	phase: LifecycleFailurePhase,
-	terminationReason: LifecycleTerminationReason,
-): Record<string, string | number | boolean> {
-	const taxonomy = LIFECYCLE_FAILURE_TAXONOMY[phase];
-	return {
-		"mcp.failure.phase": phase,
-		"mcp.termination.reason": terminationReason,
-		"error.type": taxonomy.errorType,
-		"error.category": taxonomy.errorCategory,
-	};
-}
-
-function recordLifecycleFailure(
-	span: Span,
-	error: unknown,
-	phase: LifecycleFailurePhase,
-	terminationReason: LifecycleTerminationReason,
-): void {
-	const attributes = createLifecycleFailureAttributes(phase, terminationReason);
-	span.addEvent("mcp.lifecycle.failure", attributes);
-	captureFailure(error, {
-		kind: "lifecycle",
-		attributes,
-		...(isExpectedLifecycleFailure(error) ? { expected: true } : {}),
-		span,
-	});
 }
 async function validateApiKey(apiKey: string, signal?: AbortSignal) {
 	// Keep the startup probe separate from the normal MCP-aware client. The
@@ -308,107 +223,65 @@ export async function runStdioServer() {
 		console.error(`${name} v${version}`);
 		return;
 	}
-
 	if (cliAction === "help") {
 		console.log(HELP_TEXT);
 		return;
 	}
-	const cleanupProcessExceptionTracking = installProcessExceptionTracking();
-	const lifecycleController = new AbortController();
 
-	serverStartups.add(1, { version });
-
-	let connectAttempted = false;
-	let connectSucceeded = false;
-	await tracer.startActiveSpan(
-		"mcp.server.run",
-		{
-			attributes: {
-				"mcp.span.category": "startup",
-				"mcp.transport": "stdio",
-			},
-		},
-		async (span) => {
-			try {
-				const cfg = parseConfig(process.env);
-				const apiKey = cfg.apiKey;
-				assertApiKey(apiKey);
-
-				const server = await createNodeMcpServer(
-					{ apiKey },
-					"stdio",
-					lifecycleController.signal,
-				);
-				console.error("Starting MCP server in stdio mode");
-				const transport = createInstrumentedStdioTransport(
-					new StdioServerTransport(),
-				);
-				connectAttempted = true;
-
-				await tracer.startActiveSpan(
-					"mcp.server.connect",
-					{
-						attributes: {
-							"mcp.span.category": "session",
-							"mcp.transport": "stdio",
-						},
+	await runNodeLifecycle({
+		transport: "stdio",
+		start: async (context) => {
+			const { signal } = context;
+			const cfg = parseConfig(process.env);
+			const apiKey = cfg.apiKey;
+			assertApiKey(apiKey);
+			const server = await createNodeMcpServer({ apiKey }, "stdio", signal);
+			console.error("Starting MCP server in stdio mode");
+			const transport = createInstrumentedStdioTransport(
+				new StdioServerTransport(),
+			);
+			context.markConnectAttempted();
+			await tracer.startActiveSpan(
+				"mcp.server.connect",
+				{
+					attributes: {
+						"mcp.span.category": "session",
+						"mcp.transport": "stdio",
 					},
-					async (connectSpan) => {
-						try {
-							await server.connect(transport);
-							connectSucceeded = true;
-							connectSpan.setStatus({ code: SpanStatusCode.OK });
-						} catch (e) {
-							recordLifecycleFailure(
-								connectSpan,
-								e,
-								"connect",
-								"connect_failure",
-							);
-							connectSpan.setStatus({ code: SpanStatusCode.ERROR });
-							throw e;
-						} finally {
-							connectSpan.end();
-						}
-					},
-				);
-				scheduleUpdateCheck({
-					packageName: serviceName,
-					currentVersion: serviceVersion,
-				});
-				installGracefulShutdown({
-					target: server,
-					cancel: lifecycleController,
-					onComplete: async (succeeded) => {
-						recordMcpSessionTermination(
-							resolveSessionTerminationCategory(succeeded),
+				},
+				async (connectSpan) => {
+					try {
+						await server.connect(transport);
+						context.markConnectSucceeded();
+						connectSpan.setStatus({ code: SpanStatusCode.OK });
+					} catch (error) {
+						recordLifecycleFailure(
+							connectSpan,
+							error,
+							"connect",
+							"connect_failure",
 						);
-						cleanupProcessExceptionTracking();
-						await flushTelemetry();
-					},
-				});
-
-				span.setStatus({ code: SpanStatusCode.OK });
-			} catch (e) {
-				if (!connectAttempted || connectSucceeded) {
-					recordLifecycleFailure(
-						span,
-						e,
-						"run",
-						connectSucceeded ? "runtime_failure" : "startup_failure",
-					);
-				}
-				recordMcpSessionTermination(
-					connectAttempted ? "connect_failure" : "startup_failure",
-				);
-				span.setStatus({ code: SpanStatusCode.ERROR });
-				cleanupProcessExceptionTracking();
-				throw e;
-			} finally {
-				span.end();
+						connectSpan.setStatus({ code: SpanStatusCode.ERROR });
+						throw error;
+					} finally {
+						connectSpan.end();
+					}
+				},
+			);
+			return {
+				target: server,
+				onShutdown: (succeeded) =>
+					recordMcpSessionTermination(
+						resolveSessionTerminationCategory(succeeded),
+					),
+			};
+		},
+		onFailure: (reason, outcome) => {
+			if (outcome.transport === "stdio") {
+				recordMcpSessionTermination(reason);
 			}
 		},
-	);
+	});
 }
 
 export async function runServer(): Promise<void> {
@@ -428,70 +301,38 @@ export async function runServer(): Promise<void> {
 		await runStdioServer();
 		return;
 	}
-	const cleanupProcessExceptionTracking = installProcessExceptionTracking();
-	const lifecycleController = new AbortController();
 
-	await tracer.startActiveSpan(
-		"mcp.server.run",
-		{
-			attributes: {
-				"mcp.span.category": "startup",
-				"mcp.transport": "http",
-			},
-		},
-		async (span) => {
-			let listening = false;
-			serverStartups.add(1, { version });
-			try {
-				const cfg = parseConfig(process.env);
-				assertApiKey(cfg.apiKey);
-				await validateApiKey(cfg.apiKey, lifecycleController.signal);
-				const handle = await startStreamableHttpServer(
-					options,
-					cfg.apiKey,
-					(params) =>
-						Promise.resolve(
-							buildServer(
-								params.apiKey,
-								"http",
-								mergeAbortSignals(
-									lifecycleController.signal,
-									params.lifecycleSignal,
-								),
-							),
+	await runNodeLifecycle({
+		transport: "http",
+		start: async (context) => {
+			const { signal } = context;
+			const cfg = parseConfig(process.env);
+			assertApiKey(cfg.apiKey);
+			await validateApiKey(cfg.apiKey, signal);
+			const handle = await startStreamableHttpServer(
+				options,
+				cfg.apiKey,
+				(params) =>
+					Promise.resolve(
+						buildServer(
+							params.apiKey,
+							"http",
+							mergeAbortSignals(signal, params.lifecycleSignal),
 						),
+					),
+			);
+			context.markListening();
+			console.error(
+				`Starting MCP server in HTTP mode at ${options.host}:${options.port}/mcp`,
+			);
+			return { target: handle };
+		},
+		onFailure: (_reason, outcome) => {
+			if (outcome.transport === "http") {
+				recordMcpSessionTermination(
+					outcome.listening ? "unknown" : "startup_failure",
 				);
-				listening = true;
-				console.error(
-					`Starting MCP server in HTTP mode at ${options.host}:${options.port}/mcp`,
-				);
-				scheduleUpdateCheck({
-					packageName: serviceName,
-					currentVersion: serviceVersion,
-				});
-				installGracefulShutdown({
-					target: handle,
-					cancel: lifecycleController,
-					onComplete: async () => {
-						cleanupProcessExceptionTracking();
-						await flushTelemetry();
-					},
-				});
-				span.setStatus({ code: SpanStatusCode.OK });
-			} catch (error) {
-				recordLifecycleFailure(
-					span,
-					error,
-					"run",
-					listening ? "runtime_failure" : "startup_failure",
-				);
-				recordMcpSessionTermination(listening ? "unknown" : "startup_failure");
-				span.setStatus({ code: SpanStatusCode.ERROR });
-				cleanupProcessExceptionTracking();
-				throw error;
-			} finally {
-				span.end();
 			}
 		},
-	);
+	});
 }

--- a/packages/node/src/utils/node-lifecycle.test.ts
+++ b/packages/node/src/utils/node-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const doubles = vi.hoisted(() => ({
 	cleanup: vi.fn(),
-	flush: vi.fn().mockResolvedValue(undefined),
+	flush: vi.fn().mockImplementation(() => Promise.resolve()),
 	capture: vi.fn(),
 	startup: { add: vi.fn() },
 	schedule: vi.fn(),
@@ -41,20 +41,22 @@ vi.mock("./graceful-shutdown.js", () => ({
 
 import { runNodeLifecycle } from "./node-lifecycle.js";
 
-const target = { close: vi.fn().mockResolvedValue(undefined) };
+const target = {
+	close: vi.fn().mockImplementation(() => Promise.resolve()),
+};
 
 afterEach(() => {
 	vi.clearAllMocks();
-	target.close.mockResolvedValue(undefined);
+	target.close.mockImplementation(() => Promise.resolve());
 });
 
 describe("Node lifecycle runner", () => {
 	it("starts, schedules updates, and installs shutdown ownership", async () => {
 		await runNodeLifecycle({
 			transport: "http",
-			start: async (context) => {
+			start: (context) => {
 				context.markListening();
-				return { target };
+				return Promise.resolve({ target });
 			},
 		});
 
@@ -77,9 +79,7 @@ describe("Node lifecycle runner", () => {
 		await expect(
 			runNodeLifecycle({
 				transport: "http",
-				start: async () => {
-					throw error;
-				},
+				start: () => Promise.reject(error),
 				onFailure,
 			}),
 		).rejects.toBe(error);
@@ -101,9 +101,9 @@ describe("Node lifecycle runner", () => {
 		await expect(
 			runNodeLifecycle({
 				transport: "http",
-				start: async (context) => {
+				start: (context) => {
 					context.markListening();
-					throw new Error("runtime failure");
+					return Promise.reject(new Error("runtime failure"));
 				},
 				onFailure,
 			}),
@@ -122,9 +122,9 @@ describe("Node lifecycle runner", () => {
 		await expect(
 			runNodeLifecycle({
 				transport: "stdio",
-				start: async (context) => {
+				start: (context) => {
 					context.markConnectAttempted();
-					throw new Error("connect failure");
+					return Promise.reject(new Error("connect failure"));
 				},
 				onFailure,
 			}),
@@ -144,10 +144,10 @@ describe("Node lifecycle runner", () => {
 		let sessionSignal: AbortSignal | undefined;
 		await runNodeLifecycle({
 			transport: "http",
-			start: async ({ signal }) => {
+			start: ({ signal }) => {
 				processSignal = signal;
 				sessionSignal = sessionController.signal;
-				return { target };
+				return Promise.resolve({ target });
 			},
 		});
 
@@ -163,14 +163,14 @@ describe("Node lifecycle runner", () => {
 	it("flushes telemetry and cleans process tracking on shutdown", async () => {
 		await runNodeLifecycle({
 			transport: "stdio",
-			start: async (context) => {
+			start: (context) => {
 				context.markConnectAttempted();
 				context.markConnectSucceeded();
-				return {
+				return Promise.resolve({
 					target,
 					onShutdown: (succeeded) =>
 						doubles.termination(succeeded ? "clean" : "shutdown_failure"),
-				};
+				});
 			},
 		});
 

--- a/packages/node/src/utils/node-lifecycle.test.ts
+++ b/packages/node/src/utils/node-lifecycle.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const doubles = vi.hoisted(() => ({
+	cleanup: vi.fn(),
+	flush: vi.fn().mockResolvedValue(undefined),
+	capture: vi.fn(),
+	startup: { add: vi.fn() },
+	schedule: vi.fn(),
+	shutdown: vi.fn(),
+	termination: vi.fn(),
+	span: {
+		addEvent: vi.fn(),
+		setStatus: vi.fn(),
+		end: vi.fn(),
+	},
+}));
+
+vi.mock("./telemetry.js", () => ({
+	captureFailure: doubles.capture,
+	flushTelemetry: doubles.flush,
+	installProcessExceptionTracking: vi.fn(() => doubles.cleanup),
+	serviceName: "hevy-mcp",
+	serviceVersion: "test-version",
+	tracer: {
+		startActiveSpan: vi.fn(
+			(
+				_name: string,
+				_options: unknown,
+				callback: (span: typeof doubles.span) => unknown,
+			) => callback(doubles.span),
+		),
+	},
+}));
+vi.mock("./metrics.js", () => ({ serverStartups: doubles.startup }));
+vi.mock("./version-check.js", () => ({
+	scheduleUpdateCheck: doubles.schedule,
+}));
+vi.mock("./graceful-shutdown.js", () => ({
+	installGracefulShutdown: doubles.shutdown,
+}));
+
+import { runNodeLifecycle } from "./node-lifecycle.js";
+
+const target = { close: vi.fn().mockResolvedValue(undefined) };
+
+afterEach(() => {
+	vi.clearAllMocks();
+	target.close.mockResolvedValue(undefined);
+});
+
+describe("Node lifecycle runner", () => {
+	it("starts, schedules updates, and installs shutdown ownership", async () => {
+		await runNodeLifecycle({
+			transport: "http",
+			start: async (context) => {
+				context.markListening();
+				return { target };
+			},
+		});
+
+		expect(doubles.startup.add).toHaveBeenCalledWith(1, {
+			version: "test-version",
+		});
+		expect(doubles.schedule).toHaveBeenCalledWith({
+			packageName: "hevy-mcp",
+			currentVersion: "test-version",
+		});
+		expect(doubles.shutdown).toHaveBeenCalledWith(
+			expect.objectContaining({ target }),
+		);
+	});
+
+	it("classifies startup failures without a listening state", async () => {
+		const error = new Error("startup failure");
+		const onFailure = vi.fn();
+
+		await expect(
+			runNodeLifecycle({
+				transport: "http",
+				start: async () => {
+					throw error;
+				},
+				onFailure,
+			}),
+		).rejects.toBe(error);
+
+		expect(onFailure).toHaveBeenCalledWith("startup_failure", {
+			transport: "http",
+			listening: false,
+		});
+		expect(doubles.capture).toHaveBeenCalledWith(
+			error,
+			expect.objectContaining({ kind: "lifecycle" }),
+		);
+		expect(doubles.cleanup).toHaveBeenCalledOnce();
+	});
+
+	it("classifies a runtime failure after HTTP listening", async () => {
+		const onFailure = vi.fn();
+
+		await expect(
+			runNodeLifecycle({
+				transport: "http",
+				start: async (context) => {
+					context.markListening();
+					throw new Error("runtime failure");
+				},
+				onFailure,
+			}),
+		).rejects.toThrow("runtime failure");
+
+		expect(onFailure).toHaveBeenCalledWith("runtime_failure", {
+			transport: "http",
+			listening: true,
+		});
+		expect(doubles.termination).not.toHaveBeenCalled();
+	});
+
+	it("keeps stdio connect failures distinct from startup failures", async () => {
+		const onFailure = vi.fn();
+
+		await expect(
+			runNodeLifecycle({
+				transport: "stdio",
+				start: async (context) => {
+					context.markConnectAttempted();
+					throw new Error("connect failure");
+				},
+				onFailure,
+			}),
+		).rejects.toThrow("connect failure");
+
+		expect(onFailure).toHaveBeenCalledWith("connect_failure", {
+			transport: "stdio",
+			connectAttempted: true,
+			connectSucceeded: false,
+		});
+		expect(doubles.termination).not.toHaveBeenCalled();
+	});
+
+	it("keeps an HTTP session controller independent from process shutdown", async () => {
+		const sessionController = new AbortController();
+		let processSignal: AbortSignal | undefined;
+		let sessionSignal: AbortSignal | undefined;
+		await runNodeLifecycle({
+			transport: "http",
+			start: async ({ signal }) => {
+				processSignal = signal;
+				sessionSignal = sessionController.signal;
+				return { target };
+			},
+		});
+
+		const options = doubles.shutdown.mock.calls[0]?.[0] as {
+			cancel: AbortController;
+		};
+		options.cancel.abort();
+		expect(processSignal).not.toBe(sessionSignal);
+		expect(processSignal?.aborted).toBe(true);
+		expect(sessionSignal?.aborted).toBe(false);
+	});
+
+	it("flushes telemetry and cleans process tracking on shutdown", async () => {
+		await runNodeLifecycle({
+			transport: "stdio",
+			start: async (context) => {
+				context.markConnectAttempted();
+				context.markConnectSucceeded();
+				return {
+					target,
+					onShutdown: (succeeded) =>
+						doubles.termination(succeeded ? "clean" : "shutdown_failure"),
+				};
+			},
+		});
+
+		const options = doubles.shutdown.mock.calls[0]?.[0] as {
+			onComplete: (succeeded: boolean) => Promise<void>;
+		};
+		await options.onComplete(true);
+
+		expect(doubles.termination).toHaveBeenCalledWith("clean");
+		expect(doubles.cleanup).toHaveBeenCalledOnce();
+		expect(doubles.flush).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/node/src/utils/node-lifecycle.ts
+++ b/packages/node/src/utils/node-lifecycle.ts
@@ -118,15 +118,13 @@ export interface NodeLifecycleStartupResult {
 
 export interface RunNodeLifecycleOptions {
 	transport: NodeLifecycleTransport;
-	start(
-		this: void,
+	readonly start: (
 		context: NodeLifecycleContext,
-	): Promise<NodeLifecycleStartupResult>;
-	onFailure?(
-		this: void,
+	) => Promise<NodeLifecycleStartupResult>;
+	readonly onFailure?: (
 		reason: LifecycleTerminationReason,
 		outcome: NodeLifecycleOutcome,
-	): void;
+	) => void;
 }
 
 function createOutcomeState(transport: NodeLifecycleTransport) {

--- a/packages/node/src/utils/node-lifecycle.ts
+++ b/packages/node/src/utils/node-lifecycle.ts
@@ -1,0 +1,229 @@
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import {
+	serviceName,
+	serviceVersion,
+	tracer,
+	captureFailure,
+	flushTelemetry,
+	installProcessExceptionTracking,
+} from "./telemetry.js";
+import { serverStartups } from "./metrics.js";
+import { installGracefulShutdown } from "./graceful-shutdown.js";
+import { scheduleUpdateCheck } from "./version-check.js";
+import { MissingHevyApiKeyError } from "./config.js";
+export const INVALID_API_KEY_MESSAGE =
+	"HEVY_API_KEY is invalid or expired. Please check your API key in the Hevy app under Settings > API Key.";
+
+type LifecycleFailurePhase =
+	| "config"
+	| "api_key_validation"
+	| "build"
+	| "connect"
+	| "run";
+
+type LifecycleTerminationReason =
+	| "connect_failure"
+	| "runtime_failure"
+	| "startup_failure";
+
+const LIFECYCLE_FAILURE_TAXONOMY: Record<
+	LifecycleFailurePhase,
+	{ errorType: string; errorCategory: string }
+> = {
+	config: {
+		errorType: "MCP_SERVER_CONFIG_ERROR",
+		errorCategory: "McpServerConfigFailure",
+	},
+	api_key_validation: {
+		errorType: "MCP_API_KEY_VALIDATION_ERROR",
+		errorCategory: "McpApiKeyValidationFailure",
+	},
+	build: {
+		errorType: "MCP_SERVER_BUILD_ERROR",
+		errorCategory: "McpServerBuildFailure",
+	},
+	connect: {
+		errorType: "MCP_TRANSPORT_CONNECT_ERROR",
+		errorCategory: "McpTransportConnectFailure",
+	},
+	run: {
+		errorType: "MCP_SERVER_RUN_ERROR",
+		errorCategory: "McpServerRunFailure",
+	},
+};
+
+function isExpectedLifecycleFailure(error: unknown): boolean {
+	return (
+		error instanceof MissingHevyApiKeyError ||
+		(error instanceof Error && error.message === INVALID_API_KEY_MESSAGE)
+	);
+}
+
+function createLifecycleFailureAttributes(
+	phase: LifecycleFailurePhase,
+	terminationReason: LifecycleTerminationReason,
+): Record<string, string | number | boolean> {
+	const taxonomy = LIFECYCLE_FAILURE_TAXONOMY[phase];
+	return {
+		"mcp.failure.phase": phase,
+		"mcp.termination.reason": terminationReason,
+		"error.type": taxonomy.errorType,
+		"error.category": taxonomy.errorCategory,
+	};
+}
+
+export function recordLifecycleFailure(
+	span: Span,
+	error: unknown,
+	phase: LifecycleFailurePhase,
+	terminationReason: LifecycleTerminationReason,
+): void {
+	const attributes = createLifecycleFailureAttributes(phase, terminationReason);
+	span.addEvent("mcp.lifecycle.failure", attributes);
+	captureFailure(error, {
+		kind: "lifecycle",
+		attributes,
+		...(isExpectedLifecycleFailure(error) ? { expected: true } : {}),
+		span,
+	});
+}
+
+export type NodeLifecycleTransport = "stdio" | "http";
+
+export interface NodeLifecycleContext {
+	readonly signal: AbortSignal;
+	/** Mark the beginning of a stdio transport connection attempt. */
+	markConnectAttempted(): void;
+	/** Mark a successful stdio transport connection. */
+	markConnectSucceeded(): void;
+	/** Mark the HTTP listener as successfully started. */
+	markListening(): void;
+}
+
+export type NodeLifecycleOutcome =
+	| {
+			transport: "stdio";
+			connectAttempted: boolean;
+			connectSucceeded: boolean;
+	  }
+	| {
+			transport: "http";
+			listening: boolean;
+	  };
+
+export interface NodeLifecycleStartupResult {
+	target: { close(): Promise<void> };
+	onShutdown?: (succeeded: boolean) => void | Promise<void>;
+}
+
+export interface RunNodeLifecycleOptions {
+	transport: NodeLifecycleTransport;
+	start(
+		this: void,
+		context: NodeLifecycleContext,
+	): Promise<NodeLifecycleStartupResult>;
+	onFailure?(
+		this: void,
+		reason: LifecycleTerminationReason,
+		outcome: NodeLifecycleOutcome,
+	): void;
+}
+
+function createOutcomeState(transport: NodeLifecycleTransport) {
+	let connectAttempted = false;
+	let connectSucceeded = false;
+	let listening = false;
+	return {
+		markConnectAttempted: () => {
+			connectAttempted = true;
+		},
+		markConnectSucceeded: () => {
+			connectSucceeded = true;
+		},
+		markListening: () => {
+			listening = true;
+		},
+		getOutcome: (): NodeLifecycleOutcome =>
+			transport === "stdio"
+				? { transport, connectAttempted, connectSucceeded }
+				: { transport, listening },
+	};
+}
+
+function classifyFailure(
+	outcome: NodeLifecycleOutcome,
+): LifecycleTerminationReason {
+	if (outcome.transport === "stdio") {
+		if (outcome.connectAttempted && !outcome.connectSucceeded) {
+			return "connect_failure";
+		}
+		return outcome.connectSucceeded ? "runtime_failure" : "startup_failure";
+	}
+	return outcome.listening ? "runtime_failure" : "startup_failure";
+}
+
+/** Owns process-wide Node lifecycle concerns while leaving transport state local. */
+export async function runNodeLifecycle({
+	transport,
+	start,
+	onFailure,
+}: RunNodeLifecycleOptions): Promise<void> {
+	const cleanupProcessExceptionTracking = installProcessExceptionTracking();
+	const lifecycleController = new AbortController();
+	const state = createOutcomeState(transport);
+	const context: NodeLifecycleContext = {
+		signal: lifecycleController.signal,
+		markConnectAttempted: () => state.markConnectAttempted(),
+		markConnectSucceeded: () => state.markConnectSucceeded(),
+		markListening: () => state.markListening(),
+	};
+
+	serverStartups.add(1, { version: serviceVersion });
+	await tracer.startActiveSpan(
+		"mcp.server.run",
+		{
+			attributes: {
+				"mcp.span.category": "startup",
+				"mcp.transport": transport,
+			},
+		},
+		async (span) => {
+			try {
+				const result = await start(context);
+				scheduleUpdateCheck({
+					packageName: serviceName,
+					currentVersion: serviceVersion,
+				});
+				installGracefulShutdown({
+					target: result.target,
+					cancel: lifecycleController,
+					onComplete: async (succeeded) => {
+						try {
+							await result.onShutdown?.(succeeded);
+						} finally {
+							cleanupProcessExceptionTracking();
+							await flushTelemetry();
+						}
+					},
+				});
+				span.setStatus({ code: SpanStatusCode.OK });
+			} catch (error) {
+				const outcome = state.getOutcome();
+				const reason = classifyFailure(outcome);
+				// A failed stdio connect already has its own connect span. Preserve
+				// that taxonomy and only record the common run failure otherwise.
+				if (!(outcome.transport === "stdio" && reason === "connect_failure")) {
+					recordLifecycleFailure(span, error, "run", reason);
+				}
+				onFailure?.(reason, outcome);
+				span.setStatus({ code: SpanStatusCode.ERROR });
+				cleanupProcessExceptionTracking();
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
+}
+
+export type { LifecycleFailurePhase, LifecycleTerminationReason };


### PR DESCRIPTION
## Summary

- Add a private Node lifecycle runner for process-level startup, shutdown, telemetry, and failure handling.
- Refactor stdio and HTTP startup paths to share that envelope while retaining transport-specific state and cleanup.
- Preserve explicit stdio connect outcomes, HTTP listener/session isolation, API validation, update timing, and shutdown behavior.
- Add lifecycle regression tests and a Node-only Changeset.

## Stack position

This PR is stacked on [#947](https://github.com/chrisdoc/hevy-mcp/pull/947), continuing the stack from [#946](https://github.com/chrisdoc/hevy-mcp/pull/946), [#944](https://github.com/chrisdoc/hevy-mcp/pull/944), and [#940](https://github.com/chrisdoc/hevy-mcp/pull/940).

This is the bounded process-lifecycle slice of issue [#878](https://github.com/chrisdoc/hevy-mcp/issues/878). Session capacity/expiry and other admission settings remain separate follow-ups.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run check:boundaries`
- `mise exec -- npm run test:pr` — 866 unit tests
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Centralize Node process lifecycle management into a shared utility used by both stdio and HTTP servers, aligning startup, shutdown, telemetry, and failure handling while preserving transport-specific behavior.

New Features:
- Introduce a Node lifecycle runner utility that encapsulates process-level startup, shutdown, telemetry, and failure classification for Node transports.

Enhancements:
- Refactor stdio and HTTP server entrypoints to delegate lifecycle concerns to the shared Node lifecycle runner while keeping transport-specific state and outcomes distinct.

Documentation:
- Add a Node-only changeset documenting the shared process lifecycle behavior.

Tests:
- Add unit tests covering Node lifecycle runner behavior, including failure classification, shutdown ownership, and telemetry cleanup.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Centralize process lifecycle management by extracting shared startup/shutdown logic into a reusable `runNodeLifecycle` function for both stdio and HTTP transports.

Main changes:
- Extract lifecycle ownership (telemetry, graceful shutdown, exception tracking) into new `node-lifecycle.ts` module with transport-agnostic API
- Refactor `runStdioServer` and `runServer` to use `runNodeLifecycle` callback pattern, eliminating duplicated span and error handling logic
- Add comprehensive lifecycle state tracking and failure classification with outcome-aware telemetry and callback hooks

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
