### PR TITLE
fix: reduce false-positive MCP Sentry issues

### DIFF
--- a/.changeset/fix-recent-sentry-workout-errors.md
+++ b/.changeset/fix-recent-sentry-workout-errors.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Normalize ISO timestamp variants returned by Hevy before workout updates and keep expected MCP caller validation failures out of Sentry issues.

--- a/packages/core/src/tools/mutation-semantics.test.ts
+++ b/packages/core/src/tools/mutation-semantics.test.ts
@@ -262,6 +262,23 @@ describe("mutation semantics", () => {
 		expect(payload).not.toHaveProperty("is_private");
 	});
 
+	it("normalizes ISO timestamp variants returned by Hevy", () => {
+		const payload = buildWorkoutUpdatePayload(
+			{
+				title: "Original",
+				start_time: "2026-07-29T08:00:00.123Z",
+				end_time: "2026-07-29T11:00:00+02:00",
+				exercises: [],
+			},
+			{ title: "Renamed" },
+		);
+
+		expect(payload).toMatchObject({
+			start_time: "2026-07-29T08:00:00Z",
+			end_time: "2026-07-29T09:00:00Z",
+		});
+	});
+
 	it("replaces or removes exercises without requiring fetched exercises", () => {
 		const current = {
 			title: "Original",

--- a/packages/core/src/tools/mutation-semantics.test.ts
+++ b/packages/core/src/tools/mutation-semantics.test.ts
@@ -277,6 +277,54 @@ describe("mutation semantics", () => {
 			start_time: "2026-07-29T08:00:00Z",
 			end_time: "2026-07-29T09:00:00Z",
 		});
+		expect(
+			buildWorkoutUpdatePayload(
+				{
+					title: "Original",
+					start_time: "2026-07-29T08:00:00.000Z",
+					end_time: "2026-07-29T09:00:00Z",
+					exercises: [],
+				},
+				{ title: "Renamed" },
+			).start_time,
+		).toBe("2026-07-29T08:00:00Z");
+	});
+
+	it("rejects malformed fetched timestamps instead of relying on Date parsing", () => {
+		for (const start_time of [
+			"2026-02-30T08:00:00Z",
+			"0",
+			"2026-07-29T08:00:00",
+		]) {
+			expect(() =>
+				buildWorkoutUpdatePayload(
+					{
+						title: "Original",
+						start_time,
+						end_time: "2026-07-29T09:00:00Z",
+						exercises: [],
+					},
+					{ title: "Renamed" },
+				),
+			).toThrow();
+		}
+	});
+
+	it("keeps caller-supplied timestamps strict", () => {
+		expect(() =>
+			buildWorkoutUpdatePayload(
+				{
+					title: "Original",
+					start_time: "2026-07-29T08:00:00Z",
+					end_time: "2026-07-29T09:00:00Z",
+					exercises: [],
+				},
+				{
+					title: "Renamed",
+					start_time: "2026-07-29T08:00:00.123Z",
+				},
+			),
+		).toThrow();
 	});
 
 	it("replaces or removes exercises without requiring fetched exercises", () => {

--- a/packages/core/src/tools/mutation-semantics.ts
+++ b/packages/core/src/tools/mutation-semantics.ts
@@ -191,13 +191,6 @@ function normalizeFetchedWorkoutTimestamp(value: unknown): unknown {
 	const offsetHour = offset === "Z" ? 0 : Number(offset.slice(1, 3));
 	const offsetMinute = offset === "Z" ? 0 : Number(offset.slice(4, 6));
 	if (
-		!year ||
-		!month ||
-		!day ||
-		!hour ||
-		!minute ||
-		!second ||
-		!offset ||
 		numericMonth < 1 ||
 		numericMonth > 12 ||
 		numericDay < 1 ||

--- a/packages/core/src/tools/mutation-semantics.ts
+++ b/packages/core/src/tools/mutation-semantics.ts
@@ -168,17 +168,63 @@ const workoutUpdateMetadataSchema = z.object({
 	end_time: utcSecondTimestamp,
 });
 
+const FETCHED_ISO_TIMESTAMP =
+	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/u;
+
 /**
  * Hevy documents ISO 8601 timestamps but can return millisecond or offset
- * variants. Normalize fetched values before reusing them in the API's
- * second-precision update contract. Caller-supplied values remain strict.
+ * variants. Normalize only those explicit-timezone variants before reusing
+ * fetched values in the API's second-precision update contract. Caller-
+ * supplied values remain strict.
  */
 function normalizeFetchedWorkoutTimestamp(value: unknown): unknown {
 	if (typeof value !== "string") return value;
+	const match = FETCHED_ISO_TIMESTAMP.exec(value);
+	if (!match) return value;
+
+	const [, year, month, day, hour, minute, second, offset] = match;
+	const numericMonth = Number(month);
+	const numericDay = Number(day);
+	const numericHour = Number(hour);
+	const numericMinute = Number(minute);
+	const numericSecond = Number(second);
+	const offsetHour = offset === "Z" ? 0 : Number(offset.slice(1, 3));
+	const offsetMinute = offset === "Z" ? 0 : Number(offset.slice(4, 6));
+	if (
+		!year ||
+		!month ||
+		!day ||
+		!hour ||
+		!minute ||
+		!second ||
+		!offset ||
+		numericMonth < 1 ||
+		numericMonth > 12 ||
+		numericDay < 1 ||
+		numericDay > 31 ||
+		numericHour > 23 ||
+		numericMinute > 59 ||
+		numericSecond > 59 ||
+		offsetHour > 23 ||
+		offsetMinute > 59
+	) {
+		return value;
+	}
+
+	const calendarDate = new Date(`${year}-${month}-${day}T00:00:00.000Z`);
+	if (
+		Number.isNaN(calendarDate.getTime()) ||
+		calendarDate.getUTCFullYear() !== Number(year) ||
+		calendarDate.getUTCMonth() !== numericMonth - 1 ||
+		calendarDate.getUTCDate() !== numericDay
+	) {
+		return value;
+	}
+
 	const timestamp = new Date(value);
 	if (Number.isNaN(timestamp.getTime())) return value;
 	timestamp.setUTCMilliseconds(0);
-	return timestamp.toISOString().replace(".000Z", "Z");
+	return `${timestamp.toISOString().slice(0, 19)}Z`;
 }
 
 /**

--- a/packages/core/src/tools/mutation-semantics.ts
+++ b/packages/core/src/tools/mutation-semantics.ts
@@ -169,6 +169,19 @@ const workoutUpdateMetadataSchema = z.object({
 });
 
 /**
+ * Hevy documents ISO 8601 timestamps but can return millisecond or offset
+ * variants. Normalize fetched values before reusing them in the API's
+ * second-precision update contract. Caller-supplied values remain strict.
+ */
+function normalizeFetchedWorkoutTimestamp(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	const timestamp = new Date(value);
+	if (Number.isNaN(timestamp.getTime())) return value;
+	timestamp.setUTCMilliseconds(0);
+	return timestamp.toISOString().replace(".000Z", "Z");
+}
+
+/**
  * Map fetched API exercises to the update shape without validating legacy data.
  * Caller-supplied replacement exercises are still validated by their input schema.
  */
@@ -204,8 +217,13 @@ export function buildWorkoutUpdatePayload(
 	const metadata = workoutUpdateMetadataSchema.parse({
 		title: patch.title !== undefined ? patch.title : current.title,
 		start_time:
-			patch.start_time !== undefined ? patch.start_time : current.start_time,
-		end_time: patch.end_time !== undefined ? patch.end_time : current.end_time,
+			patch.start_time !== undefined
+				? patch.start_time
+				: normalizeFetchedWorkoutTimestamp(current.start_time),
+		end_time:
+			patch.end_time !== undefined
+				? patch.end_time
+				: normalizeFetchedWorkoutTimestamp(current.end_time),
 	});
 
 	return {

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -363,6 +363,7 @@ describe("Node package entrypoint", () => {
 			.spyOn(trace, "getActiveSpan")
 			.mockReturnValue(testDoubles.span as never);
 		testDoubles.captureFailure.mockClear();
+		testDoubles.span.setStatus.mockClear();
 		testDoubles.server.createToolError?.(
 			"Input validation error: Invalid arguments for tool get-workouts",
 		);
@@ -374,7 +375,7 @@ describe("Node package entrypoint", () => {
 			expect.objectContaining({
 				expected: true,
 				attributes: expect.objectContaining({
-					"mcp.tool.name": "unknown",
+					"mcp.tool.name": "get-workouts",
 					"mcp.validation.kind": "input",
 				}),
 			}),
@@ -385,11 +386,45 @@ describe("Node package entrypoint", () => {
 			expect.objectContaining({
 				expected: true,
 				attributes: expect.objectContaining({
-					"mcp.tool.name": "unknown",
+					"mcp.tool.name": "get-workout-by-id",
 					"mcp.validation.kind": "tool_not_found",
 				}),
 			}),
 		);
+		expect(testDoubles.span.setStatus).not.toHaveBeenCalledWith({
+			code: SpanStatusCode.ERROR,
+		});
+		activeSpanSpy.mockRestore();
+	});
+
+	it("keeps expected SDK result spans out of error status", async () => {
+		const createToolError = vi.fn((message: string) => ({ message }));
+		testDoubles.server.createToolError = createToolError;
+		testDoubles.sdkProtocol._requestHandlers.set(
+			"tools/call",
+			vi.fn().mockImplementation(async () => {
+				testDoubles.server.createToolError?.(
+					"Input validation error: Invalid arguments for tool get-workouts",
+				);
+				return { isError: true };
+			}),
+		);
+		await createNodeMcpServer({ apiKey: "valid-key" });
+
+		const wrappedToolHandler =
+			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
+		if (!wrappedToolHandler) return;
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
+		testDoubles.span.setStatus.mockClear();
+
+		await expect(
+			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
+		).resolves.toEqual({ isError: true });
+		expect(testDoubles.span.setStatus).not.toHaveBeenCalledWith({
+			code: SpanStatusCode.ERROR,
+		});
 		activeSpanSpy.mockRestore();
 	});
 

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -339,8 +339,57 @@ describe("Node package entrypoint", () => {
 			}),
 		);
 		expect(testDoubles.captureFailure).toHaveBeenCalled();
+		expect(testDoubles.captureFailure).toHaveBeenCalledWith(
+			expect.any(Error),
+			expect.objectContaining({
+				expected: false,
+				attributes: expect.objectContaining({
+					"mcp.tool.name": "unknown",
+					"mcp.validation.kind": "unknown",
+				}),
+			}),
+		);
 		expect(createToolError).toHaveBeenCalledWith("invalid tool");
 		expect(previousOnError).toHaveBeenCalledTimes(2);
+		activeSpanSpy.mockRestore();
+	});
+
+	it("does not report expected SDK caller errors as Sentry issues", async () => {
+		const createToolError = vi.fn((message: string) => ({ message }));
+		testDoubles.server.createToolError = createToolError;
+		await createNodeMcpServer({ apiKey: "valid-key" });
+
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
+		testDoubles.captureFailure.mockClear();
+		testDoubles.server.createToolError?.(
+			"Input validation error: Invalid arguments for tool get-workouts",
+		);
+		testDoubles.server.createToolError?.("Tool get-workout-by-id not found");
+
+		expect(testDoubles.captureFailure).toHaveBeenNthCalledWith(
+			1,
+			expect.any(Error),
+			expect.objectContaining({
+				expected: true,
+				attributes: expect.objectContaining({
+					"mcp.tool.name": "unknown",
+					"mcp.validation.kind": "input",
+				}),
+			}),
+		);
+		expect(testDoubles.captureFailure).toHaveBeenNthCalledWith(
+			2,
+			expect.any(Error),
+			expect.objectContaining({
+				expected: true,
+				attributes: expect.objectContaining({
+					"mcp.tool.name": "unknown",
+					"mcp.validation.kind": "tool_not_found",
+				}),
+			}),
+		);
 		activeSpanSpy.mockRestore();
 	});
 

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -402,7 +402,7 @@ describe("Node package entrypoint", () => {
 		testDoubles.server.createToolError = createToolError;
 		testDoubles.sdkProtocol._requestHandlers.set(
 			"tools/call",
-			vi.fn().mockImplementation(async () => {
+			vi.fn().mockImplementation(() => {
 				testDoubles.server.createToolError?.(
 					"Input validation error: Invalid arguments for tool get-workouts",
 				);

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -29,6 +29,12 @@ interface ToolResultLike {
 
 type FailureAttributes = Record<string, string | number | boolean>;
 type SdkFailureKind = "protocol" | "tool_call" | "validation";
+type SdkValidationKind = "input" | "output" | "tool_not_found" | "unknown";
+
+type SdkFailureOptions = {
+	expected?: boolean;
+	validationKind?: SdkValidationKind;
+};
 
 const sdkToolNameStorage = new AsyncLocalStorage<string>();
 const SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
@@ -94,20 +100,29 @@ function markSdkToolFailure(
 	error: unknown,
 	toolName = sdkToolNameStorage.getStore() ?? "unknown",
 	kind: SdkFailureKind = "tool_call",
+	options: SdkFailureOptions = {},
 ): void {
 	const taxonomy = SDK_FAILURE_TAXONOMY[kind];
-	const attributes = createFailureAttributes(
-		error,
-		"sdk",
-		taxonomy.errorType,
-		taxonomy.errorCategory,
-	);
-	span.addEvent("mcp.tool.failure", {
+	const attributes: FailureAttributes = {
 		"mcp.tool.name": toolName,
-		...attributes,
-	});
+		...createFailureAttributes(
+			error,
+			"sdk",
+			taxonomy.errorType,
+			taxonomy.errorCategory,
+		),
+		...(options.validationKind
+			? { "mcp.validation.kind": options.validationKind }
+			: {}),
+	};
+	span.addEvent("mcp.tool.failure", attributes);
 	span.setAttribute("error.type", taxonomy.errorType);
-	captureFailure(error, { kind: "sdk", attributes, span });
+	captureFailure(error, {
+		kind: "sdk",
+		attributes,
+		span,
+		expected: options.expected,
+	});
 	span.setStatus({ code: SpanStatusCode.ERROR });
 }
 
@@ -166,6 +181,22 @@ function installProtocolErrorTracking(
 	};
 }
 
+function classifySdkValidation(message: string): {
+	kind: SdkValidationKind;
+	expected: boolean;
+} {
+	if (message.startsWith("Input validation error:")) {
+		return { kind: "input", expected: true };
+	}
+	if (message.startsWith("Output validation error:")) {
+		return { kind: "output", expected: false };
+	}
+	if (message.startsWith("Tool ") && message.endsWith(" not found")) {
+		return { kind: "tool_not_found", expected: true };
+	}
+	return { kind: "unknown", expected: false };
+}
+
 function installValidationErrorTracking(server: object): void {
 	const toolErrorHost = server as SdkToolErrorHost;
 	const previousCreateToolError = toolErrorHost.createToolError;
@@ -175,11 +206,20 @@ function installValidationErrorTracking(server: object): void {
 		const result = createToolError(message);
 		const activeSpan = trace.getActiveSpan();
 		if (activeSpan) {
+			const validation = classifySdkValidation(message);
 			markSdkToolFailure(
 				activeSpan,
-				new Error("MCP tool validation failed"),
-				undefined,
+				new Error(
+					validation.kind === "output"
+						? "MCP tool output validation failed"
+						: "MCP tool validation failed",
+				),
+				sdkToolNameStorage.getStore() ?? "unknown",
 				"validation",
+				{
+					expected: validation.expected,
+					validationKind: validation.kind,
+				},
 			);
 		}
 		return result;

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -37,6 +37,9 @@ type SdkFailureOptions = {
 };
 
 const sdkToolNameStorage = new AsyncLocalStorage<string>();
+const sdkRequestStateStorage = new AsyncLocalStorage<{
+	expectedValidation?: boolean;
+}>();
 const SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
 const SDK_FAILURE_TAXONOMY: Record<
 	SdkFailureKind,
@@ -123,7 +126,9 @@ function markSdkToolFailure(
 		span,
 		expected: options.expected,
 	});
-	span.setStatus({ code: SpanStatusCode.ERROR });
+	if (options.expected !== true) {
+		span.setStatus({ code: SpanStatusCode.ERROR });
+	}
 }
 
 function installProtocolErrorTracking(
@@ -184,15 +189,33 @@ function installProtocolErrorTracking(
 function classifySdkValidation(message: string): {
 	kind: SdkValidationKind;
 	expected: boolean;
+	toolName?: string;
 } {
+	const inputValidation =
+		/^Input validation error: Invalid arguments for tool ([A-Za-z0-9][A-Za-z0-9._-]{0,63})(?::|$)/u.exec(
+			message,
+		);
+	if (inputValidation) {
+		return {
+			kind: "input",
+			expected: true,
+			toolName: inputValidation[1],
+		};
+	}
 	if (message.startsWith("Input validation error:")) {
 		return { kind: "input", expected: true };
 	}
 	if (message.startsWith("Output validation error:")) {
 		return { kind: "output", expected: false };
 	}
-	if (message.startsWith("Tool ") && message.endsWith(" not found")) {
-		return { kind: "tool_not_found", expected: true };
+	const missingTool =
+		/^Tool ([A-Za-z0-9][A-Za-z0-9._-]{0,63}) not found$/u.exec(message);
+	if (missingTool) {
+		return {
+			kind: "tool_not_found",
+			expected: true,
+			toolName: missingTool[1],
+		};
 	}
 	return { kind: "unknown", expected: false };
 }
@@ -203,10 +226,12 @@ function installValidationErrorTracking(server: object): void {
 	if (!previousCreateToolError) return;
 	const createToolError = previousCreateToolError.bind(server);
 	toolErrorHost.createToolError = (message) => {
+		const validation = classifySdkValidation(message);
+		const requestState = sdkRequestStateStorage.getStore();
+		if (requestState) requestState.expectedValidation = validation.expected;
 		const result = createToolError(message);
 		const activeSpan = trace.getActiveSpan();
 		if (activeSpan) {
-			const validation = classifySdkValidation(message);
 			markSdkToolFailure(
 				activeSpan,
 				new Error(
@@ -214,7 +239,7 @@ function installValidationErrorTracking(server: object): void {
 						? "MCP tool output validation failed"
 						: "MCP tool validation failed",
 				),
-				sdkToolNameStorage.getStore() ?? "unknown",
+				sdkToolNameStorage.getStore() ?? validation.toolName ?? "unknown",
 				"validation",
 				{
 					expected: validation.expected,
@@ -259,29 +284,35 @@ function installToolCallTracking(
 		};
 		enrichActiveSdkSpan(attributes);
 		return sdkToolNameStorage.run(toolName, () =>
-			tracer.startActiveSpan(
-				"mcp.sdk.tools.call",
-				{ attributes },
-				async (span) => {
-					try {
-						const result = (await toolHandler(
-							request,
-							extra,
-						)) as ToolResultLike;
-						if (result?.isError === true) {
-							span.setAttribute("mcp.tool.outcome", "returned_error");
-							span.setStatus({ code: SpanStatusCode.ERROR });
-						} else {
-							span.setStatus({ code: SpanStatusCode.OK });
+			sdkRequestStateStorage.run({}, () =>
+				tracer.startActiveSpan(
+					"mcp.sdk.tools.call",
+					{ attributes },
+					async (span) => {
+						try {
+							const result = (await toolHandler(
+								request,
+								extra,
+							)) as ToolResultLike;
+							if (result?.isError === true) {
+								span.setAttribute("mcp.tool.outcome", "returned_error");
+								if (
+									sdkRequestStateStorage.getStore()?.expectedValidation !== true
+								) {
+									span.setStatus({ code: SpanStatusCode.ERROR });
+								}
+							} else {
+								span.setStatus({ code: SpanStatusCode.OK });
+							}
+							return result;
+						} catch (error) {
+							markSdkToolFailure(span, error, toolName);
+							throw error;
+						} finally {
+							span.end();
 						}
-						return result;
-					} catch (error) {
-						markSdkToolFailure(span, error, toolName);
-						throw error;
-					} finally {
-						span.end();
-					}
-				},
+					},
+				),
 			),
 		);
 	});


### PR DESCRIPTION
## Summary
- normalize millisecond/offset ISO timestamps returned by Hevy before workout updates
- classify SDK validation failures and include the MCP tool name in telemetry
- keep expected invalid-input and unknown-tool calls out of Sentry issue creation

## Sentry findings
- prevents recurring `update-workout`/`replace-workout-exercises` timestamp failures
- reduces noise from obsolete tool names and caller-side validation errors
- leaves output-validation failures and genuine API failures reportable

## Validation
- `npm run check`
- `npm run check:types`
- `npm run test:pr`
- `npm run test:performance`
- `npm run check:changeset`

## Summary by Sourcery

Reduce false-positive MCP Sentry issues by normalizing Hevy workout timestamps and classifying SDK validation failures as expected or reportable.

New Features:
- Normalize ISO 8601 timestamp variants returned by Hevy before constructing workout update payloads.
- Tag SDK validation failures with a specific validation kind and expected flag in telemetry.

Bug Fixes:
- Prevent recurring workout update failures caused by millisecond and offset ISO timestamps from Hevy.
- Avoid creating Sentry issues for expected MCP caller-side input validation errors and unknown tools.

Enhancements:
- Include the MCP tool name and validation classification in SDK failure telemetry events to improve observability.

Tests:
- Add tests covering timestamp normalization behavior for workout updates and expected vs unknown SDK validation failure reporting.

Chores:
- Add a changeset documenting the timestamp normalization and Sentry noise reduction changes across affected packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workout update reliability by normalizing timestamps to UTC with consistent second-level precision.
  - Preserved valid caller-provided timestamps while safely handling invalid or unexpected timestamp values.
  - Reduced monitoring noise by distinguishing expected validation failures from unexpected errors.
  - Added clearer classification for invalid inputs, outputs, missing tools, and other validation issues.
  - Prevented expected tool and validation errors from being incorrectly marked as monitoring failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Reduce false-positive Sentry issues by normalizing ISO 8601 timestamp variants and classifying expected MCP validation failures.

Main changes:
- Added `normalizeFetchedWorkoutTimestamp()` function to standardize millisecond/offset ISO variants before API updates
- Introduced `classifySdkValidation()` to categorize validation errors as expected/unexpected with detailed kind attributes
- Enhanced `markSdkToolFailure()` to accept validation classification options for selective Sentry reporting

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
