### PR TITLE
chore: enforce type-aware async linting

### DIFF
--- a/.changeset/slimy-streets-raise.md
+++ b/.changeset/slimy-streets-raise.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Enforce type-aware async function usage with Oxlint.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
 	"plugins": ["typescript", "unicorn", "oxc"],
+	"options": {
+		"typeAware": true
+	},
 	"ignorePatterns": [
 		"**/node_modules",
 		"**/dist",
@@ -23,6 +26,7 @@
 		"@typescript-eslint/consistent-type-assertions": "error",
 		"default-param-last": "error",
 		"@typescript-eslint/no-inferrable-types": "error",
+		"typescript/require-await": "error",
 		"unicorn/no-useless-fallback-in-spread": "off",
 		"unicorn/no-useless-spread": "off",
 		"no-unused-vars": [

--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -47,9 +47,9 @@ describe("mutation input sources", () => {
 			const stdin = await loadMutationInput(
 				"@-",
 				workoutInputSchema,
-				async (source) => {
+				(source) => {
 					expect(source).toBe("-");
-					return JSON.stringify(workout);
+					return Promise.resolve(JSON.stringify(workout));
 				},
 			);
 			expect(file).toEqual(inline);
@@ -60,9 +60,7 @@ describe("mutation input sources", () => {
 	});
 
 	it("reports source, JSON, and schema failures as usage errors", async () => {
-		const reader: DataSourceReader = async () => {
-			throw new Error("missing");
-		};
+		const reader: DataSourceReader = () => Promise.reject(new Error("missing"));
 		await expect(
 			loadMutationInput("@", workoutInputSchema, reader),
 		).rejects.toThrow(new UsageError("--data source is required after @"));

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -41,7 +41,7 @@ describe("registerHevyTools", () => {
 	beforeEach(async () => {
 		server = new McpServer({ name: "tool-list-test", version: "1.0.0" });
 		const catalog: ExerciseTemplateCatalog = {
-			get: async () => [],
+			get: () => Promise.resolve([]),
 			reset: () => {},
 		};
 		registerHevyTools(

--- a/packages/core/src/tools/tool-runtime.test.ts
+++ b/packages/core/src/tools/tool-runtime.test.ts
@@ -6,7 +6,7 @@ const runImmediately = <T>(operation: () => Promise<T>): Promise<T> =>
 	operation();
 
 const catalog = {
-	get: async () => [],
+	get: () => Promise.resolve([]),
 	reset: () => undefined,
 };
 
@@ -26,9 +26,9 @@ describe("createToolRuntime observation scope", () => {
 				}),
 			},
 		});
-		const handler = runtime.createHandler(async () => {
+		const handler = runtime.createHandler(() => {
 			executions += 1;
-			return { content: [{ type: "text", text: "ok" }] };
+			return Promise.resolve({ content: [{ type: "text", text: "ok" }] });
 		}, "create-workout");
 
 		await expect(handler({ id: "workout-id" })).resolves.toMatchObject({
@@ -40,9 +40,11 @@ describe("createToolRuntime observation scope", () => {
 
 	it("starts the handler lazily inside the active observer scope", async () => {
 		let active = false;
-		const handler = vi.fn(async () => {
+		const handler = vi.fn(() => {
 			expect(active).toBe(true);
-			return { content: [{ type: "text" as const, text: "ok" }] };
+			return Promise.resolve({
+				content: [{ type: "text" as const, text: "ok" }],
+			});
 		});
 		let runCalls = 0;
 		const run = async <T>(operation: () => Promise<T>): Promise<T> => {
@@ -101,7 +103,7 @@ describe("createToolRuntime observation scope", () => {
 		});
 		const secret = "private-routine-title-sentinel";
 		const handler = runtime.createHandler(
-			async () => ({ content: [] }),
+			() => Promise.resolve({ content: [] }),
 			"list-routines",
 			{ feature: "routines", kind: "read", operation: "list" },
 		);
@@ -154,7 +156,10 @@ describe("createToolRuntime observation scope", () => {
 			text: `result-${index}`,
 		}));
 
-		await runtime.createHandler(async () => ({ content }), "list-workouts")({});
+		await runtime.createHandler(
+			() => Promise.resolve({ content }),
+			"list-workouts",
+		)({});
 
 		expect(finish).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -181,9 +186,10 @@ describe("createToolRuntime observation scope", () => {
 		});
 		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
 
-		const result = await runtime.createHandler(async () => {
-			throw new Error(secret);
-		}, "get-workouts")({});
+		const result = await runtime.createHandler(
+			() => Promise.reject(new Error(secret)),
+			"get-workouts",
+		)({});
 
 		expect(result).toMatchObject({ isError: true });
 		expect(finish).toHaveBeenCalledWith(

--- a/packages/core/src/tools/workouts.test.ts
+++ b/packages/core/src/tools/workouts.test.ts
@@ -156,13 +156,13 @@ describe("workout tools", () => {
 			createWorkout: vi
 				.fn()
 				.mockResolvedValue({ id: "w1", ...workoutInput.workout }),
-			getWorkout: vi.fn().mockImplementation(async () => {
+			getWorkout: vi.fn().mockImplementation(() => {
 				calls.push("get");
-				return current;
+				return Promise.resolve(current);
 			}),
-			updateWorkout: vi.fn().mockImplementation(async () => {
+			updateWorkout: vi.fn().mockImplementation(() => {
 				calls.push("put");
-				return current;
+				return Promise.resolve(current);
 			}),
 		} as unknown as HevyClient;
 		const tool = register(client);

--- a/packages/core/src/utils/cache.test.ts
+++ b/packages/core/src/utils/cache.test.ts
@@ -49,7 +49,7 @@ describe("AsyncTtlCache", () => {
 			maxSize: 2,
 		});
 
-		const fetcher = vi.fn(async (key: string) => `${key}-value`);
+		const fetcher = vi.fn((key: string) => Promise.resolve(`${key}-value`));
 		const load = (key: string) => cache.getOrFetch(key, () => fetcher(key));
 
 		await load("a");

--- a/packages/core/src/utils/error-handler.test.ts
+++ b/packages/core/src/utils/error-handler.test.ts
@@ -225,16 +225,14 @@ describe("createErrorResponse", () => {
 describe("withErrorHandling", () => {
 	it("returns successful values unchanged", async () => {
 		const expected = { content: [{ type: "text" as const, text: "ok" }] };
-		const wrapped = withErrorHandling(async () => expected, "test");
+		const wrapped = withErrorHandling(() => Promise.resolve(expected), "test");
 		await expect(wrapped({})).resolves.toBe(expected);
 	});
 
 	it("normalizes nullish arguments and reports original failures", async () => {
 		const onError = vi.fn();
 		const wrapped = withErrorHandling(
-			async () => {
-				throw new Error("failed");
-			},
+			() => Promise.reject(new Error("failed")),
 			"test",
 			onError,
 		);
@@ -246,9 +244,7 @@ describe("withErrorHandling", () => {
 	it("does not replace normalized responses when observers fail", async () => {
 		const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const wrapped = withErrorHandling(
-			async () => {
-				throw new Error("original failure");
-			},
+			() => Promise.reject(new Error("original failure")),
 			"test",
 			() => {
 				throw new Error("observer secret");

--- a/packages/core/src/utils/pagination.test.ts
+++ b/packages/core/src/utils/pagination.test.ts
@@ -3,10 +3,12 @@ import { fetchAllPages } from "./pagination.js";
 
 describe("fetchAllPages", () => {
 	it("preserves page order and forwards the explicit page size", async () => {
-		const loader = vi.fn(async (page: number, _pageSize: number) => ({
-			items: [`page-${page}`],
-			pageCount: 3,
-		}));
+		const loader = vi.fn((page: number, _pageSize: number) =>
+			Promise.resolve({
+				items: [`page-${page}`],
+				pageCount: 3,
+			}),
+		);
 
 		await expect(fetchAllPages(loader, 10)).resolves.toEqual([
 			"page-1",
@@ -18,10 +20,12 @@ describe("fetchAllPages", () => {
 	});
 
 	it("stops when a page is empty even if the reported count keeps growing", async () => {
-		const loader = vi.fn(async (page: number) => ({
-			items: page === 1 ? ["first-page"] : [],
-			pageCount: 1_000,
-		}));
+		const loader = vi.fn((page: number) =>
+			Promise.resolve({
+				items: page === 1 ? ["first-page"] : [],
+				pageCount: 1_000,
+			}),
+		);
 
 		await expect(fetchAllPages(loader, 10)).resolves.toEqual(["first-page"]);
 		expect(loader).toHaveBeenCalledTimes(2);

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -27,21 +27,19 @@ function hangingResponse(): Response {
 
 describe("@hevy-mcp/hevy-client", () => {
 	it("uses object-form options and safely encodes requests", async () => {
-		const fetchMock = vi.fn(
-			async (input: RequestInfo | URL, init?: RequestInit) => {
-				const requestUrl =
-					input instanceof Request
-						? input.url
-						: input instanceof URL
-							? input.href
-							: input;
-				const url = new URL(requestUrl);
-				expect(url.pathname).toBe("/v1/workouts");
-				expect(url.searchParams.get("page")).toBe("2");
-				expect(new Headers(init?.headers).get("api-key")).toBe("secret-key");
-				return response({ page: 2 });
-			},
-		);
+		const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+			const requestUrl =
+				input instanceof Request
+					? input.url
+					: input instanceof URL
+						? input.href
+						: input;
+			const url = new URL(requestUrl);
+			expect(url.pathname).toBe("/v1/workouts");
+			expect(url.searchParams.get("page")).toBe("2");
+			expect(new Headers(init?.headers).get("api-key")).toBe("secret-key");
+			return Promise.resolve(response({ page: 2 }));
+		});
 
 		const client = createHevyClient({
 			apiKey: "secret-key",
@@ -280,8 +278,8 @@ describe("@hevy-mcp/hevy-client", () => {
 			releaseBody = resolve;
 		});
 		const events: string[] = [];
-		const fetchMock = vi.fn(
-			async () =>
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(
 				new Response(
 					new ReadableStream({
 						async start(controller) {
@@ -292,6 +290,7 @@ describe("@hevy-mcp/hevy-client", () => {
 					}),
 					{ status: 200 },
 				),
+			),
 		);
 		const client = createHevyClient({
 			apiKey: "secret-key",
@@ -326,8 +325,9 @@ describe("@hevy-mcp/hevy-client", () => {
 			apiKey: "secret-key",
 			fetch: fetchMock,
 			maxGetRetries: 1,
-			sleep: async (milliseconds) => {
+			sleep: (milliseconds) => {
 				waits.push(milliseconds);
+				return Promise.resolve();
 			},
 			onRequestStart: ({ retryCount }) => {
 				attempts.push(`start:${retryCount}`);
@@ -676,8 +676,9 @@ describe("@hevy-mcp/hevy-client", () => {
 				apiKey: "secret-key",
 				fetch: fetchMock,
 				maxGetRetries: 1,
-				sleep: async (delay) => {
+				sleep: (delay) => {
 					waits.push(delay);
+					return Promise.resolve();
 				},
 			});
 			await client.getUserInfo();
@@ -706,8 +707,9 @@ describe("@hevy-mcp/hevy-client", () => {
 				apiKey: "secret-key",
 				fetch: fetchMock,
 				maxGetRetries: 1,
-				sleep: async (delay) => {
+				sleep: (delay) => {
 					waits.push(delay);
+					return Promise.resolve();
 				},
 			});
 			await client.getUserInfo({ deadline: Date.now() + 30_000 });
@@ -801,7 +803,9 @@ describe("@hevy-mcp/hevy-client", () => {
 	});
 
 	it("forwards every curated operation through its generated API wrapper", async () => {
-		const fetchMock = vi.fn().mockImplementation(async () => response({}));
+		const fetchMock = vi
+			.fn()
+			.mockImplementation(() => Promise.resolve(response({})));
 		const client = createHevyClient({
 			apiKey: "secret-key",
 			fetch: fetchMock,
@@ -849,9 +853,10 @@ describe("@hevy-mcp/hevy-client", () => {
 				apiKey: "secret-key",
 				fetch: fetchMock,
 				maxGetRetries: 1,
-				sleep: async (delay) => {
+				sleep: (delay) => {
 					waits.push(delay);
 					vi.advanceTimersByTime(delay);
+					return Promise.resolve();
 				},
 			});
 			await expect(

--- a/packages/node/src/utils/graceful-shutdown.test.ts
+++ b/packages/node/src/utils/graceful-shutdown.test.ts
@@ -36,14 +36,16 @@ describe("package-local graceful shutdown", () => {
 		const events: string[] = [];
 		const controller = installGracefulShutdown({
 			target: {
-				close: vi.fn(async () => {
+				close: vi.fn(() => {
 					events.push("close");
+					return Promise.resolve();
 				}),
 			},
 			process,
 			logError: (message) => events.push(message),
-			flush: vi.fn(async () => {
+			flush: vi.fn(() => {
 				events.push("flush");
+				return Promise.resolve();
 			}),
 		});
 

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -6,14 +6,12 @@ import {
 	startStreamableHttpServer,
 } from "./streamable-http.js";
 
-const createMcpServer = async () => {
+const createMcpServer = () => {
 	const server = new McpServer({ name: "test-server", version: "1.0.0" });
-	server.registerTool(
-		"mock-tool",
-		{ description: "A mocked tool" },
-		async () => ({ content: [{ type: "text", text: "mock result" }] }),
+	server.registerTool("mock-tool", { description: "A mocked tool" }, () =>
+		Promise.resolve({ content: [{ type: "text", text: "mock result" }] }),
 	);
-	return server;
+	return Promise.resolve(server);
 };
 
 const handles: Array<{ close(): Promise<void> }> = [];
@@ -129,7 +127,7 @@ async function startDisconnectTestServer() {
 	const toolRelease = new Promise<void>((resolve) => {
 		releaseTool = resolve;
 	});
-	const createHangingServer = async () => {
+	const createHangingServer = () => {
 		const server = new McpServer({ name: "test-server", version: "1.0.0" });
 		server.registerTool(
 			"mock-tool",
@@ -140,7 +138,7 @@ async function startDisconnectTestServer() {
 				return { content: [{ type: "text", text: "mock result" }] };
 			},
 		);
-		return server;
+		return Promise.resolve(server);
 	};
 	const started = await startStreamableHttpServer(
 		{ transport: "http", host: "127.0.0.1", port: 0 },
@@ -475,7 +473,7 @@ describe("Streamable HTTP server", () => {
 		const toolStarted = new Promise<void>((resolve) => {
 			markStarted = resolve;
 		});
-		const createAbortAwareServer = async ({
+		const createAbortAwareServer = ({
 			lifecycleSignal,
 		}: {
 			apiKey: string;
@@ -496,7 +494,7 @@ describe("Streamable HTTP server", () => {
 					return { content: [{ type: "text", text: "aborted" }] };
 				},
 			);
-			return server;
+			return Promise.resolve(server);
 		};
 		const handle = await startStreamableHttpServer(
 			{ transport: "http", host: "127.0.0.1", port: 0 },
@@ -572,9 +570,7 @@ describe("Streamable HTTP server", () => {
 		const handle = await startStreamableHttpServer(
 			{ transport: "http", host: "127.0.0.1", port: 0 },
 			"test-key",
-			async () => {
-				throw new Error("private startup detail");
-			},
+			() => Promise.reject(new Error("private startup detail")),
 		);
 		handles.push(handle);
 

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -417,26 +417,30 @@ function createMemoryKV() {
 	const store = new Map<string, MemoryKVEntry>();
 	return {
 		store,
-		async get(key: string, options?: { type?: string } | string) {
+		get(key: string, options?: { type?: string } | string) {
 			const entry = store.get(key);
-			if (!entry) return null;
+			if (!entry) return Promise.resolve(null);
 			const type = typeof options === "string" ? options : options?.type;
-			return type === "json" ? JSON.parse(entry.value) : entry.value;
+			return Promise.resolve(
+				type === "json" ? JSON.parse(entry.value) : entry.value,
+			);
 		},
-		async put(key: string, value: string) {
+		put(key: string, value: string) {
 			store.set(key, { value });
+			return Promise.resolve();
 		},
-		async delete(key: string) {
+		delete(key: string) {
 			store.delete(key);
+			return Promise.resolve();
 		},
-		async list(options?: { prefix?: string }) {
+		list(options?: { prefix?: string }) {
 			const prefix = options?.prefix ?? "";
-			return {
+			return Promise.resolve({
 				keys: [...store.keys()]
 					.filter((name) => name.startsWith(prefix))
 					.map((name) => ({ name })),
 				list_complete: true,
-			};
+			});
 		},
 	};
 }
@@ -919,7 +923,7 @@ describe("OAuth-enabled Worker fetch handler", () => {
 			redirect_uris: [cimdRedirectUri],
 			token_endpoint_auth_methods_supported: ["none", "private_key_jwt"],
 		};
-		const fetchMock = vi.fn(async () => Response.json(metadata));
+		const fetchMock = vi.fn(() => Promise.resolve(Response.json(metadata)));
 		vi.stubGlobal("fetch", fetchMock);
 		const { handler, env } = createHandlerWithEnv();
 
@@ -1046,7 +1050,7 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		const redirectUri = "https://chatgpt.com/connector/oauth/test-callback";
 		vi.stubGlobal(
 			"fetch",
-			vi.fn(async () => Response.json(metadata)),
+			vi.fn(() => Promise.resolve(Response.json(metadata))),
 		);
 		const { handler, env } = createHandlerWithEnv();
 		const authorizeUrl = new URL("https://worker.example/authorize");

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -421,9 +421,14 @@ function createMemoryKV() {
 			const entry = store.get(key);
 			if (!entry) return Promise.resolve(null);
 			const type = typeof options === "string" ? options : options?.type;
-			return Promise.resolve(
-				type === "json" ? JSON.parse(entry.value) : entry.value,
-			);
+			if (type === "json") {
+				try {
+					return Promise.resolve(JSON.parse(entry.value));
+				} catch (error) {
+					return Promise.reject(error);
+				}
+			}
+			return Promise.resolve(entry.value);
 		},
 		put(key: string, value: string) {
 			store.set(key, { value });

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -899,8 +899,8 @@ describe("real stateless SDK transport", () => {
 	});
 
 	it("uses a normalized override for authentication and tool requests", async () => {
-		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
-			async () =>
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+			Promise.resolve(
 				new Response(
 					JSON.stringify({
 						page: 1,
@@ -912,6 +912,7 @@ describe("real stateless SDK transport", () => {
 						headers: { "content-type": "application/json" },
 					},
 				),
+			),
 		);
 
 		const result = await worker.fetch(

--- a/scripts/measure-token-cost.test.ts
+++ b/scripts/measure-token-cost.test.ts
@@ -367,7 +367,7 @@ describe("registered tool measurement", () => {
 		const getEncoder = vi.fn(() => ({ ...encoder, free }));
 		const report = await measureRegisteredTools({
 			getEncoder,
-			listTools: async () => [tool("alpha", "measured")],
+			listTools: () => Promise.resolve([tool("alpha", "measured")]),
 		});
 
 		expect(getEncoder).toHaveBeenCalledWith(TOKEN_ENCODING);
@@ -377,7 +377,7 @@ describe("registered tool measurement", () => {
 
 	it("instantiates and frees the configured real tokenizer", async () => {
 		const report = await measureRegisteredTools({
-			listTools: async () => [tool("alpha", "measured")],
+			listTools: () => Promise.resolve([tool("alpha", "measured")]),
 		});
 
 		expect(report).toMatchObject({
@@ -402,9 +402,7 @@ describe("registered tool measurement", () => {
 		await expect(
 			measureRegisteredTools({
 				getEncoder: () => ({ ...encoder, free }),
-				listTools: async () => {
-					throw new Error("collection failed");
-				},
+				listTools: () => Promise.reject(new Error("collection failed")),
 			}),
 		).rejects.toThrow("collection failed");
 		expect(free).toHaveBeenCalledOnce();
@@ -414,7 +412,7 @@ describe("registered tool measurement", () => {
 describe("run", () => {
 	it("prints help without measuring tools", async () => {
 		const log = vi.fn();
-		const measureTools = vi.fn(async () => reportWith());
+		const measureTools = vi.fn(() => Promise.resolve(reportWith()));
 
 		await run(["--help"], { log, measureTools });
 
@@ -428,7 +426,7 @@ describe("run", () => {
 		const current = reportWith();
 		const log = vi.fn();
 
-		await run([], { log, measureTools: async () => current });
+		await run([], { log, measureTools: () => Promise.resolve(current) });
 
 		expect(log).toHaveBeenCalledWith(formatTable(current));
 	});
@@ -452,7 +450,10 @@ describe("run", () => {
 						markdownPath,
 						"--enforce-budget",
 					],
-					{ log: vi.fn(), measureTools: async () => overBudget },
+					{
+						log: vi.fn(),
+						measureTools: () => Promise.resolve(overBudget),
+					},
 				),
 			).rejects.toThrow(
 				`MCP tool catalog exceeds the 8900-token budget: ${TOTAL_TOKEN_BUDGET + 1}`,
@@ -491,7 +492,7 @@ describe("run", () => {
 					"--markdown",
 					markdownPath,
 				],
-				{ log, measureTools: async () => current },
+				{ log, measureTools: () => Promise.resolve(current) },
 			);
 
 			expect(JSON.parse(await readFile(outputPath, "utf8"))).toEqual(current);
@@ -524,7 +525,7 @@ describe("run", () => {
 				await run(["--baseline", baselinePath, "--markdown", markdownPath], {
 					error,
 					log: vi.fn(),
-					measureTools: async () => reportWith(),
+					measureTools: () => Promise.resolve(reportWith()),
 				});
 
 				expect(error).toHaveBeenCalledWith(
@@ -554,7 +555,7 @@ describe("run", () => {
 			await run(["--baseline", baselinePath, "--markdown", markdownPath], {
 				error,
 				log: vi.fn(),
-				measureTools: async () => reportWith(),
+				measureTools: () => Promise.resolve(reportWith()),
 			});
 
 			expect(error).toHaveBeenCalledWith(
@@ -587,7 +588,7 @@ describe("run", () => {
 				await expect(
 					run([flag, outputPath], {
 						log: vi.fn(),
-						measureTools: async () => reportWith(),
+						measureTools: () => Promise.resolve(reportWith()),
 					}),
 				).rejects.toMatchObject({ code: "EEXIST" });
 				expect(await readFile(outputPath, "utf8")).toBe("keep me");
@@ -610,7 +611,7 @@ describe("run", () => {
 				await expect(
 					run(["--output", outputPath], {
 						log: vi.fn(),
-						measureTools: async () => reportWith(),
+						measureTools: () => Promise.resolve(reportWith()),
 					}),
 				).rejects.toMatchObject({ code: "EEXIST" });
 				expect(await readFile(targetPath, "utf8")).toBe("keep target");

--- a/scripts/measure-token-cost.ts
+++ b/scripts/measure-token-cost.ts
@@ -564,7 +564,7 @@ export async function listRegisteredTools(): Promise<Tool[]> {
 		createToolRuntime({
 			client: null,
 			catalog: {
-				get: async () => [],
+				get: () => Promise.resolve([]),
 				reset: () => {},
 			} satisfies ExerciseTemplateCatalog,
 		}),

--- a/tests/nightly/test_hevy_mcp.mjs
+++ b/tests/nightly/test_hevy_mcp.mjs
@@ -172,7 +172,7 @@ async function main() {
 		report("setup-or-handshake", true);
 		setupRecorded = true;
 
-		await runTest("server-info", async () => {
+		await runTest("server-info", () => {
 			assertCondition(serverInfo?.name, "$.server.name");
 			assertCondition(serverInfo?.version, "$.server.version");
 		});

--- a/tests/performance/child-fixture.mjs
+++ b/tests/performance/child-fixture.mjs
@@ -151,44 +151,45 @@ try {
 		result.expectedRequestCount += 100;
 	}
 
-	globalThis.fetch = async (input, init) => {
-		const request = input instanceof Request ? input : undefined;
-		const url = new URL(
-			request?.url ??
-				(typeof input === "string"
-					? input
-					: input instanceof URL
-						? input.href
-						: "<unsupported-fetch-input>"),
-		);
-		if (url.href === EXPECTED_UPDATE_CHECK_URL) {
-			result.blockedFetchRequests.push(url.href);
-			throw new Error("performance fixture blocked update check");
-		}
+	globalThis.fetch = (input, init) =>
+		Promise.resolve().then(() => {
+			const request = input instanceof Request ? input : undefined;
+			const url = new URL(
+				request?.url ??
+					(typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: "<unsupported-fetch-input>"),
+			);
+			if (url.href === EXPECTED_UPDATE_CHECK_URL) {
+				result.blockedFetchRequests.push(url.href);
+				throw new Error("performance fixture blocked update check");
+			}
 
-		const method = (init?.method ?? request?.method ?? "GET").toUpperCase();
-		const headers = new Headers(init?.headers ?? request?.headers);
-		const requestDescription = `${method} ${url.href}`;
-		if (url.origin !== API_BASE || headers.get("api-key") !== API_KEY) {
-			result.unexpectedRequests.push(requestDescription);
-			throw new Error("performance fixture blocked unexpected fetch");
-		}
+			const method = (init?.method ?? request?.method ?? "GET").toUpperCase();
+			const headers = new Headers(init?.headers ?? request?.headers);
+			const requestDescription = `${method} ${url.href}`;
+			if (url.origin !== API_BASE || headers.get("api-key") !== API_KEY) {
+				result.unexpectedRequests.push(requestDescription);
+				throw new Error("performance fixture blocked unexpected fetch");
+			}
 
-		const index = expectedRequests.findIndex(
-			(expected) =>
-				expected.method === method && expected.path === url.pathname,
-		);
-		if (index === -1) {
-			result.unexpectedRequests.push(requestDescription);
-			throw new Error("performance fixture received an unexpected fetch");
-		}
+			const index = expectedRequests.findIndex(
+				(expected) =>
+					expected.method === method && expected.path === url.pathname,
+			);
+			if (index === -1) {
+				result.unexpectedRequests.push(requestDescription);
+				throw new Error("performance fixture received an unexpected fetch");
+			}
 
-		const [{ body }] = expectedRequests.splice(index, 1);
-		return new Response(JSON.stringify(body()), {
-			status: 200,
-			headers: { "content-type": "application/json" },
+			const [{ body }] = expectedRequests.splice(index, 1);
+			return new Response(JSON.stringify(body()), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
 		});
-	};
 } catch (error) {
 	result.setupFailure = error instanceof Error ? error.message : String(error);
 	process.exitCode = 1;

--- a/tests/unit/performance-harness.test.ts
+++ b/tests/unit/performance-harness.test.ts
@@ -135,8 +135,9 @@ describe("server RSS observations", () => {
 describe("performance harness helpers", () => {
 	it("creates and closes a fixture-backed client harness", async () => {
 		resetHarnessMocks();
-		harnessMocks.client.connect.mockImplementation(async () => {
+		harnessMocks.client.connect.mockImplementation(() => {
 			emitFixtureMarker();
+			return Promise.resolve();
 		});
 
 		const harness = await createPerformanceHarness("startup");
@@ -160,8 +161,9 @@ describe("performance harness helpers", () => {
 
 	it("detects a fixture marker split across stderr chunks", async () => {
 		resetHarnessMocks();
-		harnessMocks.client.connect.mockImplementation(async () => {
+		harnessMocks.client.connect.mockImplementation(() => {
 			emitSplitFixtureMarker();
+			return Promise.resolve();
 		});
 
 		const harness = await createPerformanceHarness("startup");
@@ -174,9 +176,9 @@ describe("performance harness helpers", () => {
 
 	it("includes fixture diagnostics when client initialization fails", async () => {
 		resetHarnessMocks();
-		harnessMocks.client.connect.mockImplementation(async () => {
+		harnessMocks.client.connect.mockImplementation(() => {
 			emitFixtureMarker();
-			throw new Error("connection refused");
+			return Promise.reject(new Error("connection refused"));
 		});
 
 		await expect(createPerformanceHarness("startup")).rejects.toThrow(


### PR DESCRIPTION
## Summary
- enable Oxlint type-aware mode and `typescript/require-await`
- remove unnecessary async wrappers from existing callbacks and mocks
- add a Changeset for the package validation change

## Validation
- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run test:unit`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Enforce stricter, type-aware async usage across the codebase and align tests and fixtures with the updated linting rules.

Enhancements:
- Normalize async behavior in tests and helpers by replacing unnecessary async wrappers with functions that return explicit Promises or synchronous values.
- Adjust in-memory stores, tool runtimes, pagination, caching, and shutdown utilities in tests to use Promise-returning callbacks consistent with type-aware async contracts.

Documentation:
- Add a Changeset documenting the type-aware async enforcement across packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added type-aware linting to enforce consistent asynchronous function usage.

- **Bug Fixes**
  - Improved asynchronous test and performance fixtures to accurately model resolved and rejected promises.
  - Updated in-memory service mocks to match asynchronous runtime interfaces.
  - Preserved existing request, retry, shutdown, pagination, and error-handling behavior.

- **Chores**
  - Prepared patch releases for the Hevy-related packages.
  - Updated nightly, unit, and integration test coverage without changing expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enforce type-aware async linting by enabling Oxlint's typeAware option and requiring explicit await usage in async functions across the codebase.

Main changes:
- Enabled typeAware linting in .oxlintrc.json and added typescript/require-await error rule
- Refactored async functions to use Promise.resolve() explicitly instead of implicit async returns throughout test files
- Converted unnecessary async functions to synchronous functions returning Promise chains where no await statements exist

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
