### PR TITLE
feat(worker): add safe tool observation

### DIFF
--- a/.changeset/worker-semantic-observation.md
+++ b/.changeset/worker-semantic-observation.md
@@ -1,0 +1,5 @@
+---
+"@hevy-mcp/worker": patch
+---
+
+Add privacy-safe semantic tool observation events to the stateless Worker adapter.

--- a/packages/worker/src/worker-observer.test.ts
+++ b/packages/worker/src/worker-observer.test.ts
@@ -30,6 +30,13 @@ function createScope(events: WorkerObservationEvent[]) {
 	return scope;
 }
 
+function finish(
+	scope: ReturnType<typeof createScope>,
+	completion: SafeToolCompletion,
+): void {
+	Promise.resolve(scope.finish(completion)).catch(() => undefined);
+}
+
 describe("createWorkerToolObserver", () => {
 	it("emits safe bounded invocation and successful completion events", async () => {
 		const events: WorkerObservationEvent[] = [];
@@ -38,7 +45,7 @@ describe("createWorkerToolObserver", () => {
 		await expect(
 			scope.run(() => Promise.resolve("raw response body")),
 		).resolves.toBe("raw response body");
-		void scope.finish({
+		finish(scope, {
 			outcome: "success",
 			durationMs: 12,
 			result: {
@@ -115,7 +122,7 @@ describe("createWorkerToolObserver", () => {
 						},
 					}),
 		};
-		void scope.finish(completion);
+		finish(scope, completion);
 
 		const event = events[1];
 		expect(event).toMatchObject({ event: "worker.tool.completion", outcome });
@@ -138,7 +145,7 @@ describe("createWorkerToolObserver", () => {
 	it("drops malformed diagnostic fields at the Worker boundary", () => {
 		const events: WorkerObservationEvent[] = [];
 		const scope = createScope(events);
-		void scope.finish({
+		finish(scope, {
 			outcome: "thrown_error",
 			durationMs: 1,
 			error: {
@@ -190,7 +197,7 @@ describe("createWorkerToolObserver", () => {
 	it("uses the explicit execution projection for returned errors", () => {
 		const events: WorkerObservationEvent[] = [];
 		const scope = createScope(events);
-		void scope.finish({
+		finish(scope, {
 			outcome: "returned_error",
 			durationMs: 1,
 			result: {
@@ -217,8 +224,8 @@ describe("createWorkerToolObserver", () => {
 	it("finishes at most once", () => {
 		const events: WorkerObservationEvent[] = [];
 		const scope = createScope(events);
-		void scope.finish({ outcome: "success", durationMs: 1 });
-		void scope.finish({ outcome: "thrown_error", durationMs: 2 });
+		finish(scope, { outcome: "success", durationMs: 1 });
+		finish(scope, { outcome: "thrown_error", durationMs: 2 });
 		expect(
 			events.filter((event) => event.event === "worker.tool.completion"),
 		).toHaveLength(1);

--- a/packages/worker/src/worker-observer.test.ts
+++ b/packages/worker/src/worker-observer.test.ts
@@ -1,0 +1,245 @@
+import {
+	ErrorType,
+	type SafeToolCompletion,
+	type SafeToolInvocation,
+} from "@hevy-mcp/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	createWorkerToolObserver,
+	type WorkerObservationEvent,
+} from "./worker-observer.js";
+
+const invocation = {
+	name: "get-workouts",
+	kind: "tool",
+	taxonomy: { feature: "workouts", kind: "read", operation: "list" },
+	argumentKeys: ["page", "query", "workout_id", "raw-secret"],
+	argumentPresence: { query: true, workout_id: true, "raw-secret": true },
+	numericArgumentBuckets: { page: "2-10", limit: "not-a-bucket" },
+	booleanArguments: { refresh: true },
+	argumentKeyCountBucket: "2-10",
+} as unknown as SafeToolInvocation;
+
+function createScope(events: WorkerObservationEvent[]) {
+	const scope = createWorkerToolObserver({
+		sink: (event) => {
+			events.push(event);
+		},
+	}).start(invocation);
+	if (!scope) throw new Error("Expected a Worker observation scope");
+	return scope;
+}
+
+describe("createWorkerToolObserver", () => {
+	it("emits safe bounded invocation and successful completion events", async () => {
+		const events: WorkerObservationEvent[] = [];
+		const scope = createScope(events);
+
+		await expect(
+			scope.run(() => Promise.resolve("raw response body")),
+		).resolves.toBe("raw response body");
+		void scope.finish({
+			outcome: "success",
+			durationMs: 12,
+			result: {
+				isError: false,
+				hasStructuredContent: true,
+				contentCountBucket: "2-10",
+				summary: {
+					itemCountBucket: "11-50",
+					workflow: {
+						name: "training-summary",
+						cacheStatus: "miss",
+						itemsScanned: 12,
+						pagination: { workouts: 2, routines: 1, secret: 999 },
+					},
+				},
+			},
+		});
+
+		expect(events).toHaveLength(2);
+		expect(events[0]).toMatchObject({
+			event: "worker.tool.invocation",
+			name: "get-workouts",
+			kind: "tool",
+			taxonomy: invocation.taxonomy,
+			argumentKeys: ["page", "query", "workout_id"],
+			argumentPresence: { query: true, workout_id: true },
+			numericArgumentBuckets: { page: "2-10" },
+			booleanArguments: { refresh: true },
+		});
+		expect(events[1]).toMatchObject({
+			event: "worker.tool.completion",
+			outcome: "success",
+			durationMs: 12,
+			result: {
+				contentCountBucket: "2-10",
+				summary: {
+					itemCountBucket: "11-50",
+					workflow: {
+						name: "training-summary",
+						cacheStatus: "miss",
+						itemsScanned: 12,
+						pagination: { workouts: 2, routines: 1 },
+					},
+				},
+			},
+		});
+		expect(JSON.stringify(events)).not.toContain("raw-secret");
+		expect(JSON.stringify(events)).not.toContain("raw response body");
+		expect(JSON.stringify(events)).not.toContain("secret");
+	});
+
+	it.each([
+		[
+			"returned_error",
+			{ isError: true, hasStructuredContent: false, contentCountBucket: "1" },
+		],
+		["thrown_error", undefined],
+	] as const)("records %s outcomes", (outcome, result) => {
+		const events: WorkerObservationEvent[] = [];
+		const scope = createScope(events);
+		const completion: SafeToolCompletion = {
+			outcome,
+			durationMs: 4,
+			...(result
+				? { result }
+				: {
+						errorType: ErrorType.NETWORK_ERROR,
+						error: {
+							category: "HevyHttpError",
+							code: "ETIMEDOUT",
+							status: 503,
+							method: "GET",
+							endpoint: "/v1/workouts/:workoutId",
+						},
+					}),
+		};
+		void scope.finish(completion);
+
+		const event = events[1];
+		expect(event).toMatchObject({ event: "worker.tool.completion", outcome });
+		if (outcome === "thrown_error") {
+			expect(event).toMatchObject({
+				errorType: "NETWORK_ERROR",
+				error: { category: "HevyHttpError", code: "ETIMEDOUT", status: 503 },
+				execution: {
+					outcome: "terminal_failure",
+					phase: "before-dispatch",
+					commit_state: "not_sent",
+					safe_to_retry: false,
+				},
+			});
+		} else {
+			expect(event?.result?.isError).toBe(true);
+		}
+	});
+
+	it("drops malformed diagnostic fields at the Worker boundary", () => {
+		const events: WorkerObservationEvent[] = [];
+		const scope = createScope(events);
+		void scope.finish({
+			outcome: "thrown_error",
+			durationMs: 1,
+			error: {
+				category: "secret-category",
+				code: "secret-code",
+				status: 999,
+				method: "GET?token=secret",
+				endpoint: "/v1/workouts/user-secret",
+				phase: "secret-phase",
+				operation_safety: "secret-safety",
+				commit_state: "secret-state",
+				safe_to_retry: true,
+				outcome: "secret-outcome",
+				frames: [
+					{ source: "secret-source", line: 1, column: 1 },
+					{ source: "worker", line: 1, column: 1 },
+				],
+			},
+			errorOutcome: {
+				outcome: "secret-outcome",
+				phase: "secret-phase",
+				operation_safety: "secret-safety",
+				commit_state: "secret-state",
+				safe_to_retry: true,
+				code: "secret-code",
+				status: 999,
+			},
+		} as unknown as SafeToolCompletion);
+
+		const event = events[1];
+		expect(event).toMatchObject({
+			event: "worker.tool.completion",
+			error: {
+				category: "UnknownError",
+				safe_to_retry: true,
+				frames: [{ source: "worker", line: 1, column: 1 }],
+			},
+			execution: {
+				outcome: "terminal_failure",
+				phase: "before-dispatch",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: true,
+			},
+		});
+		expect(JSON.stringify(event)).not.toContain("secret");
+	});
+
+	it("uses the explicit execution projection for returned errors", () => {
+		const events: WorkerObservationEvent[] = [];
+		const scope = createScope(events);
+		void scope.finish({
+			outcome: "returned_error",
+			durationMs: 1,
+			result: {
+				isError: true,
+				hasStructuredContent: true,
+				contentCountBucket: "1",
+			},
+			errorOutcome: {
+				outcome: "deadline_exceeded",
+				phase: "dispatch",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+				code: "HEVY_DEADLINE_EXCEEDED",
+			},
+		});
+		expect(events[1]?.execution).toMatchObject({
+			outcome: "deadline_exceeded",
+			phase: "dispatch",
+			code: "HEVY_DEADLINE_EXCEEDED",
+		});
+	});
+
+	it("finishes at most once", () => {
+		const events: WorkerObservationEvent[] = [];
+		const scope = createScope(events);
+		void scope.finish({ outcome: "success", durationMs: 1 });
+		void scope.finish({ outcome: "thrown_error", durationMs: 2 });
+		expect(
+			events.filter((event) => event.event === "worker.tool.completion"),
+		).toHaveLength(1);
+	});
+
+	it("isolates synchronous and asynchronous sink failures", async () => {
+		const sink = vi
+			.fn<(_: WorkerObservationEvent) => void | Promise<void>>()
+			.mockImplementationOnce(() => {
+				throw new Error("sink failure");
+			})
+			.mockImplementationOnce(() =>
+				Promise.reject(new Error("async sink failure")),
+			);
+		const scope = createWorkerToolObserver({ sink }).start(invocation);
+		if (!scope) throw new Error("Expected a Worker observation scope");
+		await expect(scope.run(() => Promise.resolve("ok"))).resolves.toBe("ok");
+		expect(() =>
+			scope.finish({ outcome: "success", durationMs: 1 }),
+		).not.toThrow();
+		await Promise.resolve();
+		expect(sink).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -316,27 +316,25 @@ function safeResult(
 	};
 }
 
-function safeError(
-	error: ReturnType<typeof createSafeErrorDiagnostic> | undefined,
-): ReturnType<typeof createSafeErrorDiagnostic> | undefined {
-	if (!error || typeof error !== "object") return undefined;
-	const category = SAFE_ERROR_CATEGORIES.has(error.category)
-		? error.category
-		: "UnknownError";
-	const code =
-		typeof error.code === "string" && SAFE_ERROR_CODES.has(error.code)
-			? error.code
-			: undefined;
-	const method =
-		typeof error.method === "string" &&
-		SAFE_HTTP_METHODS.has(error.method.toUpperCase())
-			? error.method.toUpperCase()
-			: undefined;
-	const endpoint =
-		typeof error.endpoint === "string" && SAFE_ENDPOINTS.has(error.endpoint)
-			? error.endpoint
-			: undefined;
-	const frames = error.frames
+type SafeErrorOutput = ReturnType<typeof createSafeErrorDiagnostic>;
+
+function safeErrorStatus(value: unknown): number | undefined {
+	if (typeof value !== "number") return undefined;
+	return Number.isInteger(value) && value >= 100 && value <= 599
+		? value
+		: undefined;
+}
+
+function safeErrorMethod(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const method = value.toUpperCase();
+	return SAFE_HTTP_METHODS.has(method) ? method : undefined;
+}
+
+function safeErrorFrames(
+	frames: SafeErrorOutput["frames"],
+): SafeErrorOutput["frames"] {
+	return frames
 		?.filter(
 			(frame) =>
 				SAFE_STACK_SOURCES.has(frame.source) &&
@@ -346,45 +344,54 @@ function safeError(
 				frame.column > 0,
 		)
 		.slice(0, 3);
-	const phase =
-		typeof error.phase === "string" && SAFE_REQUEST_PHASES.has(error.phase)
-			? error.phase
-			: undefined;
-	const operationSafety =
-		typeof error.operation_safety === "string" &&
-		SAFE_OPERATION_SAFETY.has(error.operation_safety)
-			? error.operation_safety
-			: undefined;
-	const commitState =
-		typeof error.commit_state === "string" &&
-		SAFE_COMMIT_STATES.has(error.commit_state)
-			? error.commit_state
-			: undefined;
-	const outcome =
-		typeof error.outcome === "string" &&
-		SAFE_EXECUTION_OUTCOMES.has(error.outcome)
-			? error.outcome
-			: undefined;
-	return {
-		category,
-		...(code ? { code } : {}),
-		...(typeof error.status === "number" &&
-		Number.isInteger(error.status) &&
-		error.status >= 100 &&
-		error.status <= 599
-			? { status: error.status }
-			: {}),
-		...(method ? { method } : {}),
-		...(endpoint ? { endpoint } : {}),
-		...(frames?.length ? { frames } : {}),
-		...(phase ? { phase } : {}),
-		...(operationSafety ? { operation_safety: operationSafety } : {}),
-		...(commitState ? { commit_state: commitState } : {}),
-		...(typeof error.safe_to_retry === "boolean"
-			? { safe_to_retry: error.safe_to_retry }
-			: {}),
-		...(outcome ? { outcome } : {}),
-	};
+}
+
+function safeErrorBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function safeError(
+	error: ReturnType<typeof createSafeErrorDiagnostic> | undefined,
+): ReturnType<typeof createSafeErrorDiagnostic> | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const category =
+		allowedValue<SafeErrorOutput["category"]>(
+			error.category,
+			SAFE_ERROR_CATEGORIES,
+		) ?? "UnknownError";
+	const code = allowedValue<string>(error.code, SAFE_ERROR_CODES);
+	const method = safeErrorMethod(error.method);
+	const endpoint = allowedValue<string>(error.endpoint, SAFE_ENDPOINTS);
+	const frames = safeErrorFrames(error.frames);
+	const phase = allowedValue<NonNullable<SafeErrorOutput["phase"]>>(
+		error.phase,
+		SAFE_REQUEST_PHASES,
+	);
+	const operationSafety = allowedValue<
+		NonNullable<SafeErrorOutput["operation_safety"]>
+	>(error.operation_safety, SAFE_OPERATION_SAFETY);
+	const commitState = allowedValue<
+		NonNullable<SafeErrorOutput["commit_state"]>
+	>(error.commit_state, SAFE_COMMIT_STATES);
+	const outcome = allowedValue<NonNullable<SafeErrorOutput["outcome"]>>(
+		error.outcome,
+		SAFE_EXECUTION_OUTCOMES,
+	);
+	const status = safeErrorStatus(error.status);
+	const safeToRetry = safeErrorBoolean(error.safe_to_retry);
+	const sanitized: SafeErrorOutput = { category };
+	if (code !== undefined) sanitized.code = code;
+	if (status !== undefined) sanitized.status = status;
+	if (method !== undefined) sanitized.method = method;
+	if (endpoint !== undefined) sanitized.endpoint = endpoint;
+	if (frames?.length) sanitized.frames = frames;
+	if (phase !== undefined) sanitized.phase = phase;
+	if (operationSafety !== undefined)
+		sanitized.operation_safety = operationSafety;
+	if (commitState !== undefined) sanitized.commit_state = commitState;
+	if (safeToRetry !== undefined) sanitized.safe_to_retry = safeToRetry;
+	if (outcome !== undefined) sanitized.outcome = outcome;
+	return sanitized;
 }
 
 type SafeExecutionSource = Partial<
@@ -445,7 +452,7 @@ function emitBestEffort(
 ): void {
 	try {
 		const pending = sink(event);
-		if (pending) void Promise.resolve(pending).catch(() => undefined);
+		if (pending) Promise.resolve(pending).catch(() => undefined);
 	} catch {
 		// Worker observation is strictly best effort and must not affect MCP behavior.
 	}

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -1,0 +1,505 @@
+import {
+	createExecutionProjection,
+	createSafeErrorDiagnostic,
+	type SafeToolCompletion,
+	type SafeToolInvocation,
+	type StructuredExecutionProjection,
+	type ToolObservationScope,
+	type ToolObserver,
+	type ToolResultObservation,
+	type ToolResultTelemetry,
+} from "@hevy-mcp/core";
+
+const MAX_NAME_LENGTH = 96;
+const MAX_STRING_LENGTH = 160;
+const MAX_ARGUMENT_KEYS = 32;
+const MAX_WORKFLOW_PAGES = 10_000;
+const MAX_WORKFLOW_ITEMS = 1_000_000;
+
+const SAFE_ARGUMENT_KEYS = new Set([
+	"date",
+	"end_date",
+	"exercise_template_id",
+	"folder_id",
+	"include_custom",
+	"limit",
+	"offset",
+	"page",
+	"page_size",
+	"primary_muscle_group",
+	"query",
+	"refresh",
+	"routine_id",
+	"since",
+	"start_date",
+	"updated_since",
+	"workout_id",
+]);
+const SAFE_COUNT_BUCKETS = new Set(["0", "1", "2-10", "11-50", "51+"]);
+const SAFE_WORKFLOW_NAMES = new Set(["training-summary", "routine-discovery"]);
+const SAFE_CACHE_STATUSES = new Set(["hit", "miss", "not-used"]);
+const SAFE_ERROR_TYPES = new Set([
+	"API_ERROR",
+	"RATE_LIMIT",
+	"VALIDATION_ERROR",
+	"NOT_FOUND",
+	"NETWORK_ERROR",
+	"UNKNOWN_ERROR",
+]);
+const SAFE_ERROR_CATEGORIES = new Set([
+	"AggregateError",
+	"DOMException",
+	"Error",
+	"EvalError",
+	"HevyHttpError",
+	"RangeError",
+	"ReferenceError",
+	"SyntaxError",
+	"TypeError",
+	"URIError",
+	"UnknownError",
+]);
+const SAFE_ERROR_CODES = new Set([
+	"EAI_AGAIN",
+	"ECONNABORTED",
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"ENETUNREACH",
+	"ENOTFOUND",
+	"ERR_NETWORK",
+	"ERR_SOCKET_TIMEOUT",
+	"ETIMEDOUT",
+	"HEVY_INVALID_ENDPOINT",
+	"HEVY_REQUEST_ABORTED",
+	"HEVY_RETRY_EXHAUSTED",
+	"HEVY_DEADLINE_EXCEEDED",
+]);
+const SAFE_HTTP_METHODS = new Set([
+	"DELETE",
+	"GET",
+	"HEAD",
+	"OPTIONS",
+	"PATCH",
+	"POST",
+	"PUT",
+]);
+const SAFE_ENDPOINTS = new Set([
+	"/v1/body_measurements",
+	"/v1/body_measurements/:date",
+	"/v1/exercise_history/:exerciseTemplateId",
+	"/v1/exercise_templates",
+	"/v1/exercise_templates/:exerciseTemplateId",
+	"/v1/routine_folders",
+	"/v1/routine_folders/:folderId",
+	"/v1/routines",
+	"/v1/routines/:routineId",
+	"/v1/user/info",
+	"/v1/workouts",
+	"/v1/workouts/:workoutId",
+	"/v1/workouts/count",
+	"/v1/workouts/events",
+]);
+const SAFE_EXECUTION_OUTCOMES = new Set([
+	"success",
+	"expected",
+	"retryable_failure",
+	"terminal_failure",
+	"cancelled",
+	"deadline_exceeded",
+]);
+const SAFE_REQUEST_PHASES = new Set([
+	"before-dispatch",
+	"dispatch",
+	"response-headers",
+	"response-content",
+	"backoff",
+	"completed",
+]);
+const SAFE_OPERATION_SAFETY = new Set([
+	"read",
+	"idempotent-write",
+	"non-idempotent-write",
+]);
+const SAFE_COMMIT_STATES = new Set(["not_sent", "confirmed", "unknown"]);
+const SAFE_STACK_SOURCES = new Set([
+	"error-handler",
+	"hevy-client",
+	"index",
+	"server",
+	"worker",
+]);
+
+/** Structured events emitted by the Worker adapter's private observation sink. */
+export interface WorkerObservationEvent {
+	readonly event: "worker.tool.invocation" | "worker.tool.completion";
+	readonly name: string;
+	readonly kind: "tool" | "prompt";
+	readonly taxonomy?: {
+		readonly feature: string;
+		readonly kind: string;
+		readonly operation: string;
+	};
+	readonly argumentKeys?: readonly string[];
+	readonly argumentPresence?: Readonly<Record<string, true>>;
+	readonly numericArgumentBuckets?: Readonly<Record<string, string>>;
+	readonly booleanArguments?: Readonly<Record<string, boolean>>;
+	readonly argumentKeyCountBucket?: string;
+	readonly outcome?: SafeToolCompletion["outcome"];
+	readonly durationMs?: number;
+	readonly result?: WorkerResultObservation;
+	readonly errorType?: string;
+	readonly error?: ReturnType<typeof createSafeErrorDiagnostic>;
+	readonly execution?: ReturnType<typeof createExecutionProjection>;
+}
+
+interface WorkerResultObservation {
+	readonly isError: boolean;
+	readonly hasStructuredContent: boolean;
+	readonly contentCountBucket: string;
+	readonly summary?: SafeResultSummary;
+}
+
+interface SafeResultSummary {
+	readonly itemCountBucket?: string;
+	readonly exerciseCountBucket?: string;
+	readonly setCountBucket?: string;
+	readonly workflow?: {
+		readonly name: string;
+		readonly pagination: Readonly<Record<string, number>>;
+		readonly cacheStatus: string;
+		readonly itemsScanned: number;
+	};
+}
+
+export type WorkerObservationSink = (
+	event: WorkerObservationEvent,
+) => void | Promise<void>;
+
+export interface WorkerToolObserverOptions {
+	/** Defaults to console.log; test callers can provide an isolated sink. */
+	readonly sink?: WorkerObservationSink;
+}
+
+function boundedString(
+	value: unknown,
+	maxLength = MAX_STRING_LENGTH,
+): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	return value.slice(0, maxLength);
+}
+
+function safeName(value: unknown): string {
+	return boundedString(value, MAX_NAME_LENGTH) ?? "unknown";
+}
+
+function safeBucket(value: unknown): string | undefined {
+	return typeof value === "string" && SAFE_COUNT_BUCKETS.has(value)
+		? value
+		: undefined;
+}
+
+function safeTaxonomy(
+	invocation: SafeToolInvocation,
+): WorkerObservationEvent["taxonomy"] {
+	const taxonomy = invocation.taxonomy;
+	if (!taxonomy) return undefined;
+	const feature = boundedString(taxonomy.feature, MAX_NAME_LENGTH);
+	const kind = boundedString(taxonomy.kind, MAX_NAME_LENGTH);
+	const operation = boundedString(taxonomy.operation, MAX_NAME_LENGTH);
+	return feature && kind && operation
+		? { feature, kind, operation }
+		: undefined;
+}
+
+function safeInvocation(
+	invocation: SafeToolInvocation,
+): Omit<WorkerObservationEvent, "event"> {
+	const argumentKeys = (invocation.argumentKeys ?? [])
+		.filter((key) => SAFE_ARGUMENT_KEYS.has(key))
+		.slice(0, MAX_ARGUMENT_KEYS);
+	const argumentPresence: Record<string, true> = {};
+	for (const key of Object.keys(invocation.argumentPresence ?? {})) {
+		if (SAFE_ARGUMENT_KEYS.has(key)) argumentPresence[key] = true;
+	}
+	const numericArgumentBuckets: Record<string, string> = {};
+	for (const [key, value] of Object.entries(
+		invocation.numericArgumentBuckets ?? {},
+	)) {
+		const bucket = safeBucket(value);
+		if (SAFE_ARGUMENT_KEYS.has(key) && bucket)
+			numericArgumentBuckets[key] = bucket;
+	}
+	const booleanArguments: Record<string, boolean> = {};
+	for (const [key, value] of Object.entries(
+		invocation.booleanArguments ?? {},
+	)) {
+		if (SAFE_ARGUMENT_KEYS.has(key) && typeof value === "boolean") {
+			booleanArguments[key] = value;
+		}
+	}
+	const keyCountBucket = safeBucket(invocation.argumentKeyCountBucket);
+	return {
+		name: safeName(invocation.name),
+		kind: invocation.kind === "prompt" ? "prompt" : "tool",
+		...(safeTaxonomy(invocation) ? { taxonomy: safeTaxonomy(invocation) } : {}),
+		...(argumentKeys.length ? { argumentKeys } : {}),
+		...(Object.keys(argumentPresence).length ? { argumentPresence } : {}),
+		...(Object.keys(numericArgumentBuckets).length
+			? { numericArgumentBuckets }
+			: {}),
+		...(Object.keys(booleanArguments).length ? { booleanArguments } : {}),
+		...(keyCountBucket ? { argumentKeyCountBucket: keyCountBucket } : {}),
+	};
+}
+
+function boundedCount(value: unknown, maximum: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+	return Math.min(maximum, Math.max(0, Math.floor(value)));
+}
+
+function safeSummary(
+	summary: ToolResultTelemetry | undefined,
+): SafeResultSummary | undefined {
+	if (!summary) return undefined;
+	const itemCountBucket = safeBucket(summary.itemCountBucket);
+	const exerciseCountBucket = safeBucket(summary.exerciseCountBucket);
+	const setCountBucket = safeBucket(summary.setCountBucket);
+	const workflow = summary.workflow;
+	const safeWorkflow =
+		workflow && SAFE_WORKFLOW_NAMES.has(workflow.name)
+			? {
+					name: workflow.name,
+					cacheStatus: SAFE_CACHE_STATUSES.has(workflow.cacheStatus)
+						? workflow.cacheStatus
+						: "not-used",
+					itemsScanned: boundedCount(workflow.itemsScanned, MAX_WORKFLOW_ITEMS),
+					pagination: Object.fromEntries(
+						Object.entries(workflow.pagination)
+							.filter(([resource]) =>
+								["workouts", "bodyMeasurements", "routines"].includes(resource),
+							)
+							.slice(0, MAX_ARGUMENT_KEYS)
+							.map(([resource, pages]) => [
+								resource,
+								boundedCount(pages, MAX_WORKFLOW_PAGES),
+							]),
+					),
+				}
+			: undefined;
+	if (
+		!itemCountBucket &&
+		!exerciseCountBucket &&
+		!setCountBucket &&
+		!safeWorkflow
+	) {
+		return undefined;
+	}
+	return {
+		...(itemCountBucket ? { itemCountBucket } : {}),
+		...(exerciseCountBucket ? { exerciseCountBucket } : {}),
+		...(setCountBucket ? { setCountBucket } : {}),
+		...(safeWorkflow ? { workflow: safeWorkflow } : {}),
+	};
+}
+
+function safeResult(
+	result: ToolResultObservation | undefined,
+): WorkerResultObservation | undefined {
+	if (!result) return undefined;
+	return {
+		isError: result.isError === true,
+		hasStructuredContent: result.hasStructuredContent === true,
+		contentCountBucket: safeBucket(result.contentCountBucket) ?? "0",
+		...(safeSummary(result.summary)
+			? { summary: safeSummary(result.summary) }
+			: {}),
+	};
+}
+
+function safeError(
+	error: ReturnType<typeof createSafeErrorDiagnostic> | undefined,
+): ReturnType<typeof createSafeErrorDiagnostic> | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const category = SAFE_ERROR_CATEGORIES.has(error.category)
+		? error.category
+		: "UnknownError";
+	const code =
+		typeof error.code === "string" && SAFE_ERROR_CODES.has(error.code)
+			? error.code
+			: undefined;
+	const method =
+		typeof error.method === "string" &&
+		SAFE_HTTP_METHODS.has(error.method.toUpperCase())
+			? error.method.toUpperCase()
+			: undefined;
+	const endpoint =
+		typeof error.endpoint === "string" && SAFE_ENDPOINTS.has(error.endpoint)
+			? error.endpoint
+			: undefined;
+	const frames = error.frames
+		?.filter(
+			(frame) =>
+				SAFE_STACK_SOURCES.has(frame.source) &&
+				Number.isSafeInteger(frame.line) &&
+				Number.isSafeInteger(frame.column) &&
+				frame.line > 0 &&
+				frame.column > 0,
+		)
+		.slice(0, 3);
+	const phase =
+		typeof error.phase === "string" && SAFE_REQUEST_PHASES.has(error.phase)
+			? error.phase
+			: undefined;
+	const operationSafety =
+		typeof error.operation_safety === "string" &&
+		SAFE_OPERATION_SAFETY.has(error.operation_safety)
+			? error.operation_safety
+			: undefined;
+	const commitState =
+		typeof error.commit_state === "string" &&
+		SAFE_COMMIT_STATES.has(error.commit_state)
+			? error.commit_state
+			: undefined;
+	const outcome =
+		typeof error.outcome === "string" &&
+		SAFE_EXECUTION_OUTCOMES.has(error.outcome)
+			? error.outcome
+			: undefined;
+	return {
+		category,
+		...(code ? { code } : {}),
+		...(typeof error.status === "number" &&
+		Number.isInteger(error.status) &&
+		error.status >= 100 &&
+		error.status <= 599
+			? { status: error.status }
+			: {}),
+		...(method ? { method } : {}),
+		...(endpoint ? { endpoint } : {}),
+		...(frames?.length ? { frames } : {}),
+		...(phase ? { phase } : {}),
+		...(operationSafety ? { operation_safety: operationSafety } : {}),
+		...(commitState ? { commit_state: commitState } : {}),
+		...(typeof error.safe_to_retry === "boolean"
+			? { safe_to_retry: error.safe_to_retry }
+			: {}),
+		...(outcome ? { outcome } : {}),
+	};
+}
+
+type SafeExecutionSource = Partial<
+	Pick<
+		StructuredExecutionProjection,
+		| "outcome"
+		| "phase"
+		| "operation_safety"
+		| "commit_state"
+		| "safe_to_retry"
+		| "code"
+		| "status"
+	>
+>;
+
+function allowedValue<T extends string>(
+	value: unknown,
+	allowed: ReadonlySet<string>,
+): T | undefined {
+	return typeof value === "string" && allowed.has(value)
+		? (value as T)
+		: undefined;
+}
+
+function safeExecution(
+	source: SafeExecutionSource | undefined,
+): ReturnType<typeof createExecutionProjection> | undefined {
+	if (!source) return undefined;
+	return createExecutionProjection({
+		outcome: allowedValue(source.outcome, SAFE_EXECUTION_OUTCOMES),
+		phase: allowedValue(source.phase, SAFE_REQUEST_PHASES),
+		operation_safety: allowedValue(
+			source.operation_safety,
+			SAFE_OPERATION_SAFETY,
+		),
+		commit_state: allowedValue(source.commit_state, SAFE_COMMIT_STATES),
+		safe_to_retry:
+			typeof source.safe_to_retry === "boolean"
+				? source.safe_to_retry
+				: undefined,
+		code:
+			typeof source.code === "string" && SAFE_ERROR_CODES.has(source.code)
+				? source.code
+				: undefined,
+		status:
+			typeof source.status === "number" &&
+			Number.isInteger(source.status) &&
+			source.status >= 100 &&
+			source.status <= 599
+				? source.status
+				: undefined,
+	});
+}
+
+function emitBestEffort(
+	sink: WorkerObservationSink,
+	event: WorkerObservationEvent,
+): void {
+	try {
+		const pending = sink(event);
+		if (pending) void Promise.resolve(pending).catch(() => undefined);
+	} catch {
+		// Worker observation is strictly best effort and must not affect MCP behavior.
+	}
+}
+
+/** Worker-only adapter for Core's privacy-safe semantic observation contract. */
+export function createWorkerToolObserver(
+	options: WorkerToolObserverOptions = {},
+): ToolObserver {
+	const sink =
+		options.sink ?? ((event: WorkerObservationEvent) => console.log(event));
+	return {
+		start(invocation): ToolObservationScope {
+			let safe: Omit<WorkerObservationEvent, "event">;
+			try {
+				safe = safeInvocation(invocation);
+			} catch {
+				safe = { name: "unknown", kind: "tool" };
+			}
+			const startedAt = Date.now();
+			emitBestEffort(sink, { event: "worker.tool.invocation", ...safe });
+			let finished = false;
+			return {
+				run: <T>(operation: () => Promise<T>) => operation(),
+				finish(completion) {
+					if (finished) return;
+					finished = true;
+					try {
+						const durationMs = boundedCount(
+							completion.durationMs || Date.now() - startedAt,
+							Number.MAX_SAFE_INTEGER,
+						);
+						const error = safeError(completion.error);
+						const execution = completion.errorOutcome
+							? safeExecution(completion.errorOutcome)
+							: safeExecution(error);
+						const result = safeResult(completion.result);
+						emitBestEffort(sink, {
+							event: "worker.tool.completion",
+							...safe,
+							outcome: completion.outcome,
+							durationMs,
+							...(result ? { result } : {}),
+							...(SAFE_ERROR_TYPES.has(completion.errorType ?? "")
+								? { errorType: completion.errorType }
+								: {}),
+							...(error ? { error } : {}),
+							...(execution ? { execution } : {}),
+						});
+					} catch {
+						// Observation projection is best effort and must not affect MCP behavior.
+					}
+				},
+			};
+		},
+	};
+}

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -439,6 +439,48 @@ describe("real stateless SDK transport", () => {
 		);
 	});
 
+	it("constructs a fresh observer for every stateless MCP request", async () => {
+		const observers: object[] = [];
+		const createObserver = vi.fn(() => {
+			const observer = { start: vi.fn() };
+			observers.push(observer);
+			return observer;
+		});
+		const createServer = vi.fn(
+			(
+				createClient: CreateHevyMcpServerOptions["createClient"],
+				_signal: AbortSignal | undefined,
+				_deadline: number | undefined,
+				observer: CreateHevyMcpServerOptions["observer"],
+			) => createHevyMcpServer({ createClient, observer }),
+		);
+		const handler = createWorkerHandler({
+			createValidationClient: () => createMockClient(),
+			createRequestClient: () => createMockClient(),
+			createObserver,
+			createServer,
+		});
+		const initialize = {
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2025-11-25",
+				capabilities: {},
+				clientInfo: { name: "fresh-observer-test", version: "1" },
+			},
+		};
+
+		expect((await handler(mcpRequest(initialize), {})).status).toBe(200);
+		expect(
+			(await handler(mcpRequest({ ...initialize, id: 2 }), {})).status,
+		).toBe(200);
+		expect(createObserver).toHaveBeenCalledTimes(2);
+		expect(observers[0]).not.toBe(observers[1]);
+		expect(createServer.mock.calls[0]?.[3]).toBe(observers[0]);
+		expect(createServer.mock.calls[1]?.[3]).toBe(observers[1]);
+	});
+
 	it("shares one absolute deadline across validation and MCP execution", async () => {
 		let validationOptions:
 			| { signal?: AbortSignal; deadline?: number }
@@ -473,7 +515,9 @@ describe("real stateless SDK transport", () => {
 
 		expect(result.status).toBe(200);
 		expect(validationOptions?.signal).toBeInstanceOf(AbortSignal);
-		expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
+		await vi.waitFor(() =>
+			expect(requestOptions?.signal).toBeInstanceOf(AbortSignal),
+		);
 		expect(validationOptions?.deadline).toBeLessThan(
 			requestOptions?.deadline ?? Number.POSITIVE_INFINITY,
 		);

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -21,6 +21,7 @@ import {
 	WORKER_INVOCATION_TIMEOUT_MS,
 } from "./worker-oauth.js";
 import { executionResponse } from "./execution-response.js";
+import { createWorkerToolObserver } from "./worker-observer.js";
 
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
@@ -68,8 +69,10 @@ interface WorkerDependencies {
 		createClient: CreateHevyMcpServerOptions["createClient"],
 		lifecycleSignal?: AbortSignal,
 		executionDeadline?: number,
+		observer?: CreateHevyMcpServerOptions["observer"],
 	) => McpServer;
 	createTransport?: () => WebStandardStreamableHTTPServerTransport;
+	createObserver?: () => CreateHevyMcpServerOptions["observer"];
 }
 
 type ResolvedWorkerDependencies = Required<WorkerDependencies>;
@@ -229,9 +232,11 @@ function createDefaultServer(
 	createClient: CreateHevyMcpServerOptions["createClient"],
 	lifecycleSignal?: AbortSignal,
 	executionDeadline?: number,
+	observer?: CreateHevyMcpServerOptions["observer"],
 ): McpServer {
 	return createHevyMcpServer({
 		createClient,
+		observer,
 		lifecycleSignal,
 		executionDeadline,
 	});
@@ -286,6 +291,7 @@ function resolveWorkerDependencies(
 			dependencies.createRequestClient ?? createDefaultRequestClient,
 		createServer: dependencies.createServer ?? createDefaultServer,
 		createTransport: dependencies.createTransport ?? createDefaultTransport,
+		createObserver: dependencies.createObserver ?? createWorkerToolObserver,
 	};
 }
 
@@ -328,11 +334,13 @@ async function serveMcpRequest(
 	deadline: number,
 ): Promise<Response> {
 	try {
+		const observer = dependencies.createObserver();
 		const server = dependencies.createServer(
 			({ onLog }) =>
 				dependencies.createRequestClient(apiKey, hevyApiBaseUrl, onLog),
 			request.signal,
 			deadline,
+			observer,
 		);
 		const transport = dependencies.createTransport();
 		transport.onerror = (error) => {


### PR DESCRIPTION
## Summary

- Add a private Worker-local semantic observer over Core's privacy-safe observation contract.
- Emit bounded structured invocation/completion events without raw arguments, request bodies, response content, credentials, or resource IDs.
- Construct a fresh observer for every stateless MCP request while preserving fresh client/server/transport isolation and Worker auth/routing behavior.
- Add boundary sanitization, sink-failure isolation, per-request wiring tests, and a Worker-only Changeset.

## Stack position

This PR is stacked on [#948](https://github.com/chrisdoc/hevy-mcp/pull/948), continuing the stack from [#947](https://github.com/chrisdoc/hevy-mcp/pull/947), [#946](https://github.com/chrisdoc/hevy-mcp/pull/946), [#944](https://github.com/chrisdoc/hevy-mcp/pull/944), and [#940](https://github.com/chrisdoc/hevy-mcp/pull/940).

This is the bounded Worker semantic-observation slice of issue [#879](https://github.com/chrisdoc/hevy-mcp/issues/879). Durable Objects, caching, auth/routing changes, and broader request normalization remain out of scope.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run check:boundaries`
- `mise exec -- npm run build`
- `mise exec -- npm run worker:dry-run`
- `mise exec -- npm run test:pr` — 874 tests
- `mise exec -- npm run test:worker`
- `mise exec -- npm run test:worker-http`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Introduce privacy-safe semantic tool observation for stateless Worker MCP requests and wire it into the Worker adapter with per-request isolation.

Enhancements:
- Add a Worker-local tool observer that projects bounded, privacy-safe invocation and completion telemetry from Core into structured Worker events.
- Integrate the tool observer into the stateless Worker MCP request flow, ensuring a fresh observer instance per request and best-effort, non-disruptive event emission.
- Refine Worker request deadline handling to wait for the request signal to be initialized before assertion.

Tests:
- Add dedicated tests for the Worker tool observer covering safe field projection, error diagnostics sanitization, execution outcome handling, sink failure isolation, and idempotent completion behavior.
- Add a Worker transport test verifying that a new observer is constructed for each stateless MCP request and correctly passed to the server.

Chores:
- Add a Worker-only changeset documenting the new semantic observation behavior and releasing it as a patch.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement privacy-safe semantic tool observation for the Worker adapter by filtering invocation/completion telemetry through allowlists before emission.

Main changes:
- Created `createWorkerToolObserver` with strict allowlists for arguments, endpoints, errors, and workflow metadata
- Integrated observer into Worker's MCP request handler, instantiating fresh observer per request with configurable sink
- Added comprehensive filtering logic to sanitize invocation arguments, error diagnostics, and result telemetry against predefined safe sets

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
