### PR TITLE
fix(worker): support Claude CIMD metadata

### DIFF
--- a/.changeset/issue-942-cimd-compatibility.md
+++ b/.changeset/issue-942-cimd-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@hevy-mcp/worker": patch
+---
+
+Fix Claude OAuth compatibility by accepting CIMD documents that advertise optional unsupported grant types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@changesets/changelog-github": "^0.7.0",
 				"@changesets/cli": "3.0.0-next.11",
 				"@cloudflare/vitest-pool-workers": "^0.20.2",
-				"@cloudflare/workers-oauth-provider": "^0.10.0",
+				"@cloudflare/workers-oauth-provider": "^0.10.2",
 				"@codecov/rollup-plugin": "^2.0.1",
 				"@commitlint/cli": "^21.2.1",
 				"@commitlint/config-conventional": "^21.2.0",
@@ -1002,9 +1002,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-oauth-provider": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.0.tgz",
-			"integrity": "sha512-hH9AHhhQ47z9u5enEnWkYb1CucKNWRdE9NdCHpbiWTy7U0LrkaSCb13cefKqhVz1hEVji38/eCA/H+bNxgTvAQ==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.2.tgz",
+			"integrity": "sha512-3yWtnPaZyNaiLuv9tWkWfEyqbILFsvfG0Q5RwZGJ2jkSkrOMM8IxKYaGCFakSGbMXmatvyrhFDCDZ70S6TVnqQ==",
 			"license": "MIT"
 		},
 		"node_modules/@codecov/bundler-plugin-core": {
@@ -14055,7 +14055,7 @@
 			"name": "@hevy-mcp/worker",
 			"version": "0.1.1",
 			"dependencies": {
-				"@cloudflare/workers-oauth-provider": "^0.10.0",
+				"@cloudflare/workers-oauth-provider": "^0.10.2",
 				"@modelcontextprotocol/server": "^2.0.0",
 				"zod": "^4.4.3"
 			},

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"@changesets/changelog-github": "^0.7.0",
 		"@changesets/cli": "3.0.0-next.11",
 		"@cloudflare/vitest-pool-workers": "^0.20.2",
-		"@cloudflare/workers-oauth-provider": "^0.10.0",
+		"@cloudflare/workers-oauth-provider": "^0.10.2",
 		"@codecov/rollup-plugin": "^2.0.1",
 		"@commitlint/cli": "^21.2.1",
 		"@commitlint/config-conventional": "^21.2.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -14,7 +14,7 @@
 		"check:types": "tsc --noEmit -p tsconfig.json"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.10.0",
+		"@cloudflare/workers-oauth-provider": "^0.10.2",
 		"@modelcontextprotocol/server": "^2.0.0",
 		"zod": "^4.4.3"
 	},

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -935,11 +935,22 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		const fetchMock = vi.fn(() => Promise.resolve(Response.json(metadata)));
 		vi.stubGlobal("fetch", fetchMock);
 		const { handler, env } = createHandlerWithEnv();
