### PR TITLE
test(worker): fix live workout events smoke test

### DIFF
--- a/tests/integration/worker-http.live.integration.test.ts
+++ b/tests/integration/worker-http.live.integration.test.ts
@@ -391,6 +391,7 @@ describeLive("live Wrangler Worker HTTP integration", () => {
 				}
 
 				const events = await callReadTool(client, "get-workout-events", {
+					page: 1,
 					page_size: 1,
 					since: "1970-01-01T00:00:00Z",
 				});


### PR DESCRIPTION
## Summary

Fixes the release smoke-test failure in `Smoke test live local Worker HTTP path`.

The live test invoked `get-workout-events` without its required `page` input. Zod coerced the missing value to `NaN`, producing:

> Input validation error: Invalid arguments for tool get-workout-events: page: Invalid input: expected number, received NaN

This PR now:

- Passes `page: 1` in the live smoke test.
- Exposes `HevyToolName` and schema-derived `HevyToolArguments` from `@hevy-mcp/core`.
- Preserves literal tool names in the production registry so names map to their exact schemas.
- Uses those types in live and mocked MCP call helpers instead of generic `JSONObject` arguments.
- Adds compile-time type assertions for the tool registry and `get-workout-events` arguments.

Removing `page` now fails `check:types` before any test runs:

> Property 'page' is missing ... but required in type '{ page: number; page_size: number; since: string; }'

## Validation

- Unit: 78 files, 783 tests passed.
- Worker HTTP integration: 10 tests passed.
- Mocked MCP integration and registry tests passed (29 tests).
- `check:types`, `check:boundaries`, lint, formatting, changeset checks, and pre-push passed.
