### PR TITLE
feat: add Claude plugin integration

### DIFF
--- a/.changeset/claude-plugin.md
+++ b/.changeset/claude-plugin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Claude plugin metadata, a hosted OAuth connector, and a Hevy workflow skill.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+	"name": "hevy-mcp",
+	"version": "1.0.0",
+	"description": "Read, analyze, create, and update Hevy workouts, routines, exercises, and body measurements in Claude."
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+	"mcpServers": {
+		"hevy": {
+			"type": "http",
+			"url": "https://mcp.hevy-mcp.dev/mcp",
+			"oauth": true
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,33 @@ Try asking:
 > Create a completed workout from my saved routine. Ask me for any missing set
 > results before writing it to Hevy.
 
+## Claude integration
+
+The repository includes a Claude plugin that connects to the hosted OAuth-enabled
+MCP endpoint without embedding a user's Hevy API key.
+
+### Claude.ai and Claude Desktop
+
+In Claude, open **Settings → Connectors → Add custom connector** and enter:
+
+```text
+https://mcp.hevy-mcp.dev/mcp
+```
+
+Complete the OAuth flow and enter the Hevy API key when prompted. The same
+remote endpoint can be used by Claude Desktop and other clients that support
+remote MCP connectors.
+
+### Claude Code and Cowork
+
+The Claude plugin is defined by [`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json)
+and [`.mcp.json`](./.mcp.json). Install it from this public repository or from
+the Claude Plugin Directory after publication. It adds the hosted Hevy MCP
+connector and the [Hevy workout skill](./skills/hevy-workouts/SKILL.md).
+
+See the [privacy policy](./docs/privacy-policy.md) for the hosted service's
+data handling details.
+
 ## Quick start
 
 ### 1. Get your Hevy API key

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,69 @@
+# Hevy MCP Privacy Policy
+
+_Last updated: 2026-08-09_
+
+This policy describes how the hosted Hevy MCP service at
+`https://mcp.hevy-mcp.dev/mcp` handles information. The open-source software
+can also be run locally; local deployments are controlled by the person who
+runs them and do not send data to the hosted service unless configured to do so.
+
+## Information processed
+
+The hosted service processes the following information to provide MCP tools:
+
+- A user's Hevy API key, supplied in an authorization header or through the
+  OAuth authorization page.
+- The user's Hevy data needed to answer a tool request, including workouts,
+  routines, exercise templates, and body measurements.
+- Operational request metadata such as the request path, client origin,
+  authentication mode, response status, and duration.
+
+The service does not intentionally collect conversation history, prompts, tool
+arguments, tool results, workout content, measurement values, or API keys in
+its operational telemetry.
+
+## How information is used
+
+Information is used only to authenticate the user with Hevy and perform the
+requested MCP operation. The service does not sell personal information or use
+workout data for advertising.
+
+## Storage and retention
+
+For direct bearer authentication, the hosted Worker validates the API key with
+Hevy for each request and does not persist the key. Request data is processed
+transiently to produce the MCP response.
+
+For Claude and other OAuth clients, the OAuth layer stores the authorization
+grant in encrypted Cloudflare KV storage so that the client can refresh its
+access. OAuth access tokens expire after seven days and refresh tokens expire
+after thirty days. Rotating the Hevy API key invalidates grants created with
+that key.
+
+The hosted Worker uses request-scoped in-memory caches and does not maintain a
+shared workout-data database. Cloudflare may process operational logs under
+its own privacy terms and retention policies.
+
+## Third parties
+
+The service sends authenticated API requests to Hevy to fulfill user requests.
+Claude or another MCP client receives the resulting data according to that
+client's own policies. Cloudflare provides hosting and storage for the hosted
+Worker and OAuth grants.
+
+## User choices
+
+Users can disconnect the MCP connector, revoke its authorization, or rotate
+their Hevy API key. Users running the software locally can disable telemetry
+and control all local storage and network configuration; see the repository
+README for details.
+
+## Contact
+
+For privacy questions or deletion requests related to the hosted service,
+open an issue at <https://github.com/chrisdoc/hevy-mcp/issues>.
+
+## Changes
+
+This policy may be updated when the service or its data practices change. The
+latest version is maintained in the public repository.

--- a/skills/hevy-workouts/SKILL.md
+++ b/skills/hevy-workouts/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: hevy-workouts
+description: Use when the user asks to inspect, summarize, plan, log, or update Hevy workouts, routines, exercises, or body measurements.
+---
+
+# Hevy workout workflows
+
+Use the Hevy MCP connector for the user's authenticated Hevy account.
+
+## Analysis and retrieval
+
+- Prefer `get-training-summary` for a high-level trend across workouts and body measurements.
+- Use focused list and detail tools when the user asks about a particular workout, routine, exercise, or date.
+- State the date range and distinguish observations from recommendations.
+- Cite the workout or measurement evidence used in a summary when practical.
+
+## Mutations
+
+- Treat create and update tools as state-changing operations.
+- Before changing Hevy data, summarize the proposed change and confirm it with the user unless the user has already given an unambiguous instruction to make that exact change.
+- Never invent completed set results, workout times, body measurements, or other missing values. Ask the user for missing values.
+- Explain that create operations can produce duplicates if retried and that update operations replace existing values.
+
+## Health context
+
+Workout and body-measurement data is personal information. Describe trends without diagnosing medical conditions, and recommend a qualified professional for medical advice.

--- a/skills/hevy-workouts/SKILL.md
+++ b/skills/hevy-workouts/SKILL.md
@@ -7,6 +7,32 @@ description: Use when the user asks to inspect, summarize, plan, log, or update 
 
 Use the Hevy MCP connector for the user's authenticated Hevy account.
 
+## MCP server connection
+
+This plugin registers the remote MCP server as `hevy` through the repository's
+`.mcp.json` file:
+
+```json
+{
+	"mcpServers": {
+		"hevy": {
+			"type": "http",
+			"url": "https://mcp.hevy-mcp.dev/mcp",
+			"oauth": true
+		}
+	}
+}
+```
+
+When the plugin is installed, connect or authorize the `hevy` server in Claude's
+connector settings. The authorization page asks the user for their Hevy API
+key. Never put an API key in this skill, plugin files, or a conversation. If the
+server is unavailable, ask the user to complete the connector authorization
+instead of attempting to start a different server.
+
+Use the tools and resources exposed by the `hevy` server for Hevy requests. Do
+not call the Hevy API directly or invent an alternative authentication path.
+
 ## Analysis and retrieval
 
 - Prefer `get-training-summary` for a high-level trend across workouts and body measurements.


### PR DESCRIPTION
## Summary

- add a Claude plugin manifest for the hosted Hevy MCP connector
- configure the OAuth-enabled Streamable HTTP endpoint without embedding user keys
- add a Hevy workout workflow skill and hosted-service privacy policy
- document Claude.ai, Claude Desktop, Claude Code, and Cowork usage

## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run build`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:pack:cli`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`
- JSON parsing and `git diff --check`

`claude plugin validate` was not run because the Claude CLI is not installed in this environment; the plugin manifests were JSON-parsed and formatting-checked.

## Summary by Sourcery

Integrate the project with Claude via a hosted OAuth-enabled MCP connector and associated plugin metadata.

New Features:
- Add Claude plugin configuration and MCP manifest to expose the hosted Hevy connector to Claude clients.
- Introduce a Hevy workout workflow skill for guided usage of Hevy workouts, routines, exercises, and body measurements via MCP.

Documentation:
- Document how to connect Claude.ai, Claude Desktop, Claude Code, and Cowork to the hosted Hevy MCP endpoint.
- Add a privacy policy covering data handling for the hosted Hevy MCP service.
- Provide usage guidelines for the Hevy workout workflows skill, including analysis, mutation, and health-context recommendations.

Chores:
- Record the Claude integration and workflow skill addition in a changeset entry.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Claude plugin integration enabling secure OAuth-authenticated access to Hevy MCP endpoint without embedding API keys.

Main changes:
- Created plugin metadata (`.claude-plugin/plugin.json`, `.mcp.json`) registering remote OAuth-enabled MCP server at `https://mcp.hevy-mcp.dev/mcp`
- Added Hevy workout skill definition with MCP tool usage guidelines and data mutation workflows for Claude integration
- Added privacy policy documenting hosted service data handling, OAuth token storage in Cloudflare KV, and user control options

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