+		const verifier = base64UrlEncode(
+			crypto.getRandomValues(new Uint8Array(32)),
+		);
+		const challenge = base64UrlEncode(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
 		const authorizeUrl = new URL("https://worker.example/authorize");
 		authorizeUrl.searchParams.set("response_type", "code");
 		authorizeUrl.searchParams.set("client_id", clientId);
 		authorizeUrl.searchParams.set("redirect_uri", redirectUri);
-		authorizeUrl.searchParams.set("code_challenge", "claude-s256-challenge");
+		authorizeUrl.searchParams.set("code_challenge", challenge);
 		authorizeUrl.searchParams.set("code_challenge_method", "S256");
 		authorizeUrl.searchParams.set("state", "claude-state");
 		authorizeUrl.searchParams.set("scope", "mcp");
@@ -947,12 +958,21 @@ describe("OAuth-enabled Worker fetch handler", () => {
 
 		const result = await handler(new Request(authorizeUrl), env, {});
 
-		// This is the expected behavior. With workers-oauth-provider 0.10.0,
-		// the optional JWT grant is rejected before the consent page renders,
-		// so this test reproduces issue #942 until the provider is upgraded.
+		// Regression coverage for issue #942: provider 0.10.0 rejected
+		// Claude's optional JWT grant; 0.10.2 negotiates it away and renders
+		// the consent page.
 		expect(result.status).toBe(200);
 		expect(await result.text()).toContain("Claude");
 		expect(fetchMock).toHaveBeenCalled();
+		for (const [input] of fetchMock.mock.calls) {
+			const requestedUrl =
+				input instanceof Request
+					? input.url
+					: input instanceof URL
+						? input.href
+						: input;
+			expect(requestedUrl).toBe(clientId);
+		}
 	});
 
 	it("completes the CIMD OAuth flow and serves MCP requests", async () => {

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -932,7 +932,9 @@ describe("OAuth-enabled Worker fetch handler", () => {
 			response_types: ["code"],
 			token_endpoint_auth_method: "none",
 		};
-		const fetchMock = vi.fn(() => Promise.resolve(Response.json(metadata)));
+		const fetchMock = vi.fn((_input: RequestInfo | URL) =>
+			Promise.resolve(Response.json(metadata)),
+		);
 		vi.stubGlobal("fetch", fetchMock);
 		const { handler, env } = createHandlerWithEnv();
 		const verifier = base64UrlEncode(

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -917,6 +917,44 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		expect(rejected.status).toBe(401);
 	});
 
+	it("accepts Claude's published CIMD metadata with an optional JWT grant", async () => {
+		const clientId = "https://claude.ai/oauth/mcp-oauth-client-metadata";
+		const metadata = {
+			client_id: clientId,
+			client_name: "Claude",
+			client_uri: "https://claude.ai",
+			redirect_uris: [redirectUri],
+			grant_types: [
+				"authorization_code",
+				"refresh_token",
+				"urn:ietf:params:oauth:grant-type:jwt-bearer",
+			],
+			response_types: ["code"],
+			token_endpoint_auth_method: "none",
+		};
+		const fetchMock = vi.fn(() => Promise.resolve(Response.json(metadata)));
+		vi.stubGlobal("fetch", fetchMock);
+		const { handler, env } = createHandlerWithEnv();
+		const authorizeUrl = new URL("https://worker.example/authorize");
+		authorizeUrl.searchParams.set("response_type", "code");
+		authorizeUrl.searchParams.set("client_id", clientId);
+		authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+		authorizeUrl.searchParams.set("code_challenge", "claude-s256-challenge");
+		authorizeUrl.searchParams.set("code_challenge_method", "S256");
+		authorizeUrl.searchParams.set("state", "claude-state");
+		authorizeUrl.searchParams.set("scope", "mcp");
+		authorizeUrl.searchParams.set("resource", "https://worker.example/mcp");
+
+		const result = await handler(new Request(authorizeUrl), env, {});
+
+		// This is the expected behavior. With workers-oauth-provider 0.10.0,
+		// the optional JWT grant is rejected before the consent page renders,
+		// so this test reproduces issue #942 until the provider is upgraded.
+		expect(result.status).toBe(200);
+		expect(await result.text()).toContain("Claude");
+		expect(fetchMock).toHaveBeenCalled();
+	});
+
 	it("completes the CIMD OAuth flow and serves MCP requests", async () => {
 		const clientId = "https://chatgpt.com/oauth/hevy-mcp/client.json";
 		const cimdRedirectUri = "https://chatgpt.com/connector/oauth/test-callback";


### PR DESCRIPTION
## Summary

- Upgrade `@cloudflare/workers-oauth-provider` to `0.10.2`.
- Add a regression test using Claude's published Client ID Metadata Document.
- Add a patch changeset for `@hevy-mcp/worker`.

## Root cause

Claude's CIMD advertises `authorization_code`, `refresh_token`, and the optional `urn:ietf:params:oauth:grant-type:jwt-bearer` capability. Provider `0.10.0` strictly rejected the unsupported JWT grant before rendering `/authorize`, producing the reported `400 Invalid authorization request`. Provider `0.10.2` negotiates unsupported optional CIMD capabilities away while retaining the supported authorization-code flow.

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run build`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`
- `mise exec -- npx vitest run packages/worker/src/worker-oauth.test.ts`

## Summary by Sourcery

Upgrade the OAuth provider dependency to restore compatibility with Claude’s CIMD-based OAuth flow and document the change as a patch release.

Enhancements:
- Update @cloudflare/workers-oauth-provider to version 0.10.2 in the root project and worker package to support negotiation of optional unsupported grant types.

Tests:
- Add a regression test ensuring Claude’s published CIMD metadata with an optional JWT grant type is accepted and the authorization flow proceeds successfully.

Chores:
- Add a patch changeset for @hevy-mcp/worker describing the Claude OAuth compatibility fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude OAuth compatibility when client metadata includes optional, unsupported grant types.
  * Authorization requests using PKCE, scopes, and resource parameters now complete successfully in this scenario.

* **Tests**
  * Added regression coverage for Claude’s published client metadata and consent-page rendering.

* **Chores**
  * Updated the OAuth provider component to the latest compatible patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Upgrade workers-oauth-provider to support Claude's CIMD metadata with optional JWT grant type support.

Main changes:
- Updated @cloudflare/workers-oauth-provider from ^0.10.0 to ^0.10.2 in root and worker package dependencies
- Added test case validating Claude CIMD metadata acceptance with JWT-bearer optional grant type

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
