### PR TITLE
docs: prohibit Git use in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,14 @@ Never push directly to `main`. Use Conventional Commits (`feat:`, `fix:`,
 `docs:`, `test:`, `refactor:`, `build:`, `ci:`, `chore:`, or `style:`) and keep
 Git hooks enabled. Fix hook failures instead of bypassing them.
 
+## Git safety in tests
+
+- Never write tests that invoke Git, execute `git` commands, or mutate Git
+  repositories or Git configuration. Use pure logic and ordinary filesystem
+  fixtures instead.
+- Never create, configure, or persist test Git identities such as
+  `user.name`, `user.email`, `GIT_AUTHOR_*`, or `GIT_COMMITTER_*`.
+
 ## Source-of-truth pointers
 
 - `CONTRIBUTING.md` owns development setup, Node policy, Worker operations,


### PR DESCRIPTION
## Summary

- prohibit tests from invoking Git or mutating Git repositories/configuration
- prohibit creating or persisting test Git identities

## Validation

- `git diff --check`
- pre-push hook passed with `NX_PARALLEL=1`

## Summary by Sourcery

Document Git safety guidelines for tests to avoid invoking Git or mutating repositories and identities.

Documentation:
- Add guidance prohibiting tests from invoking Git commands or mutating Git repositories or configuration.
- Add guidance prohibiting creation or persistence of test Git identities such as user.name, user.email, and author/committer environment variables.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Establish Git safety guidelines for test code to prevent repository mutations and identity configuration issues during testing.

Main changes:
- Added section prohibiting Git command execution and repository mutations in tests, requiring pure logic and filesystem fixtures instead
- Documented restriction on creating or persisting test Git identities via environment variables or configuration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
