### PR TITLE
feat(operations): add workout retrieval operation

### DIFF
--- a/.changeset/workouts-get-operation.md
+++ b/.changeset/workouts-get-operation.md
@@ -1,0 +1,9 @@
+---
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Add a typed workouts get operation and use it from Core while preserving the CLI get path.

--- a/packages/core/src/tools/workouts.test.ts
+++ b/packages/core/src/tools/workouts.test.ts
@@ -1,15 +1,26 @@
 /* oxlint-disable typescript/unbound-method */
 import type { McpServer } from "@modelcontextprotocol/server";
 import type { HevyClient } from "@hevy-mcp/hevy-client";
+import type { HevyOperations } from "@hevy-mcp/operations";
+import type { ToolExecutionContext } from "../execution.js";
 import { describe, expect, it, vi } from "vitest";
 import { createToolRuntime } from "./tool-runtime.js";
 import { registerToolDefinition } from "./define-tool.js";
 import { workoutToolDefinitions } from "./workouts.js";
 
-function register(client: HevyClient | null) {
+function register(
+	client: HevyClient | null,
+	operations?: HevyOperations,
+	execution?: ToolExecutionContext,
+) {
 	const tool = vi.fn();
 	const server = { tool, registerTool: tool } as unknown as McpServer;
-	const runtime = createToolRuntime({ client, catalog: {} as never });
+	const runtime = createToolRuntime({
+		client,
+		operations,
+		execution,
+		catalog: {} as never,
+	});
 	for (const definition of workoutToolDefinitions) {
 		registerToolDefinition(server, runtime, definition);
 	}
@@ -81,6 +92,35 @@ describe("workout tools", () => {
 			pageSize: 5,
 			since: "2025-01-01T00:00:00Z",
 		});
+	});
+
+	it("uses the injected workout get operation and execution context", async () => {
+		const execute = vi.fn().mockResolvedValue({
+			workout: { id: "w1", title: "Push" },
+		});
+		const operations = {
+			workouts: { get: { execute }, list: { execute: vi.fn() } },
+		} as unknown as HevyOperations;
+		const execution: ToolExecutionContext = {
+			signal: new AbortController().signal,
+			deadline: Date.now() + 5_000,
+		};
+		const tool = register(null, operations, execution);
+
+		const response = await toolHandler(
+			tool,
+			"get-workout",
+		)({
+			workout_id: "w1",
+		});
+
+		expect(execute).toHaveBeenCalledWith({ workoutId: "w1" }, execution);
+		expect(response).toMatchObject({
+			structuredContent: {
+				workout: { id: "w1", title: "Push" },
+			},
+		});
+		expect(response).toMatchObject({ content: [{ type: "text" }] });
 	});
 
 	it("gets before patching metadata and sends the exact built payload", async () => {

--- a/packages/core/src/tools/workouts.ts
+++ b/packages/core/src/tools/workouts.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import type {
 	GetV1WorkoutsEvents200,
-	GetV1WorkoutsWorkoutid200,
 	PostV1Workouts201,
 	PutV1WorkoutsWorkoutid200,
 } from "@hevy-mcp/hevy-client/types";
@@ -29,10 +28,7 @@ import {
 
 import type { InferToolParams } from "../utils/tool-helpers.js";
 import { buildWorkoutUpdatePayload } from "./mutation-semantics.js";
-import {
-	isExpectedListPageNotFound,
-	isExpectedReadNotFound,
-} from "../utils/hevy-error-policy.js";
+import { isExpectedListPageNotFound } from "../utils/hevy-error-policy.js";
 
 const getWorkoutsSchema = paginationShape({
 	defaultPageSize: 5,
@@ -96,21 +92,13 @@ export const workoutToolDefinitions = [
 		kind: "read" as const,
 		responseContract: workoutResponse,
 		execute: async (runtime: ToolRuntime, args: GetWorkoutParams) => {
-			try {
-				const data: GetV1WorkoutsWorkoutid200 = await runtime
-					.getClient()
-					.getWorkout(args.workout_id);
-				return { workout: data, workout_id: args.workout_id };
-			} catch (error) {
-				if (isExpectedReadNotFound(error)) {
-					return {
-						workout: null,
-						workout_id: args.workout_id,
-						expected404Outcome: "not_found",
-					};
-				}
-				throw error;
-			}
+			const data = await runtime
+				.getOperations()
+				.workouts.get.execute(
+					{ workoutId: args.workout_id },
+					runtime.execution,
+				);
+			return { ...data, workout_id: args.workout_id };
 		},
 	},
 	{

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -6,7 +6,9 @@ import {
 	type RoutinesListOperation,
 } from "./routines.js";
 import {
+	createWorkoutsGetOperation,
 	createWorkoutsListOperation,
+	type WorkoutsGetOperation,
 	type WorkoutsListOperation,
 } from "./workouts.js";
 
@@ -29,9 +31,17 @@ export {
 	type RoutinesListOutput,
 } from "./routines.js";
 export {
+	createWorkoutsGetOperation,
 	createWorkoutsListOperation,
+	isWorkoutsGetNotFound,
 	isWorkoutsListEndOfList,
+	workoutsGetDescriptor,
 	workoutsListDescriptor,
+	type WorkoutsGetAdapter,
+	type WorkoutsGetDescriptor,
+	type WorkoutsGetInput,
+	type WorkoutsGetOperation,
+	type WorkoutsGetOutput,
 	type WorkoutsListAdapter,
 	type WorkoutsListDescriptor,
 	type WorkoutsListInput,
@@ -45,6 +55,7 @@ export interface HevyOperations {
 		readonly list: RoutinesListOperation;
 	};
 	readonly workouts: {
+		readonly get: WorkoutsGetOperation;
 		readonly list: WorkoutsListOperation;
 	};
 }
@@ -56,6 +67,7 @@ export function createOperations(client: HevyClient): HevyOperations {
 			list: createRoutinesListOperation(client),
 		},
 		workouts: {
+			get: createWorkoutsGetOperation(client),
 			list: createWorkoutsListOperation(client),
 		},
 	};

--- a/packages/operations/src/workouts.test.ts
+++ b/packages/operations/src/workouts.test.ts
@@ -86,9 +86,7 @@ describe("workouts.get operation", () => {
 	});
 
 	it("normalizes a missing workout response to null", async () => {
-		const operation = createWorkoutsGetOperation(
-			createInMemoryGetAdapter(),
-		);
+		const operation = createWorkoutsGetOperation(createInMemoryGetAdapter());
 
 		await expect(operation.execute({ workoutId: "missing" })).resolves.toEqual({
 			workout: null,

--- a/packages/operations/src/workouts.test.ts
+++ b/packages/operations/src/workouts.test.ts
@@ -1,9 +1,14 @@
 import type { HevyClient, HevyExecutionOptions } from "@hevy-mcp/hevy-client";
 import { HevyHttpError } from "@hevy-mcp/hevy-client";
-import type { GetV1Workouts200 } from "@hevy-mcp/hevy-client/types";
+import type {
+	GetV1Workouts200,
+	GetV1WorkoutsWorkoutid200,
+} from "@hevy-mcp/hevy-client/types";
 import { describe, expect, it } from "vitest";
 import {
+	createWorkoutsGetOperation,
 	createWorkoutsListOperation,
+	type WorkoutsGetAdapter,
 	type WorkoutsListAdapter,
 } from "./workouts.js";
 
@@ -38,6 +43,76 @@ function notFound(endpoint = "/v1/workouts") {
 		outcome: "expected",
 	});
 }
+
+interface InMemoryWorkoutsGetAdapter extends WorkoutsGetAdapter {
+	readonly requests: Array<{
+		readonly workoutId: Parameters<HevyClient["getWorkout"]>[0];
+		readonly options: Parameters<HevyClient["getWorkout"]>[1];
+	}>;
+}
+
+function createInMemoryGetAdapter(
+	response: GetV1WorkoutsWorkoutid200 | undefined | Error,
+): InMemoryWorkoutsGetAdapter {
+	const requests: InMemoryWorkoutsGetAdapter["requests"] = [];
+	return {
+		requests,
+		async getWorkout(workoutId, options) {
+			requests.push({ workoutId, options });
+			if (response instanceof Error) throw response;
+			return response as GetV1WorkoutsWorkoutid200;
+		},
+	};
+}
+
+describe("workouts.get operation", () => {
+	it("maps the workout ID, propagates execution options, normalizes, and describes a read", async () => {
+		const adapter = createInMemoryGetAdapter({ id: "w1" });
+		const operation = createWorkoutsGetOperation(adapter);
+		const signal = new AbortController().signal;
+		const options: HevyExecutionOptions = {
+			signal,
+			deadline: Date.now() + 5_000,
+		};
+
+		await expect(
+			operation.execute({ workoutId: "w1" }, options),
+		).resolves.toEqual({ workout: { id: "w1" } });
+		expect(operation.descriptor).toEqual({
+			id: "workouts.get",
+			safety: "read",
+		});
+		expect(adapter.requests).toEqual([{ workoutId: "w1", options }]);
+	});
+
+	it("normalizes a missing workout response to null", async () => {
+		const operation = createWorkoutsGetOperation(
+			createInMemoryGetAdapter(undefined),
+		);
+
+		await expect(operation.execute({ workoutId: "missing" })).resolves.toEqual({
+			workout: null,
+		});
+	});
+
+	it("returns not_found only for the canonical workout resource 404", async () => {
+		const operation = createWorkoutsGetOperation(
+			createInMemoryGetAdapter(notFound("/v1/workouts/w1")),
+		);
+
+		await expect(operation.execute({ workoutId: "w1" })).resolves.toEqual({
+			workout: null,
+			expected404Outcome: "not_found",
+		});
+
+		const unrelatedOperation = createWorkoutsGetOperation(
+			createInMemoryGetAdapter(notFound("/v1/routines/r1")),
+		);
+		await expect(
+			unrelatedOperation.execute({ workoutId: "w1" }),
+		).rejects.toBeInstanceOf(HevyHttpError);
+	});
+});
 
 describe("workouts.list operation", () => {
 	it("describes a read and normalizes the curated client page", async () => {

--- a/packages/operations/src/workouts.test.ts
+++ b/packages/operations/src/workouts.test.ts
@@ -26,11 +26,11 @@ function createInMemoryAdapter(
 	const requests: InMemoryWorkoutsAdapter["requests"] = [];
 	return {
 		requests,
-		async getWorkouts(params, options) {
+		getWorkouts(params, options) {
 			requests.push({ params, options });
 			const response = responses[responseIndex++] ?? { workouts: [] };
-			if (response instanceof Error) throw response;
-			return response;
+			if (response instanceof Error) return Promise.reject(response);
+			return Promise.resolve(response);
 		},
 	};
 }
@@ -52,15 +52,15 @@ interface InMemoryWorkoutsGetAdapter extends WorkoutsGetAdapter {
 }
 
 function createInMemoryGetAdapter(
-	response: GetV1WorkoutsWorkoutid200 | undefined | Error,
+	response?: GetV1WorkoutsWorkoutid200 | Error,
 ): InMemoryWorkoutsGetAdapter {
 	const requests: InMemoryWorkoutsGetAdapter["requests"] = [];
 	return {
 		requests,
-		async getWorkout(workoutId, options) {
+		getWorkout(workoutId, options) {
 			requests.push({ workoutId, options });
-			if (response instanceof Error) throw response;
-			return response as GetV1WorkoutsWorkoutid200;
+			if (response instanceof Error) return Promise.reject(response);
+			return Promise.resolve(response as GetV1WorkoutsWorkoutid200);
 		},
 	};
 }
@@ -87,7 +87,7 @@ describe("workouts.get operation", () => {
 
 	it("normalizes a missing workout response to null", async () => {
 		const operation = createWorkoutsGetOperation(
-			createInMemoryGetAdapter(undefined),
+			createInMemoryGetAdapter(),
 		);
 
 		await expect(operation.execute({ workoutId: "missing" })).resolves.toEqual({

--- a/packages/operations/src/workouts.ts
+++ b/packages/operations/src/workouts.ts
@@ -25,6 +25,35 @@ export interface WorkoutsListOutput {
 
 export type WorkoutsListAdapter = Pick<HevyClient, "getWorkouts">;
 
+export interface WorkoutsGetInput {
+	readonly workoutId: string;
+}
+
+export interface WorkoutsGetOutput {
+	readonly workout: Workout | null;
+	readonly expected404Outcome?: "not_found";
+}
+
+export type WorkoutsGetAdapter = Pick<HevyClient, "getWorkout">;
+
+export interface WorkoutsGetDescriptor {
+	readonly id: "workouts.get";
+	readonly safety: Extract<HevyOperationSafety, "read">;
+}
+
+export const workoutsGetDescriptor: WorkoutsGetDescriptor = {
+	id: "workouts.get",
+	safety: "read",
+};
+
+export interface WorkoutsGetOperation {
+	readonly descriptor: WorkoutsGetDescriptor;
+	execute(
+		input: WorkoutsGetInput,
+		options?: HevyExecutionOptions,
+	): Promise<WorkoutsGetOutput>;
+}
+
 export interface WorkoutsListDescriptor {
 	readonly id: "workouts.list";
 	readonly safety: Extract<HevyOperationSafety, "read">;
@@ -41,6 +70,19 @@ export interface WorkoutsListOperation {
 		input: WorkoutsListInput,
 		options?: HevyExecutionOptions,
 	): Promise<WorkoutsListOutput>;
+}
+
+function isExpectedWorkoutNotFound(error: unknown): boolean {
+	return (
+		isHevyHttpError(error) &&
+		canonicalEndpointIdentity(error.endpoint) === "/v1/workouts/:workoutId" &&
+		expectedGet404Outcome(error.endpoint, error.method, error.status) ===
+			"not_found"
+	);
+}
+
+export function isWorkoutsGetNotFound(error: unknown): error is HevyHttpError {
+	return isExpectedWorkoutNotFound(error);
 }
 
 function isExpectedEndOfList(error: unknown, page: number): boolean {
@@ -66,6 +108,31 @@ function normalizeWorkoutsPage(
 		items: response.workouts ?? [],
 		page: response.page ?? input.page,
 		pageCount: response.page_count,
+	};
+}
+
+export function createWorkoutsGetOperation(
+	adapter: WorkoutsGetAdapter,
+): WorkoutsGetOperation {
+	return {
+		descriptor: workoutsGetDescriptor,
+		async execute(input, options) {
+			try {
+				const response =
+					options === undefined
+						? await adapter.getWorkout(input.workoutId)
+						: await adapter.getWorkout(input.workoutId, options);
+				return { workout: response ?? null };
+			} catch (error) {
+				if (isWorkoutsGetNotFound(error)) {
+					return {
+						workout: null,
+						expected404Outcome: "not_found",
+					};
+				}
+				throw error;
+			}
+		},
 	};
 }
 


### PR DESCRIPTION
## Summary

- Add a runtime-neutral `workouts.get` operation with execution-control propagation and read safety metadata.
- Centralize canonical workout-resource 404 handling as `not_found` while preserving unrelated resource errors.
- Migrate Core `get-workout` to the operation while retaining its existing MCP response projection.
- Keep the CLI `workouts get` path unchanged in this bounded slice; CLI migration remains a separate compatibility-reviewed follow-up.

## Stack position

This PR is stacked on [#953](https://github.com/chrisdoc/hevy-mcp/pull/953), continuing the stack from [#952](https://github.com/chrisdoc/hevy-mcp/pull/952), [#951](https://github.com/chrisdoc/hevy-mcp/pull/951), [#949](https://github.com/chrisdoc/hevy-mcp/pull/949), [#948](https://github.com/chrisdoc/hevy-mcp/pull/948), [#947](https://github.com/chrisdoc/hevy-mcp/pull/947), [#946](https://github.com/chrisdoc/hevy-mcp/pull/946), [#944](https://github.com/chrisdoc/hevy-mcp/pull/944), and [#940](https://github.com/chrisdoc/hevy-mcp/pull/940).

This is the bounded `workouts.get` operations slice of issue [#872](https://github.com/chrisdoc/hevy-mcp/issues/872). Mutations, events, search, workflows, and CLI get migration remain separate.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run check:boundaries`
- `mise exec -- npm run check:exports`
- `mise exec -- npm run build`
- `mise exec -- npm run test:pr` — 890 tests
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Add a centralized workouts.get operation, expose it through the shared operations API, and migrate Core workout tools to consume it without altering the CLI workouts get path.

New Features:
- Introduce a typed runtime-neutral workouts.get operation with read safety metadata and canonical 404 handling

Enhancements:
- Wire the new workouts.get operation into Core workout tools so they use shared operations and execution context while preserving existing response projection
- Extend the shared HevyOperations factory and surface workouts.get types and helpers from the operations package

Documentation:
- Add a changeset describing the new workouts.get operation and its usage from Core while keeping the CLI get behavior unchanged
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implement a typed workout retrieval operation in the operations layer and integrate it into the Core tool to replace direct client calls.

Main changes:
- Added `WorkoutsGetOperation` interface with typed input/output and `createWorkoutsGetOperation` factory function handling 404 errors
- Refactored Core's get-workout tool to use operations layer instead of direct client calls, removing `isExpectedReadNotFound` dependency
- Exported new workout get operation types and functions from operations index; added comprehensive unit tests for retrieval behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
