### PR TITLE
fix: reduce false-positive Sentry errors in 6.1

### DIFF
--- a/.changeset/quiet-sdk-tool-errors.md
+++ b/.changeset/quiet-sdk-tool-errors.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Treat unknown MCP tool calls as expected caller validation failures instead of reporting them as Sentry errors.

--- a/.changeset/safe-api-error-details.md
+++ b/.changeset/safe-api-error-details.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Capture bounded, allowlisted, redacted upstream error details in API diagnostics without adding response text to metrics.

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -100,6 +100,8 @@ export interface HevyRequestObservation {
 		readonly status?: number;
 		readonly code?: string;
 		readonly category?: "HevyHttpError" | "NetworkError";
+		/** Bounded, sanitized text from an allowlisted upstream error field. */
+		readonly response_error?: string;
 	};
 }
 
@@ -866,6 +868,7 @@ function createFailureObservation(
 					? error.code
 					: undefined,
 			category: error.status === undefined ? "NetworkError" : "HevyHttpError",
+			...(error.responseError ? { response_error: error.responseError } : {}),
 		},
 	};
 }

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -159,7 +159,7 @@ describe("@hevy-mcp/hevy-client", () => {
 			response(
 				{
 					message:
-						"Invalid email jane@example.com; Authorization: Bearer response-secret; see https://api.example.test/workouts/123",
+						"Invalid email jane@example.com; Authorization: Bearer response-secret; Cookie: session=body-secret; validation failed; see https://api.example.test/workouts/123",
 					token: "body-secret",
 				},
 				500,
@@ -181,7 +181,7 @@ describe("@hevy-mcp/hevy-client", () => {
 
 		expect(thrown).toMatchObject({
 			responseError:
-				"Invalid email [EMAIL_REDACTED]; Authorization: [REDACTED]; see [URL_REDACTED]",
+				"Invalid email [EMAIL_REDACTED]; Authorization: [REDACTED]; Cookie: [REDACTED]; validation failed; see [URL_REDACTED]",
 		});
 		const observationText = JSON.stringify(observations);
 		expect(observationText).toContain("response_error");

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -153,6 +153,44 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(eventText).not.toContain("observer-secret");
 		expect(onLog).toHaveBeenCalled();
 	});
+	it("exposes only bounded, sanitized allowlisted response diagnostics", async () => {
+		const observations: unknown[] = [];
+		const fetchMock = vi.fn().mockResolvedValue(
+			response(
+				{
+					message:
+						"Invalid email jane@example.com; Authorization: Bearer response-secret; see https://api.example.test/workouts/123",
+					token: "body-secret",
+				},
+				500,
+			),
+		);
+		const client = createHevyClient({
+			apiKey: "api-key-secret",
+			fetch: fetchMock,
+			maxGetRetries: 0,
+			onRequestComplete: (observation) => observations.push(observation),
+		});
+
+		let thrown: unknown;
+		try {
+			await client.getUserInfo();
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toMatchObject({
+			responseError:
+				"Invalid email [EMAIL_REDACTED]; Authorization: [REDACTED]; see [URL_REDACTED]",
+		});
+		const observationText = JSON.stringify(observations);
+		expect(observationText).toContain("response_error");
+		expect(observationText).toContain("[EMAIL_REDACTED]");
+		expect(observationText).not.toContain("jane@example.com");
+		expect(observationText).not.toContain("response-secret");
+		expect(observationText).not.toContain("body-secret");
+	});
+
 	it("times out while consuming a response body", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(hangingResponse());
 		const client = createHevyClient({

--- a/packages/hevy-client/src/hevy-http-error.ts
+++ b/packages/hevy-client/src/hevy-http-error.ts
@@ -4,6 +4,7 @@ import type {
 	HevyOperationSafety,
 	HevyRequestPhase,
 } from "./execution.js";
+import { extractSafeResponseError } from "./response-error.js";
 
 export const HEVY_RETRY_EXHAUSTED_ERROR_CODE = "HEVY_RETRY_EXHAUSTED";
 export const HEVY_REQUEST_ABORTED_ERROR_CODE = "HEVY_REQUEST_ABORTED";
@@ -38,6 +39,7 @@ export class HevyHttpError extends Error {
 	readonly status?: number;
 	readonly statusText?: string;
 	readonly data?: unknown;
+	readonly responseError?: string;
 	readonly headers?: Headers;
 	readonly method: string;
 	readonly endpoint: string;
@@ -61,6 +63,7 @@ export class HevyHttpError extends Error {
 		this.status = options.status;
 		this.statusText = options.statusText;
 		this.data = options.data;
+		this.responseError = extractSafeResponseError(options.data);
 		this.headers = options.headers;
 		this.method = options.method;
 		this.endpoint = options.endpoint;

--- a/packages/hevy-client/src/response-error.ts
+++ b/packages/hevy-client/src/response-error.ts
@@ -1,0 +1,97 @@
+const MAX_RESPONSE_ERROR_INPUT_LENGTH = 4_096;
+const MAX_RESPONSE_ERROR_LENGTH = 256;
+const RESPONSE_ERROR_KEYS = ["error", "message", "detail"] as const;
+
+const COOKIE_ASSIGNMENT = /\b(?:cookie|set-cookie)\s*[:=][^\r\n]*/gi;
+const SECRET_ASSIGNMENT =
+	/(\b(?:authorization|proxy-authorization|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|token|client[-_ ]?secret|password|passwd|secret|credential|signature)\b\s*[:=]\s*)(?:"[^"]*"|'[^']*'|(?:Bearer\s+)?[^\s,;}"]+)/gi;
+const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const JSON_WEB_TOKEN =
+	/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g;
+const SECRET_QUERY_PARAMETER =
+	/([?&](?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|token|signature|password|secret)=)[^&#\s]+/gi;
+const URL = /\bhttps?:\/\/[^\s<>"']+/gi;
+const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const UUID =
+	/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+
+type ResponseErrorBody = {
+	readonly error?: unknown;
+	readonly message?: unknown;
+	readonly detail?: unknown;
+};
+
+function isResponseErrorBody(value: unknown): value is ResponseErrorBody {
+	return typeof value === "object" && value !== null;
+}
+
+function ownValue(value: object, key: PropertyKey): unknown {
+	const descriptor = Object.getOwnPropertyDescriptor(value, key);
+	return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function responseErrorText(value: unknown): string | undefined {
+	if (!isResponseErrorBody(value)) return undefined;
+	for (const key of RESPONSE_ERROR_KEYS) {
+		const candidate = ownValue(value, key);
+		if (typeof candidate === "string") return candidate;
+		if (!isResponseErrorBody(candidate)) continue;
+		const nestedMessage = ownValue(candidate, "message");
+		if (typeof nestedMessage === "string") return nestedMessage;
+		const nestedDetail = ownValue(candidate, "detail");
+		if (typeof nestedDetail === "string") return nestedDetail;
+	}
+	return undefined;
+}
+
+function removeControlCharacters(value: string): string {
+	let output = "";
+	for (const character of value) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		if (codePoint <= 0x1f || codePoint === 0x7f) {
+			if (codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d) {
+				output += " ";
+			}
+			continue;
+		}
+		output += character;
+	}
+	return output;
+}
+
+function truncate(value: string): string {
+	return value.length > MAX_RESPONSE_ERROR_LENGTH
+		? `${value.slice(0, MAX_RESPONSE_ERROR_LENGTH - 1)}…`
+		: value;
+}
+
+function sanitizeResponseErrorText(value: string): string {
+	const bounded = removeControlCharacters(
+		value.slice(0, MAX_RESPONSE_ERROR_INPUT_LENGTH),
+	);
+	return truncate(
+		bounded
+			.replace(COOKIE_ASSIGNMENT, "[REDACTED]")
+			.replace(SECRET_ASSIGNMENT, "$1[REDACTED]")
+			.replace(BEARER_TOKEN, "Bearer [REDACTED]")
+			.replace(JSON_WEB_TOKEN, "[JWT_REDACTED]")
+			.replace(SECRET_QUERY_PARAMETER, "$1[REDACTED]")
+			.replace(URL, "[URL_REDACTED]")
+			.replace(EMAIL, "[EMAIL_REDACTED]")
+			.replace(UUID, "[ID_REDACTED]")
+			.replace(/\s+/g, " ")
+			.trim(),
+	);
+}
+
+/** Extract one bounded, sanitized diagnostic string from an upstream error body. */
+export function extractSafeResponseError(data: unknown): string | undefined {
+	try {
+		const text = responseErrorText(data);
+		if (!text) return undefined;
+		const sanitized = sanitizeResponseErrorText(text);
+		return sanitized || undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/hevy-client/src/response-error.ts
+++ b/packages/hevy-client/src/response-error.ts
@@ -2,7 +2,7 @@ const MAX_RESPONSE_ERROR_INPUT_LENGTH = 4_096;
 const MAX_RESPONSE_ERROR_LENGTH = 256;
 const RESPONSE_ERROR_KEYS = ["error", "message", "detail"] as const;
 
-const COOKIE_ASSIGNMENT = /\b(?:cookie|set-cookie)\s*[:=][^\r\n]*/gi;
+const COOKIE_ASSIGNMENT = /(\b(?:cookie|set-cookie)\s*[:=]\s*)[^;\s]+/gi;
 const SECRET_ASSIGNMENT =
 	/(\b(?:authorization|proxy-authorization|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|token|client[-_ ]?secret|password|passwd|secret|credential|signature)\b\s*[:=]\s*)(?:"[^"]*"|'[^']*'|(?:Bearer\s+)?[^\s,;}"]+)/gi;
 const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
@@ -10,7 +10,7 @@ const JSON_WEB_TOKEN =
 	/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g;
 const SECRET_QUERY_PARAMETER =
 	/([?&](?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|token|signature|password|secret)=)[^&#\s]+/gi;
-const URL = /\bhttps?:\/\/[^\s<>"']+/gi;
+const HTTP_URL = /\bhttps?:\/\/[^\s<>"']+/gi;
 const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const UUID =
 	/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
@@ -71,12 +71,12 @@ function sanitizeResponseErrorText(value: string): string {
 	);
 	return truncate(
 		bounded
-			.replace(COOKIE_ASSIGNMENT, "[REDACTED]")
+			.replace(COOKIE_ASSIGNMENT, "$1[REDACTED]")
 			.replace(SECRET_ASSIGNMENT, "$1[REDACTED]")
 			.replace(BEARER_TOKEN, "Bearer [REDACTED]")
 			.replace(JSON_WEB_TOKEN, "[JWT_REDACTED]")
 			.replace(SECRET_QUERY_PARAMETER, "$1[REDACTED]")
-			.replace(URL, "[URL_REDACTED]")
+			.replace(HTTP_URL, "[URL_REDACTED]")
 			.replace(EMAIL, "[EMAIL_REDACTED]")
 			.replace(UUID, "[ID_REDACTED]")
 			.replace(/\s+/g, " ")

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -313,6 +313,44 @@ describe("Node package entrypoint", () => {
 		expect(testDoubles.captureFailure).toHaveBeenCalled();
 	});
 
+	it("treats unknown MCP tool requests as expected validation failures", async () => {
+		const toolHandler = vi
+			.fn()
+			.mockRejectedValue(new Error("Tool get-workout-workoutId not found"));
+		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
+		await createNodeMcpServer({ apiKey: "valid-key" });
+
+		const wrappedToolHandler =
+			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
+		if (!wrappedToolHandler) return;
+
+		testDoubles.captureFailure.mockClear();
+		testDoubles.span.addEvent.mockClear();
+		testDoubles.span.setStatus.mockClear();
+		const activeSpanSpy = vi
+			.spyOn(trace, "getActiveSpan")
+			.mockReturnValue(testDoubles.span as never);
+
+		await expect(
+			wrappedToolHandler({ params: { name: "get-workout-workoutId" } }, {}),
+		).rejects.toThrow("Tool get-workout-workoutId not found");
+
+		expect(testDoubles.captureFailure).toHaveBeenCalledWith(
+			expect.any(Error),
+			expect.objectContaining({
+				expected: true,
+				attributes: expect.objectContaining({
+					"mcp.tool.name": "get-workout-workoutId",
+					"mcp.validation.kind": "tool_not_found",
+				}),
+			}),
+		);
+		expect(testDoubles.span.setStatus).not.toHaveBeenCalledWith({
+			code: SpanStatusCode.ERROR,
+		});
+		activeSpanSpy.mockRestore();
+	});
+
 	it("tracks SDK validation and protocol failures", async () => {
 		const previousOnError = vi.fn(() => {
 			throw new Error("previous SDK handler failure");

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -244,13 +244,14 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
 		const wrappedInitializeHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("initialize");
-		expect(wrappedToolHandler).toBeDefined();
-		expect(wrappedInitializeHandler).toBeDefined();
+		if (!wrappedToolHandler || !wrappedInitializeHandler) {
+			throw new Error("Expected SDK handlers to be installed");
+		}
 
 		const activeSpanSpy = vi
 			.spyOn(trace, "getActiveSpan")
 			.mockReturnValue(testDoubles.span as never);
-		await expect(wrappedInitializeHandler!({}, {})).resolves.toEqual({
+		await expect(wrappedInitializeHandler({}, {})).resolves.toEqual({
 			protocolVersion: "1",
 		});
 		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
@@ -263,7 +264,7 @@ describe("Node package entrypoint", () => {
 		testDoubles.span.setAttributes.mockClear();
 
 		await expect(
-			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({});
 		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
 			"mcp.span.category": "protocol",
@@ -294,19 +295,20 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
 		const wrappedDiscoveryHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("server/discover");
-		expect(wrappedToolHandler).toBeDefined();
-		expect(wrappedDiscoveryHandler).toBeDefined();
+		if (!wrappedToolHandler || !wrappedDiscoveryHandler) {
+			throw new Error("Expected SDK handlers to be installed");
+		}
 
 		await expect(
-			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({ isError: true });
 		await expect(
-			wrappedToolHandler!({ params: { name: "bad name" } }, {}),
+			wrappedToolHandler({ params: { name: "bad name" } }, {}),
 		).rejects.toThrow("tool failure");
-		await expect(wrappedDiscoveryHandler!({}, {})).resolves.toEqual({
+		await expect(wrappedDiscoveryHandler({}, {})).resolves.toEqual({
 			capabilities: [],
 		});
-		await expect(wrappedDiscoveryHandler!({}, {})).rejects.toThrow(
+		await expect(wrappedDiscoveryHandler({}, {})).rejects.toThrow(
 			"discovery failure",
 		);
 
@@ -321,7 +323,9 @@ describe("Node package entrypoint", () => {
 
 		const wrappedToolHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		expect(wrappedToolHandler).toBeDefined();
+		if (!wrappedToolHandler) {
+			throw new Error("Expected wrapped tools/call handler to be installed");
+		}
 
 		testDoubles.captureFailure.mockClear();
 		testDoubles.span.addEvent.mockClear();
@@ -331,7 +335,7 @@ describe("Node package entrypoint", () => {
 			.mockReturnValue(testDoubles.span as never);
 
 		await expect(
-			wrappedToolHandler!({ params: { name: "get-workout-workoutId" } }, {}),
+			wrappedToolHandler({ params: { name: "get-workout-workoutId" } }, {}),
 		).rejects.toThrow("Tool get-workout-workoutId not found");
 
 		expect(testDoubles.captureFailure).toHaveBeenCalledWith(
@@ -450,14 +454,16 @@ describe("Node package entrypoint", () => {
 
 		const wrappedToolHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		expect(wrappedToolHandler).toBeDefined();
+		if (!wrappedToolHandler) {
+			throw new Error("Expected wrapped tools/call handler to be installed");
+		}
 		const activeSpanSpy = vi
 			.spyOn(trace, "getActiveSpan")
 			.mockReturnValue(testDoubles.span as never);
 		testDoubles.span.setStatus.mockClear();
 
 		await expect(
-			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({ isError: true });
 		expect(testDoubles.span.setStatus).not.toHaveBeenCalledWith({
 			code: SpanStatusCode.ERROR,
@@ -487,12 +493,13 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("initialize");
 		const wrappedTool =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		expect(wrappedInitialize).toBeDefined();
-		expect(wrappedTool).toBeDefined();
+		if (!wrappedInitialize || !wrappedTool) {
+			throw new Error("Expected SDK handlers to be installed");
+		}
 
-		await expect(wrappedInitialize!({}, {})).resolves.toEqual({});
+		await expect(wrappedInitialize({}, {})).resolves.toEqual({});
 		await expect(
-			wrappedTool!({ params: { name: "get-workouts" } }, {}),
+			wrappedTool({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({});
 		expect(initializeHandler).toHaveBeenCalledOnce();
 		expect(toolHandler).toHaveBeenCalledOnce();

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -246,12 +246,11 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("initialize");
 		expect(wrappedToolHandler).toBeDefined();
 		expect(wrappedInitializeHandler).toBeDefined();
-		if (!wrappedToolHandler || !wrappedInitializeHandler) return;
 
 		const activeSpanSpy = vi
 			.spyOn(trace, "getActiveSpan")
 			.mockReturnValue(testDoubles.span as never);
-		await expect(wrappedInitializeHandler({}, {})).resolves.toEqual({
+		await expect(wrappedInitializeHandler!({}, {})).resolves.toEqual({
 			protocolVersion: "1",
 		});
 		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
@@ -264,7 +263,7 @@ describe("Node package entrypoint", () => {
 		testDoubles.span.setAttributes.mockClear();
 
 		await expect(
-			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({});
 		expect(testDoubles.span.setAttributes).toHaveBeenCalledWith({
 			"mcp.span.category": "protocol",
@@ -295,18 +294,19 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
 		const wrappedDiscoveryHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("server/discover");
-		if (!wrappedToolHandler || !wrappedDiscoveryHandler) return;
+		expect(wrappedToolHandler).toBeDefined();
+		expect(wrappedDiscoveryHandler).toBeDefined();
 
 		await expect(
-			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({ isError: true });
 		await expect(
-			wrappedToolHandler({ params: { name: "bad name" } }, {}),
+			wrappedToolHandler!({ params: { name: "bad name" } }, {}),
 		).rejects.toThrow("tool failure");
-		await expect(wrappedDiscoveryHandler({}, {})).resolves.toEqual({
+		await expect(wrappedDiscoveryHandler!({}, {})).resolves.toEqual({
 			capabilities: [],
 		});
-		await expect(wrappedDiscoveryHandler({}, {})).rejects.toThrow(
+		await expect(wrappedDiscoveryHandler!({}, {})).rejects.toThrow(
 			"discovery failure",
 		);
 
@@ -314,15 +314,14 @@ describe("Node package entrypoint", () => {
 	});
 
 	it("treats unknown MCP tool requests as expected validation failures", async () => {
-		const toolHandler = vi
-			.fn()
-			.mockRejectedValue(new Error("Tool get-workout-workoutId not found"));
+		const unknownToolError = new Error("Tool get-workout-workoutId not found");
+		const toolHandler = vi.fn().mockRejectedValue(unknownToolError);
 		testDoubles.sdkProtocol._requestHandlers.set("tools/call", toolHandler);
 		await createNodeMcpServer({ apiKey: "valid-key" });
 
 		const wrappedToolHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		if (!wrappedToolHandler) return;
+		expect(wrappedToolHandler).toBeDefined();
 
 		testDoubles.captureFailure.mockClear();
 		testDoubles.span.addEvent.mockClear();
@@ -332,11 +331,11 @@ describe("Node package entrypoint", () => {
 			.mockReturnValue(testDoubles.span as never);
 
 		await expect(
-			wrappedToolHandler({ params: { name: "get-workout-workoutId" } }, {}),
+			wrappedToolHandler!({ params: { name: "get-workout-workoutId" } }, {}),
 		).rejects.toThrow("Tool get-workout-workoutId not found");
 
 		expect(testDoubles.captureFailure).toHaveBeenCalledWith(
-			expect.any(Error),
+			unknownToolError,
 			expect.objectContaining({
 				expected: true,
 				attributes: expect.objectContaining({
@@ -451,14 +450,14 @@ describe("Node package entrypoint", () => {
 
 		const wrappedToolHandler =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		if (!wrappedToolHandler) return;
+		expect(wrappedToolHandler).toBeDefined();
 		const activeSpanSpy = vi
 			.spyOn(trace, "getActiveSpan")
 			.mockReturnValue(testDoubles.span as never);
 		testDoubles.span.setStatus.mockClear();
 
 		await expect(
-			wrappedToolHandler({ params: { name: "get-workouts" } }, {}),
+			wrappedToolHandler!({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({ isError: true });
 		expect(testDoubles.span.setStatus).not.toHaveBeenCalledWith({
 			code: SpanStatusCode.ERROR,
@@ -488,11 +487,12 @@ describe("Node package entrypoint", () => {
 			testDoubles.sdkProtocol._requestHandlers.get("initialize");
 		const wrappedTool =
 			testDoubles.sdkProtocol._requestHandlers.get("tools/call");
-		if (!wrappedInitialize || !wrappedTool) return;
+		expect(wrappedInitialize).toBeDefined();
+		expect(wrappedTool).toBeDefined();
 
-		await expect(wrappedInitialize({}, {})).resolves.toEqual({});
+		await expect(wrappedInitialize!({}, {})).resolves.toEqual({});
 		await expect(
-			wrappedTool({ params: { name: "get-workouts" } }, {}),
+			wrappedTool!({ params: { name: "get-workouts" } }, {}),
 		).resolves.toEqual({});
 		expect(initializeHandler).toHaveBeenCalledOnce();
 		expect(toolHandler).toHaveBeenCalledOnce();

--- a/packages/node/src/utils/failure-reporter.test.ts
+++ b/packages/node/src/utils/failure-reporter.test.ts
@@ -1,4 +1,5 @@
 import type { ErrorEvent } from "@sentry/node";
+import { HevyHttpError } from "@hevy-mcp/hevy-client";
 import type { Span } from "@opentelemetry/api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -34,6 +35,7 @@ vi.mock("@opentelemetry/api", () => ({
 }));
 
 const spanDoubles = {
+	addEvent: vi.fn(),
 	recordException: vi.fn(),
 	setAttributes: vi.fn(),
 	setAttribute: vi.fn(),
@@ -49,14 +51,16 @@ describe("failure reporter", () => {
 
 	it("scrubs credentials, URLs, control characters, and home paths", () => {
 		const value =
-			"Bearer bearer-secret api-key=api-secret https://example.test/path?secret=1\n/home/alice/project\u0000";
+			"Bearer bearer-secret api-key=api-secret jane@example.com https://example.test/path?secret=1\n/home/alice/project\u0000";
 
 		const result = sanitizeDiagnosticText(value);
 
 		expect(result).not.toContain("bearer-secret");
 		expect(result).not.toContain("api-secret");
 		expect(result).not.toContain("https://example.test");
+		expect(result).not.toContain("jane@example.com");
 		expect(result).not.toContain("/home/alice");
+		expect(result).toContain("[EMAIL_REDACTED]");
 		expect(result).not.toContain("\u0000");
 		expect(result).toContain("[REDACTED]");
 	});
@@ -162,6 +166,36 @@ describe("failure reporter", () => {
 		});
 		expect(serialized).not.toContain("secret");
 		expect(serialized).not.toContain("/Users/alice");
+	});
+
+	it("keeps sanitized response diagnostics in context and failure events", () => {
+		const error = new HevyHttpError("request failed", {
+			status: 500,
+			method: "PUT",
+			endpoint: "/v1/workouts/:workoutId",
+			code: "HEVY_RETRY_EXHAUSTED",
+			data: {
+				message: "Invalid email jane@example.com; token=raw-token",
+			},
+		});
+
+		captureFailure(error, { kind: "api", span });
+
+		expect(testDoubles.setContext).toHaveBeenCalledWith(
+			"mcp",
+			expect.objectContaining({
+				"hevy.api.response_error":
+					"Invalid email [EMAIL_REDACTED]; token=[REDACTED]",
+			}),
+		);
+		expect(testDoubles.setTag).not.toHaveBeenCalledWith(
+			"hevy.api.response_error",
+			expect.anything(),
+		);
+		expect(spanDoubles.addEvent).toHaveBeenCalledWith("mcp.failure.detail", {
+			"hevy.api.response_error":
+				"Invalid email [EMAIL_REDACTED]; token=[REDACTED]",
+		});
 	});
 
 	it("captures one sanitized Sentry event and one owning OTel exception", () => {

--- a/packages/node/src/utils/failure-reporter.ts
+++ b/packages/node/src/utils/failure-reporter.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import { isHevyHttpError } from "@hevy-mcp/hevy-client";
 import * as Sentry from "@sentry/node";
 import { SpanStatusCode, trace, type Span } from "@opentelemetry/api";
 import type { ErrorEvent, EventHint } from "@sentry/node";
@@ -31,6 +32,7 @@ export interface NormalizedFailure {
 	readonly exceptionType: string;
 	readonly message?: string;
 	readonly stack?: string;
+	readonly responseError?: string;
 	readonly exception: {
 		readonly name: string;
 		readonly message?: string;
@@ -83,6 +85,8 @@ function removeHomePath(value: string): string {
 	return withConfiguredHome.replace(/\/(?:Users|home)\/[^/\s]+/g, "~");
 }
 
+const EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+
 function removeControlCharacters(value: string): string {
 	let output = "";
 	let inEscapeSequence = false;
@@ -124,6 +128,7 @@ export function sanitizeDiagnosticText(
 			/\b(api[-_ ]?key|authorization|password|secret|token)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
 			"$1=[REDACTED]",
 		)
+		.replace(EMAIL, "[EMAIL_REDACTED]")
 		.replace(/\bhttps?:\/\/[^\s)<>]+/gi, "[URL]");
 	return truncate(removeHomePath(withoutSecrets).trim(), maxLength);
 }
@@ -262,6 +267,10 @@ export function normalizeFailure(
 		DIAGNOSTIC_DETAILS_ENABLED && text.stack
 			? sanitizeDiagnosticText(text.stack, MAX_STACK_LENGTH)
 			: undefined;
+	const responseError =
+		DIAGNOSTIC_DETAILS_ENABLED && isHevyHttpError(error) && error.responseError
+			? sanitizeDiagnosticText(error.responseError, MAX_ATTRIBUTE_LENGTH)
+			: undefined;
 
 	attributes["exception.type"] = exceptionType;
 	addErrorAttributes(attributes, diagnostic, context.expected);
@@ -273,6 +282,7 @@ export function normalizeFailure(
 		exceptionType,
 		...(message ? { message } : {}),
 		...(stack ? { stack } : {}),
+		...(responseError ? { responseError } : {}),
 		exception: {
 			name: exceptionType,
 			...(message ? { message } : {}),
@@ -479,6 +489,9 @@ export function captureFailure(
 				scope.setContext("mcp", {
 					kind: context.kind,
 					...record.attributes,
+					...(record.responseError
+						? { "hevy.api.response_error": record.responseError }
+						: {}),
 				});
 				return Sentry.captureException(createSentryError(record));
 			});
@@ -491,6 +504,11 @@ export function captureFailure(
 		try {
 			if (!duplicate && !context.expected) {
 				span.recordException(record.exception);
+				if (record.responseError) {
+					span.addEvent("mcp.failure.detail", {
+						"hevy.api.response_error": record.responseError,
+					});
+				}
 			}
 			setSpanAttributes(span, record.attributes);
 			if (!context.expected) {

--- a/packages/node/src/utils/hevy-client-observability.test.ts
+++ b/packages/node/src/utils/hevy-client-observability.test.ts
@@ -231,6 +231,35 @@ describe("createNodeHevyClientOptions", () => {
 		);
 	});
 
+	it("records response diagnostics on failure events but not metric labels", () => {
+		const options = createNodeHevyClientOptions();
+		observe(options, {
+			method: "PUT",
+			endpoint: "/v1/workouts/:workoutId",
+			status: 500,
+			durationMs: 25,
+			retryCount: 3,
+			outcome: "terminal_failure",
+			error: {
+				status: 500,
+				category: "HevyHttpError",
+				response_error: "Invalid email [EMAIL_REDACTED]",
+			},
+		});
+
+		expect(testDoubles.span.addEvent).toHaveBeenCalledWith(
+			"hevy.api.failure",
+			expect.objectContaining({
+				"hevy.api.response_error": "Invalid email [EMAIL_REDACTED]",
+			}),
+		);
+		const metricText = JSON.stringify([
+			testDoubles.apiCallsAdd.mock.calls,
+			testDoubles.apiDurationRecord.mock.calls,
+		]);
+		expect(metricText).not.toContain("response_error");
+	});
+
 	it("records allowlisted error codes and normalizes an absent status", () => {
 		const error = new HevyHttpError("private retry message", {
 			method: "GET",

--- a/packages/node/src/utils/hevy-client-observability.test.ts
+++ b/packages/node/src/utils/hevy-client-observability.test.ts
@@ -260,6 +260,40 @@ describe("createNodeHevyClientOptions", () => {
 		expect(metricText).not.toContain("response_error");
 	});
 
+	it("honors the diagnostics opt-out for response details", () => {
+		const originalSetting = process.env.HEVY_MCP_TELEMETRY_DIAGNOSTICS;
+		process.env.HEVY_MCP_TELEMETRY_DIAGNOSTICS = "0";
+		try {
+			const options = createNodeHevyClientOptions();
+			observe(options, {
+				method: "PUT",
+				endpoint: "/v1/workouts/:workoutId",
+				status: 500,
+				durationMs: 25,
+				retryCount: 3,
+				outcome: "terminal_failure",
+				error: {
+					status: 500,
+					category: "HevyHttpError",
+					response_error: "sensitive upstream detail",
+				},
+			});
+
+			expect(testDoubles.span.addEvent).toHaveBeenCalledWith(
+				"hevy.api.failure",
+				{
+					"error.category": "HevyHttpError",
+				},
+			);
+		} finally {
+			if (originalSetting === undefined) {
+				delete process.env.HEVY_MCP_TELEMETRY_DIAGNOSTICS;
+			} else {
+				process.env.HEVY_MCP_TELEMETRY_DIAGNOSTICS = originalSetting;
+			}
+		}
+	});
+
 	it("records allowlisted error codes and normalizes an absent status", () => {
 		const error = new HevyHttpError("private retry message", {
 			method: "GET",

--- a/packages/node/src/utils/hevy-client-observability.ts
+++ b/packages/node/src/utils/hevy-client-observability.ts
@@ -32,6 +32,14 @@ function safeErrorAttributes(observation: HevyRequestObservation): {
 	};
 }
 
+function getDiagnosticResponseError(
+	observation: HevyRequestObservation,
+): string | undefined {
+	return process.env.HEVY_MCP_TELEMETRY_DIAGNOSTICS === "0"
+		? undefined
+		: observation.error?.response_error;
+}
+
 function startApiSpan(start: HevyRequestStart) {
 	const sessionId = getCurrentMcpSessionId();
 	const diagnosticEndpoint = diagnosticEndpointIdentity(start.endpoint);
@@ -71,14 +79,13 @@ function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 				: SpanStatusCode.ERROR,
 	});
 	if (observation.outcome !== "success" && observation.outcome !== "expected") {
+		const responseError = getDiagnosticResponseError(observation);
 		span.addEvent("hevy.api.failure", {
 			"error.category": errorAttributes.error_category ?? "HevyHttpError",
 			...(errorAttributes.error_code
 				? { "error.code": errorAttributes.error_code }
 				: {}),
-			...(observation.error?.response_error
-				? { "hevy.api.response_error": observation.error.response_error }
-				: {}),
+			...(responseError ? { "hevy.api.response_error": responseError } : {}),
 		});
 	}
 	span.end();
@@ -108,6 +115,7 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 		onRequestComplete(observation) {
 			const retryCountBucket = bucketCount(observation.retryCount);
 			const errorAttributes = safeErrorAttributes(observation);
+			const responseError = getDiagnosticResponseError(observation);
 			const metricEndpoint = metricEndpointIdentity(observation.endpoint);
 			const diagnosticEndpoint = diagnosticEndpointIdentity(
 				observation.endpoint,
@@ -146,9 +154,7 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 				status: observation.status || null,
 				retryCountBucket,
 				outcome: observation.outcome,
-				...(observation.error?.response_error
-					? { response_error: observation.error.response_error }
-					: {}),
+				...(responseError ? { response_error: responseError } : {}),
 				...errorAttributes,
 			});
 		},

--- a/packages/node/src/utils/hevy-client-observability.ts
+++ b/packages/node/src/utils/hevy-client-observability.ts
@@ -76,6 +76,9 @@ function finishApiSpan(span: Span, observation: HevyRequestObservation): void {
 			...(errorAttributes.error_code
 				? { "error.code": errorAttributes.error_code }
 				: {}),
+			...(observation.error?.response_error
+				? { "hevy.api.response_error": observation.error.response_error }
+				: {}),
 		});
 	}
 	span.end();
@@ -143,6 +146,9 @@ export function createNodeHevyClientOptions(): HevyClientOptions {
 				status: observation.status || null,
 				retryCountBucket,
 				outcome: observation.outcome,
+				...(observation.error?.response_error
+					? { response_error: observation.error.response_error }
+					: {}),
 				...errorAttributes,
 			});
 		},

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -311,16 +311,10 @@ function installToolCallTracking(
 									? classifySdkValidation(error.message)
 									: { kind: "unknown" as const, expected: false };
 							if (validation.kind === "tool_not_found") {
-								markSdkToolFailure(
-									span,
-									new Error("MCP tool validation failed"),
-									toolName,
-									"validation",
-									{
-										expected: true,
-										validationKind: validation.kind,
-									},
-								);
+								markSdkToolFailure(span, error, toolName, "validation", {
+									expected: true,
+									validationKind: validation.kind,
+								});
 							} else {
 								markSdkToolFailure(span, error, toolName);
 							}

--- a/packages/node/src/utils/sdk-observability.ts
+++ b/packages/node/src/utils/sdk-observability.ts
@@ -306,7 +306,24 @@ function installToolCallTracking(
 							}
 							return result;
 						} catch (error) {
-							markSdkToolFailure(span, error, toolName);
+							const validation =
+								error instanceof Error
+									? classifySdkValidation(error.message)
+									: { kind: "unknown" as const, expected: false };
+							if (validation.kind === "tool_not_found") {
+								markSdkToolFailure(
+									span,
+									new Error("MCP tool validation failed"),
+									toolName,
+									"validation",
+									{
+										expected: true,
+										validationKind: validation.kind,
+									},
+								);
+							} else {
+								markSdkToolFailure(span, error, toolName);
+							}
 							throw error;
 						} finally {
 							span.end();


### PR DESCRIPTION
## Summary
- classify unknown MCP tool calls as expected caller validation failures
- extract only upstream `error`, `message`, or `detail` fields
- redact credentials, URLs, emails, JWTs, cookies, and UUIDs before Sentry/Tempo diagnostics
- keep response details out of metric labels

## Design
Response diagnostics are bounded to 256 characters after a 4 KiB input cap. Raw response bodies remain internal to `HevyHttpError`; only sanitized allowlisted text reaches telemetry. The sanitizer is dependency-free so the published Node 20 support floor is unchanged.

## Validation
- `npm run test:unit` — 76 files, 798 tests
- `npm run check:types`
- `npm run check:changeset`
- pre-push contract, mocked, stdio, Worker, build, package, and formatting lanes passed

## Related
- Sentry `HEVY-MCP-43` unknown-tool false positive
- Sentry `HEVY-MCP-44` repeated HTTP 500 update-workout failure
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Extract and sanitize upstream API error details for diagnostic telemetry while preventing sensitive data exposure in Sentry and metrics.

Main changes:
- Added bounded response error extraction with regex-based redaction of credentials, tokens, URLs, emails, and UUIDs to HevyHttpError and observations
- Propagate sanitized response_error field through failure normalization to Sentry context and OTel span events without exposing to metrics
- Classify unknown MCP tool validation errors as expected failures to reduce false-positive Sentry alerts

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
