### PR TITLE
feat(operations): add routine retrieval operation

### DIFF
--- a/.changeset/routines-get-operation.md
+++ b/.changeset/routines-get-operation.md
@@ -1,0 +1,9 @@
+---
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Add a typed routines get operation and use it from Core while preserving the CLI get path.

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -124,6 +124,32 @@ describe("routine tools", () => {
 		});
 	});
 
+	it("uses the injected routines get operation and execution context", async () => {
+		const execute = vi.fn().mockResolvedValue({
+			routine: { id: "r1", title: "Push", exercises: [] },
+		});
+		const operations = {
+			routines: { get: { execute }, list: { execute: vi.fn() } },
+		} as unknown as HevyOperations;
+		const execution: ToolExecutionContext = {
+			signal: new AbortController().signal,
+			deadline: Date.now() + 5_000,
+		};
+		const tool = register(null, operations, execution);
+
+		const response = await handler(
+			tool,
+			"get-routine",
+		)({
+			routine_id: "r1",
+		});
+
+		expect(execute).toHaveBeenCalledWith({ routineId: "r1" }, execution);
+		expect(response).toMatchObject({
+			structuredContent: { routine: { id: "r1", title: "Push" } },
+		});
+	});
+
 	it("parses a routine whose exercise rest_seconds is an integer", async () => {
 		// Regression: the Hevy API returns rest_seconds as an integer, but the
 		// Routine read schema (and the get-routine output contract) previously

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -1,5 +1,4 @@
 import type {
-	GetV1RoutinesRoutineid200,
 	PostV1Routines201,
 	PutV1RoutinesRoutineid200,
 	Routine,
@@ -26,7 +25,6 @@ import { buildRoutinePayload } from "./mutation-semantics.js";
 import type { ToolDefinition } from "./define-tool.js";
 import type { ToolRuntime } from "./tool-runtime.js";
 import type { PaginatedToolResult } from "../utils/response-contracts.js";
-import { isExpectedReadNotFound } from "../utils/hevy-error-policy.js";
 
 const getRoutinesSchema = paginationShape({
 	defaultPageSize: 5,
@@ -57,7 +55,7 @@ const getRoutinesDefinition: ToolDefinition<
 const getRoutineSchema = { routine_id: nonEmptyId } as const;
 
 type GetRoutineResult = {
-	routine: GetV1RoutinesRoutineid200["routine"] | null;
+	routine: Routine | null;
 	routine_id: string;
 	expected404Outcome?: "not_found";
 };
@@ -76,21 +74,10 @@ const getRoutineDefinition: ToolDefinition<
 	annotations: readOnlyAnnotations("Get Routine"),
 	responseContract: routineResponse,
 	execute: async (runtime, { routine_id }) => {
-		try {
-			const data: GetV1RoutinesRoutineid200 = await runtime
-				.getClient()
-				.getRoutineById(String(routine_id));
-			return { routine: data?.routine, routine_id };
-		} catch (error) {
-			if (isExpectedReadNotFound(error)) {
-				return {
-					routine: null,
-					routine_id,
-					expected404Outcome: "not_found",
-				};
-			}
-			throw error;
-		}
+		const data = await runtime
+			.getOperations()
+			.routines.get.execute({ routineId: routine_id }, runtime.execution);
+		return { ...data, routine_id };
 	},
 };
 

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -1,6 +1,8 @@
 import type { HevyClient } from "@hevy-mcp/hevy-client";
 import {
+	createRoutinesGetOperation,
 	createRoutinesListOperation,
+	type RoutinesGetOperation,
 	type RoutinesListOperation,
 } from "./routines.js";
 import {
@@ -9,9 +11,17 @@ import {
 } from "./workouts.js";
 
 export {
+	createRoutinesGetOperation,
 	createRoutinesListOperation,
+	isRoutinesGetNotFound,
 	isRoutinesListEndOfList,
+	routinesGetDescriptor,
 	routinesListDescriptor,
+	type RoutinesGetAdapter,
+	type RoutinesGetDescriptor,
+	type RoutinesGetInput,
+	type RoutinesGetOperation,
+	type RoutinesGetOutput,
 	type RoutinesListAdapter,
 	type RoutinesListDescriptor,
 	type RoutinesListInput,
@@ -31,6 +41,7 @@ export {
 
 export interface HevyOperations {
 	readonly routines: {
+		readonly get: RoutinesGetOperation;
 		readonly list: RoutinesListOperation;
 	};
 	readonly workouts: {
@@ -41,6 +52,7 @@ export interface HevyOperations {
 export function createOperations(client: HevyClient): HevyOperations {
 	return {
 		routines: {
+			get: createRoutinesGetOperation(client),
 			list: createRoutinesListOperation(client),
 		},
 		workouts: {

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -1,9 +1,14 @@
 import type { HevyClient, HevyExecutionOptions } from "@hevy-mcp/hevy-client";
 import { HevyHttpError } from "@hevy-mcp/hevy-client";
-import type { GetV1Routines200 } from "@hevy-mcp/hevy-client/types";
+import type {
+	GetV1Routines200,
+	GetV1RoutinesRoutineid200,
+} from "@hevy-mcp/hevy-client/types";
 import { describe, expect, it } from "vitest";
 import {
+	createRoutinesGetOperation,
 	createRoutinesListOperation,
+	type RoutinesGetAdapter,
 	type RoutinesListAdapter,
 } from "./routines.js";
 
@@ -38,6 +43,78 @@ function notFound(endpoint = "/v1/routines") {
 		outcome: "expected",
 	});
 }
+
+interface InMemoryRoutinesGetAdapter extends RoutinesGetAdapter {
+	readonly requests: Array<{
+		readonly routineId: Parameters<HevyClient["getRoutineById"]>[0];
+		readonly options: Parameters<HevyClient["getRoutineById"]>[1];
+	}>;
+}
+
+function createInMemoryGetAdapter(
+	response: GetV1RoutinesRoutineid200 | Error,
+): InMemoryRoutinesGetAdapter {
+	const requests: InMemoryRoutinesGetAdapter["requests"] = [];
+	return {
+		requests,
+		async getRoutineById(routineId, options) {
+			requests.push({ routineId, options });
+			if (response instanceof Error) throw response;
+			return response;
+		},
+	};
+}
+
+describe("routines.get operation", () => {
+	it("maps the routine ID, propagates execution options, and normalizes the response", async () => {
+		const adapter = createInMemoryGetAdapter({
+			routine: { id: "r1", title: "Push", exercises: [] },
+		});
+		const operation = createRoutinesGetOperation(adapter);
+		const signal = new AbortController().signal;
+		const options: HevyExecutionOptions = {
+			signal,
+			deadline: Date.now() + 5_000,
+		};
+
+		await expect(
+			operation.execute({ routineId: "r1" }, options),
+		).resolves.toEqual({
+			routine: { id: "r1", title: "Push", exercises: [] },
+		});
+		expect(operation.descriptor).toEqual({
+			id: "routines.get",
+			safety: "read",
+		});
+		expect(adapter.requests).toEqual([{ routineId: "r1", options }]);
+	});
+
+	it("normalizes a missing routine field to null", async () => {
+		const operation = createRoutinesGetOperation(createInMemoryGetAdapter({}));
+
+		await expect(operation.execute({ routineId: "missing" })).resolves.toEqual({
+			routine: null,
+		});
+	});
+
+	it("returns not_found only for the canonical routine resource 404", async () => {
+		const operation = createRoutinesGetOperation(
+			createInMemoryGetAdapter(notFound("/v1/routines/r1")),
+		);
+
+		await expect(operation.execute({ routineId: "r1" })).resolves.toEqual({
+			routine: null,
+			expected404Outcome: "not_found",
+		});
+
+		const unrelatedOperation = createRoutinesGetOperation(
+			createInMemoryGetAdapter(notFound("/v1/workouts/w1")),
+		);
+		await expect(
+			unrelatedOperation.execute({ routineId: "r1" }),
+		).rejects.toBeInstanceOf(HevyHttpError);
+	});
+});
 
 describe("routines.list operation", () => {
 	it("describes a read and normalizes the curated client page", async () => {

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -57,10 +57,10 @@ function createInMemoryGetAdapter(
 	const requests: InMemoryRoutinesGetAdapter["requests"] = [];
 	return {
 		requests,
-		async getRoutineById(routineId, options) {
+		getRoutineById(routineId, options) {
 			requests.push({ routineId, options });
-			if (response instanceof Error) throw response;
-			return response;
+			if (response instanceof Error) return Promise.reject(response);
+			return Promise.resolve(response);
 		},
 	};
 }

--- a/packages/operations/src/routines.ts
+++ b/packages/operations/src/routines.ts
@@ -25,6 +25,35 @@ export interface RoutinesListOutput {
 
 export type RoutinesListAdapter = Pick<HevyClient, "getRoutines">;
 
+export interface RoutinesGetInput {
+	readonly routineId: string;
+}
+
+export interface RoutinesGetOutput {
+	readonly routine: Routine | null;
+	readonly expected404Outcome?: "not_found";
+}
+
+export type RoutinesGetAdapter = Pick<HevyClient, "getRoutineById">;
+
+export interface RoutinesGetDescriptor {
+	readonly id: "routines.get";
+	readonly safety: Extract<HevyOperationSafety, "read">;
+}
+
+export const routinesGetDescriptor: RoutinesGetDescriptor = {
+	id: "routines.get",
+	safety: "read",
+};
+
+export interface RoutinesGetOperation {
+	readonly descriptor: RoutinesGetDescriptor;
+	execute(
+		input: RoutinesGetInput,
+		options?: HevyExecutionOptions,
+	): Promise<RoutinesGetOutput>;
+}
+
 export interface RoutinesListDescriptor {
 	readonly id: "routines.list";
 	readonly safety: Extract<HevyOperationSafety, "read">;
@@ -66,6 +95,44 @@ function normalizeRoutinesPage(
 		items: response.routines ?? [],
 		page: response.page ?? input.page,
 		pageCount: response.page_count,
+	};
+}
+
+function isExpectedRoutineNotFound(error: unknown): boolean {
+	return (
+		isHevyHttpError(error) &&
+		canonicalEndpointIdentity(error.endpoint) === "/v1/routines/:routineId" &&
+		expectedGet404Outcome(error.endpoint, error.method, error.status) ===
+			"not_found"
+	);
+}
+
+export function isRoutinesGetNotFound(error: unknown): error is HevyHttpError {
+	return isExpectedRoutineNotFound(error);
+}
+
+export function createRoutinesGetOperation(
+	adapter: RoutinesGetAdapter,
+): RoutinesGetOperation {
+	return {
+		descriptor: routinesGetDescriptor,
+		async execute(input, options) {
+			try {
+				const response =
+					options === undefined
+						? await adapter.getRoutineById(input.routineId)
+						: await adapter.getRoutineById(input.routineId, options);
+				return { routine: response.routine ?? null };
+			} catch (error) {
+				if (isRoutinesGetNotFound(error)) {
+					return {
+						routine: null,
+						expected404Outcome: "not_found",
+					};
+				}
+				throw error;
+			}
+		},
 	};
 }
 


### PR DESCRIPTION
## Summary

- Add a runtime-neutral `routines.get` operation with execution-control propagation and read safety metadata.
- Centralize canonical routine-resource 404 handling as `not_found` while preserving unrelated resource errors.
- Migrate Core `get-routine` to the operation and retain its existing MCP response projection.
- Keep the CLI `routines get` path unchanged in this bounded slice; CLI migration is a follow-up with its own compatibility review.

## Stack position

This PR is stacked on [#952](https://github.com/chrisdoc/hevy-mcp/pull/952), continuing the stack from [#951](https://github.com/chrisdoc/hevy-mcp/pull/951), [#949](https://github.com/chrisdoc/hevy-mcp/pull/949), [#948](https://github.com/chrisdoc/hevy-mcp/pull/948), [#947](https://github.com/chrisdoc/hevy-mcp/pull/947), [#946](https://github.com/chrisdoc/hevy-mcp/pull/946), [#944](https://github.com/chrisdoc/hevy-mcp/pull/944), and [#940](https://github.com/chrisdoc/hevy-mcp/pull/940).

This is the bounded `routines.get` operations slice of issue [#872](https://github.com/chrisdoc/hevy-mcp/issues/872). Mutations, search, workflow composition, and CLI get migration remain separate.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run check:boundaries`
- `mise exec -- npm run check:exports`
- `mise exec -- npm run build`
- `mise exec -- npm run test:pr` — 886 tests
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Introduce a typed routines.get operation in the operations layer and wire Core’s get-routine tool to use it while maintaining existing external behavior.

New Features:
- Add a runtime-neutral routines.get operation with read safety metadata and canonical not_found handling for routine retrieval.

Enhancements:
- Expose routines.get operation types and factory from the operations index and integrate it into the shared HevyOperations interface.
- Refine the Core get-routine tool to consume the routines.get operation and propagate execution context without changing its response contract.

Tests:
- Add operation-level tests for routines.get, covering option propagation, response normalization, and canonical 404 handling.
- Extend Core routine tool tests to verify that get-routine delegates to the injected routines.get operation with the provided execution context.

Chores:
- Add a changeset documenting the introduction of routines.get and its adoption in Core while leaving the CLI routines get path unchanged.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Extract routine retrieval logic into a dedicated typed operation to enable reusable error handling and execution context propagation across Core and CLI.

Main changes:
- Created `RoutinesGetOperation` with typed input/output contracts, descriptor, and 404 error normalization in operations package
- Refactored Core's `getRoutineDefinition` to use injected `routines.get` operation instead of direct client calls
- Removed `isExpectedReadNotFound` utility in favor of operation-level error handling with canonical endpoint validation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
