### PR TITLE
feat(worker): add locality to hosted activity spans

### DIFF
--- a/.changeset/quiet-cities-usage.md
+++ b/.changeset/quiet-cities-usage.md
@@ -1,0 +1,5 @@
+---
+"@hevy-mcp/worker": patch
+---
+
+Add bounded Cloudflare locality, region, and country attributes to hosted MCP activity spans for privacy-reviewed usage aggregation.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -18,9 +18,10 @@ The hosted service processes the following information to provide MCP tools:
 - Operational request metadata such as the request path, client origin,
   authentication mode, response status, and duration.
 - Hosted MCP activity spans may contain a short HMAC-based pseudonym derived
-  from the API key and the Cloudflare colo that processed the request. The
-  pseudonym is not the API key, and the colo is a regional edge proxy rather
-  than exact user geography.
+  from the API key, the Cloudflare colo that processed the request, and bounded
+  approximate Cloudflare IP-geolocation fields such as city, region, and
+  country. The pseudonym is not the API key, and these fields are not exact
+  user geography.
 
 The service does not intentionally collect conversation history, prompts, tool
 arguments, tool results, workout content, measurement values, raw client IP
@@ -44,9 +45,10 @@ access. OAuth access tokens expire after seven days and refresh tokens expire
 after thirty days. Rotating the Hevy API key invalidates grants created with
 that key.
 
-Hosted activity spans containing `span.user.hash` or `span.cloudflare.colo` are
-retained for 30 days and are accessible only to repository maintainers and the
-on-call operator.
+Hosted activity spans containing `span.user.hash`,
+`span.cloudflare.colo`, or approximate geography fields are retained for 30
+days and are accessible only to repository maintainers and the on-call
+operator.
 
 The hosted Worker uses request-scoped in-memory caches and does not maintain a
 shared workout-data database. Cloudflare may process operational logs under

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -48,7 +48,9 @@ that key.
 Hosted activity spans containing `span.user.hash`,
 `span.cloudflare.colo`, or approximate geography fields are retained for 30
 days and are accessible only to repository maintainers and the on-call
-operator.
+operator. Trace-derived Worker usage metrics that retain `user_hash` together
+with locality use the same 30-day retention and access policy; tool-usage and
+Worker-location rollups omit `user_hash`.
 
 The hosted Worker uses request-scoped in-memory caches and does not maintain a
 shared workout-data database. Cloudflare may process operational logs under

--- a/docs/telemetry-dashboards.md
+++ b/docs/telemetry-dashboards.md
@@ -92,7 +92,10 @@ with placeholders; raw IDs never reach these panels.
 
 Approved application policy for these dashboards:
 
-- aggregate metrics: 90 days;
+- application aggregate metrics without a user pseudonym: 90 days;
+- trace-derived Worker usage metrics containing `user_hash` with locality:
+  30 days, with access limited to repository maintainers and the on-call
+  operator;
 - Sentry error events and OTel traces containing sanitized client metadata or
   bounded diagnostic details: 30 days;
 - correlation-ID troubleshooting views: 24 hours of access and no saved

--- a/docs/telemetry-dashboards.md
+++ b/docs/telemetry-dashboards.md
@@ -26,20 +26,30 @@ WHERE transport = "stdio"
 ## Hosted Worker regional activity
 
 Hosted Worker MCP activity spans carry the deterministic pseudonymous
-`span.user.hash` and, only for requests with Cloudflare request metadata,
-`span.cloudflare.colo`. A colo is the Cloudflare edge point of presence that
-processed the request; it is a regional proxy, not the user's exact geography.
+`span.user.hash`, Cloudflare's edge `span.cloudflare.colo`, and, when
+available, bounded approximate request geography:
+`span.geo.locality.name`, `span.geo.locality.region`, and
+`span.geo.country.code`. A colo is the Cloudflare edge point of presence that
+processed the request; geography is IP-derived and is not verified residence.
 
-Use a scoped TraceQL metrics query to produce one row per user/colo pair:
+Use a scoped TraceQL metrics query to produce one row per user/locality pair:
 
 ```text
-{ span.user.hash != nil && span.cloudflare.colo != nil }
-| count_over_time() by (span.cloudflare.colo, span.user.hash)
+{ span.user.hash != nil && span.geo.locality.name != nil }
+| count_over_time() by (
+    span.geo.locality.name,
+    span.geo.locality.region,
+    span.geo.country.code,
+    span.user.hash
+  )
 ```
 
-Count distinct `span.user.hash` values per `span.cloudflare.colo` client-side
-for the selected window. Do not include raw client IP addresses, and do not
-save the pseudonymous hash as a per-user behavior history.
+The production VictoriaMetrics path should use separate trace-derived metric
+profiles: user activity keeps `user_hash` plus locality, while tool usage keeps
+tool taxonomy plus locality and omits `user_hash`. This avoids a
+`user_hash × tool × locality` series explosion. Count distinct user hashes per
+locality for the selected window. Do not include raw client IP addresses, and
+do not save a per-user behavior history beyond the approved retention window.
 
 ## Tool reliability
 

--- a/docs/telemetry-data-dictionary.md
+++ b/docs/telemetry-data-dictionary.md
@@ -28,6 +28,9 @@ final defense-in-depth scrubber.
 | Correlation IDs                | OTel trace/span IDs, Sentry event ID, and opaque per-failure ID; never a user identity       | Failure events and traces                     |
 | `user.hash`                    | Ten-character lowercase HMAC pseudonym; never the raw Hevy API key                           | Hosted Worker MCP activity spans              |
 | `cloudflare.colo`              | Three-letter Cloudflare edge colo; a regional proxy, not exact user geography                | Hosted Worker MCP activity spans              |
+| `geo.locality.name`            | Bounded approximate Cloudflare IP-geolocation city                                           | Hosted Worker MCP activity spans              |
+| `geo.locality.region`          | Bounded approximate Cloudflare IP-geolocation region                                         | Hosted Worker MCP activity spans              |
+| `geo.country.code`             | Two-letter approximate Cloudflare IP-geolocation country code                                | Hosted Worker MCP activity spans              |
 
 API error categories and codes are emitted only after
 `createSafeErrorDiagnostic` normalization. Categories are the finite
@@ -64,10 +67,12 @@ missing values become `unknown`. The transport is always `stdio` for this
 path. Emitted metrics never contain a session ID, request ID, progress token, prompt,
 argument, result, or API-key-derived identity. TraceQL-derived metrics may
 aggregate the approved attributes from hosted Worker activity spans. Hosted
-Worker MCP activity spans may carry `user.hash` for distinct-user analysis and
-`cloudflare.colo` only when Cloudflare supplies it on the request. The hash is
-pseudonymous, and the colo is an edge point of presence rather than the user's
-location.
+Worker MCP activity spans may carry `user.hash` for distinct-user analysis,
+`cloudflare.colo` for the edge point of presence, and bounded approximate
+Cloudflare IP-geolocation fields (`geo.locality.name`,
+`geo.locality.region`, and `geo.country.code`) when Cloudflare supplies them.
+The hash is pseudonymous; the colo is an edge point of presence; and the
+geography fields are approximate request location, not verified residence.
 The server version is supplied by the service resource (`service.version`)
 and server lifecycle spans. Cloudflare-native telemetry is normalized at the
 collector from the deployment tag in `faas.version` only when
@@ -95,7 +100,8 @@ Never send or inspect for telemetry:
 - exact dates or timestamps from tool arguments or returned records;
 - body measurements, weights, reps, distances, durations, or other measurement
   values;
-- raw client IP addresses or exact location data;
+- raw client IP addresses, exact location data, latitude, longitude, or postal
+  codes;
 - arbitrary client metadata or unnormalized endpoint paths.
 
 ## Regression guard

--- a/packages/worker/src/worker-observer.test.ts
+++ b/packages/worker/src/worker-observer.test.ts
@@ -156,6 +156,40 @@ describe("createWorkerToolObserver", () => {
 		);
 	});
 
+	it.each([
+		"198.51.100.10",
+		"37.7749",
+		"37.7749, -122.4194",
+		"94103",
+		"12345-6789",
+		"a".repeat(65),
+	])(
+		"omits identifier-shaped or oversized geography attributes: %s",
+		async (value) => {
+			const events: WorkerObservationEvent[] = [];
+			const { span, tracing } = createTracingDouble();
+			const scope = createScope(events, {
+				geoLocalityName: value,
+				geoLocalityRegion: value,
+				geoCountryCode: "US",
+				tracing,
+			});
+
+			await scope.run(() => Promise.resolve("ok"));
+			finish(scope, { outcome: "success", durationMs: 1 });
+
+			expect(span.setAttribute).not.toHaveBeenCalledWith(
+				"geo.locality.name",
+				expect.anything(),
+			);
+			expect(span.setAttribute).not.toHaveBeenCalledWith(
+				"geo.locality.region",
+				expect.anything(),
+			);
+			expect(span.setAttribute).toHaveBeenCalledWith("geo.country.code", "US");
+		},
+	);
+
 	it("emits safe bounded invocation and successful completion events", async () => {
 		const events: WorkerObservationEvent[] = [];
 		const scope = createScope(events);

--- a/packages/worker/src/worker-observer.test.ts
+++ b/packages/worker/src/worker-observer.test.ts
@@ -66,6 +66,9 @@ describe("createWorkerToolObserver", () => {
 		const scope = createScope(events, {
 			userHash: "2cb0b5f95a",
 			cloudflareColo: "SFO",
+			geoLocalityName: "San Francisco",
+			geoLocalityRegion: "California",
+			geoCountryCode: "US",
 			tracing,
 		});
 
@@ -78,6 +81,21 @@ describe("createWorkerToolObserver", () => {
 		);
 		expect(span.setAttribute).toHaveBeenCalledWith("user.hash", "2cb0b5f95a");
 		expect(span.setAttribute).toHaveBeenCalledWith("cloudflare.colo", "SFO");
+		expect(span.setAttribute).toHaveBeenCalledWith("hevy.feature", "workouts");
+		expect(span.setAttribute).toHaveBeenCalledWith("mcp.tool.kind", "read");
+		expect(span.setAttribute).toHaveBeenCalledWith(
+			"mcp.tool.operation",
+			"list",
+		);
+		expect(span.setAttribute).toHaveBeenCalledWith(
+			"geo.locality.name",
+			"San Francisco",
+		);
+		expect(span.setAttribute).toHaveBeenCalledWith(
+			"geo.locality.region",
+			"California",
+		);
+		expect(span.setAttribute).toHaveBeenCalledWith("geo.country.code", "US");
 		expect(span.end).toHaveBeenCalledOnce();
 		expect(JSON.stringify(span.setAttribute.mock.calls)).not.toContain(
 			"test-key",
@@ -111,6 +129,9 @@ describe("createWorkerToolObserver", () => {
 		const { span, tracing } = createTracingDouble();
 		const scope = createScope(events, {
 			userHash: "2cb0b5f95a",
+			geoLocalityName: "<script>",
+			geoLocalityRegion: "California",
+			geoCountryCode: "USA",
 			tracing,
 		});
 
@@ -119,6 +140,18 @@ describe("createWorkerToolObserver", () => {
 
 		expect(span.setAttribute).not.toHaveBeenCalledWith(
 			"cloudflare.colo",
+			expect.anything(),
+		);
+		expect(span.setAttribute).not.toHaveBeenCalledWith(
+			"geo.locality.name",
+			expect.anything(),
+		);
+		expect(span.setAttribute).toHaveBeenCalledWith(
+			"geo.locality.region",
+			"California",
+		);
+		expect(span.setAttribute).not.toHaveBeenCalledWith(
+			"geo.country.code",
 			expect.anything(),
 		);
 	});

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -17,8 +17,11 @@ const MAX_STRING_LENGTH = 160;
 const MAX_ARGUMENT_KEYS = 32;
 const MAX_WORKFLOW_PAGES = 10_000;
 const MAX_WORKFLOW_ITEMS = 1_000_000;
+const MAX_GEO_VALUE_LENGTH = 64;
 const SAFE_USER_HASH_PATTERN = /^[0-9a-f]{10}$/u;
 const SAFE_CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
+const SAFE_COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
+const SAFE_GEO_VALUE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .,'’()/_-]{0,63}$/u;
 
 const SAFE_ARGUMENT_KEYS = new Set([
 	"date",
@@ -190,6 +193,12 @@ export interface WorkerToolObserverOptions {
 	readonly userHash?: string;
 	/** Cloudflare's three-letter edge colo, when the request has one. */
 	readonly cloudflareColo?: string;
+	/** Approximate Cloudflare IP-geolocation locality name. */
+	readonly geoLocalityName?: string;
+	/** Approximate Cloudflare IP-geolocation region. */
+	readonly geoLocalityRegion?: string;
+	/** Approximate Cloudflare IP-geolocation country code. */
+	readonly geoCountryCode?: string;
 	/** Injectable for unit tests; production uses Cloudflare's tracing API when available. */
 	readonly tracing?: WorkerTracing;
 }
@@ -214,6 +223,21 @@ function safeUserHash(value: unknown): string | undefined {
 
 function safeCloudflareColo(value: unknown): string | undefined {
 	return typeof value === "string" && SAFE_CLOUDFLARE_COLO_PATTERN.test(value)
+		? value
+		: undefined;
+}
+
+function safeGeoValue(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().replace(/\s+/gu, " ");
+	return normalized.length <= MAX_GEO_VALUE_LENGTH &&
+		SAFE_GEO_VALUE_PATTERN.test(normalized)
+		? normalized
+		: undefined;
+}
+
+function safeCountryCode(value: unknown): string | undefined {
+	return typeof value === "string" && SAFE_COUNTRY_CODE_PATTERN.test(value)
 		? value
 		: undefined;
 }
@@ -527,6 +551,9 @@ export function createWorkerToolObserver(
 		options.tracing ?? cloudflareWorkers.tracing;
 	const userHash = safeUserHash(options.userHash);
 	const cloudflareColo = safeCloudflareColo(options.cloudflareColo);
+	const geoLocalityName = safeGeoValue(options.geoLocalityName);
+	const geoLocalityRegion = safeGeoValue(options.geoLocalityRegion);
+	const geoCountryCode = safeCountryCode(options.geoCountryCode);
 	return {
 		start(invocation): ToolObservationScope {
 			let safe: Omit<WorkerObservationEvent, "event">;
@@ -555,9 +582,25 @@ export function createWorkerToolObserver(
 									[safe.kind === "prompt"
 										? "mcp.prompt.name"
 										: "mcp.tool.name"]: safe.name,
+									...(safe.taxonomy
+										? {
+												"hevy.feature": safe.taxonomy.feature,
+												"mcp.tool.kind": safe.taxonomy.kind,
+												"mcp.tool.operation": safe.taxonomy.operation,
+											}
+										: {}),
 									...(userHash ? { "user.hash": userHash } : {}),
 									...(cloudflareColo
 										? { "cloudflare.colo": cloudflareColo }
+										: {}),
+									...(geoLocalityName
+										? { "geo.locality.name": geoLocalityName }
+										: {}),
+									...(geoLocalityRegion
+										? { "geo.locality.region": geoLocalityRegion }
+										: {}),
+									...(geoCountryCode
+										? { "geo.country.code": geoCountryCode }
 										: {}),
 								});
 								return operation();

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -1,5 +1,6 @@
 import type { Span } from "@cloudflare/workers-types";
 import * as cloudflareWorkers from "cloudflare:workers";
+import { sanitizeCloudflareGeographyValue } from "./worker-telemetry.js";
 import {
 	createExecutionProjection,
 	createSafeErrorDiagnostic,
@@ -17,11 +18,9 @@ const MAX_STRING_LENGTH = 160;
 const MAX_ARGUMENT_KEYS = 32;
 const MAX_WORKFLOW_PAGES = 10_000;
 const MAX_WORKFLOW_ITEMS = 1_000_000;
-const MAX_GEO_VALUE_LENGTH = 64;
 const SAFE_USER_HASH_PATTERN = /^[0-9a-f]{10}$/u;
 const SAFE_CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
 const SAFE_COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
-const SAFE_GEO_VALUE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .,'’()/_-]{0,63}$/u;
 
 const SAFE_ARGUMENT_KEYS = new Set([
 	"date",
@@ -224,15 +223,6 @@ function safeUserHash(value: unknown): string | undefined {
 function safeCloudflareColo(value: unknown): string | undefined {
 	return typeof value === "string" && SAFE_CLOUDFLARE_COLO_PATTERN.test(value)
 		? value
-		: undefined;
-}
-
-function safeGeoValue(value: unknown): string | undefined {
-	if (typeof value !== "string") return undefined;
-	const normalized = value.trim().replace(/\s+/gu, " ");
-	return normalized.length <= MAX_GEO_VALUE_LENGTH &&
-		SAFE_GEO_VALUE_PATTERN.test(normalized)
-		? normalized
 		: undefined;
 }
 
@@ -551,8 +541,12 @@ export function createWorkerToolObserver(
 		options.tracing ?? cloudflareWorkers.tracing;
 	const userHash = safeUserHash(options.userHash);
 	const cloudflareColo = safeCloudflareColo(options.cloudflareColo);
-	const geoLocalityName = safeGeoValue(options.geoLocalityName);
-	const geoLocalityRegion = safeGeoValue(options.geoLocalityRegion);
+	const geoLocalityName = sanitizeCloudflareGeographyValue(
+		options.geoLocalityName,
+	);
+	const geoLocalityRegion = sanitizeCloudflareGeographyValue(
+		options.geoLocalityRegion,
+	);
 	const geoCountryCode = safeCountryCode(options.geoCountryCode);
 	return {
 		start(invocation): ToolObservationScope {

--- a/packages/worker/src/worker-telemetry.test.ts
+++ b/packages/worker/src/worker-telemetry.test.ts
@@ -51,6 +51,33 @@ describe("Worker telemetry context", () => {
 		);
 	});
 
+	it("reads each geography field once", () => {
+		const reads = { city: 0, region: 0, country: 0 };
+		const cf = {
+			get city() {
+				reads.city += 1;
+				return "San Francisco";
+			},
+			get region() {
+				reads.region += 1;
+				return "California";
+			},
+			get country() {
+				reads.country += 1;
+				return "US";
+			},
+		};
+		const request = new Request("https://worker.example/mcp");
+		Object.defineProperty(request, "cf", { value: cf });
+
+		expect(getCloudflareGeography(request)).toEqual({
+			localityName: "San Francisco",
+			localityRegion: "California",
+			countryCode: "US",
+		});
+		expect(reads).toEqual({ city: 1, region: 1, country: 1 });
+	});
+
 	it.each([
 		{ city: "", region: "California", country: "US" },
 		{ city: "San Francisco", region: "California", country: "USA" },
@@ -63,6 +90,21 @@ describe("Worker telemetry context", () => {
 				? { localityName: "San Francisco", localityRegion: "California" }
 				: { localityRegion: "California", countryCode: "US" },
 		);
+	});
+
+	it.each([
+		"198.51.100.10",
+		"37.7749",
+		"37.7749, -122.4194",
+		"94103",
+		"12345-6789",
+		"a".repeat(65),
+	])("rejects identifier-shaped or oversized geography values: %s", (value) => {
+		const request = new Request("https://worker.example/mcp");
+		Object.defineProperty(request, "cf", {
+			value: { city: value, region: value, country: "US" },
+		});
+		expect(getCloudflareGeography(request)).toEqual({ countryCode: "US" });
 	});
 
 	it.each([

--- a/packages/worker/src/worker-telemetry.test.ts
+++ b/packages/worker/src/worker-telemetry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createWorkerUserHash, getCloudflareColo } from "./worker-telemetry.js";
+import {
+	createWorkerUserHash,
+	getCloudflareColo,
+	getCloudflareGeography,
+} from "./worker-telemetry.js";
 
 describe("Worker telemetry context", () => {
 	it("keeps the existing deterministic HMAC user pseudonym", async () => {
@@ -24,6 +28,40 @@ describe("Worker telemetry context", () => {
 		expect(getCloudflareColo(request)).toBe("SFO");
 		expect(JSON.stringify(getCloudflareColo(request))).not.toContain(
 			"198.51.100.10",
+		);
+	});
+
+	it("returns bounded approximate geography without client identifiers", () => {
+		const request = new Request("https://worker.example/mcp");
+		Object.defineProperty(request, "cf", {
+			value: {
+				city: "San Francisco",
+				region: "California",
+				country: "US",
+				clientIp: "198.51.100.10",
+			},
+		});
+		expect(getCloudflareGeography(request)).toEqual({
+			localityName: "San Francisco",
+			localityRegion: "California",
+			countryCode: "US",
+		});
+		expect(JSON.stringify(getCloudflareGeography(request))).not.toContain(
+			"198.51.100.10",
+		);
+	});
+
+	it.each([
+		{ city: "", region: "California", country: "US" },
+		{ city: "San Francisco", region: "California", country: "USA" },
+		{ city: "<script>", region: "California", country: "US" },
+	])("drops malformed geography fields: %j", (cf) => {
+		const request = new Request("https://worker.example/mcp");
+		Object.defineProperty(request, "cf", { value: cf });
+		expect(getCloudflareGeography(request)).toEqual(
+			cf.country === "USA"
+				? { localityName: "San Francisco", localityRegion: "California" }
+				: { localityRegion: "California", countryCode: "US" },
 		);
 	});
 

--- a/packages/worker/src/worker-telemetry.ts
+++ b/packages/worker/src/worker-telemetry.ts
@@ -1,12 +1,59 @@
 const USER_HASH_CONTEXT = "hevy-mcp:sentry-user-id:v1";
 const USER_HASH_LENGTH = 10;
 const CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
+const COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
+const GEO_VALUE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .,'’()/_-]{0,63}$/u;
+const MAX_GEO_VALUE_LENGTH = 64;
 
 type RequestWithCloudflareProperties = Request & {
 	readonly cf?: {
 		readonly colo?: unknown;
+		readonly city?: unknown;
+		readonly region?: unknown;
+		readonly country?: unknown;
 	};
 };
+
+export interface CloudflareGeography {
+	readonly localityName?: string;
+	readonly localityRegion?: string;
+	readonly countryCode?: string;
+}
+
+function safeGeoValue(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().replace(/\s+/gu, " ");
+	return normalized.length <= MAX_GEO_VALUE_LENGTH &&
+		GEO_VALUE_PATTERN.test(normalized)
+		? normalized
+		: undefined;
+}
+
+/**
+ * Return bounded Cloudflare IP-geolocation fields. These values describe the
+ * request's approximate location; they are not exact location data.
+ */
+export function getCloudflareGeography(request: Request): CloudflareGeography {
+	try {
+		const cf = (request as RequestWithCloudflareProperties).cf;
+		const countryCode =
+			typeof cf?.country === "string" && COUNTRY_CODE_PATTERN.test(cf.country)
+				? cf.country
+				: undefined;
+		return {
+			...(safeGeoValue(cf?.city)
+				? { localityName: safeGeoValue(cf?.city) }
+				: {}),
+			...(safeGeoValue(cf?.region)
+				? { localityRegion: safeGeoValue(cf?.region) }
+				: {}),
+			...(countryCode ? { countryCode } : {}),
+		};
+	} catch {
+		// Request metadata is optional and must never affect MCP behavior.
+		return {};
+	}
+}
 
 /**
  * Return the Cloudflare edge colo only when the Worker supplied a valid value.

--- a/packages/worker/src/worker-telemetry.ts
+++ b/packages/worker/src/worker-telemetry.ts
@@ -3,6 +3,8 @@ const USER_HASH_LENGTH = 10;
 const CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
 const COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
 const GEO_VALUE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .,'’()/_-]{0,63}$/u;
+const IDENTIFIER_SHAPED_GEO_VALUE_PATTERN =
+	/^(?:(?:\d{1,3}\.){3}\d{1,3}|-?\d+(?:\.\d+)?(?:\s*,\s*-?\d+(?:\.\d+)?)?|\d[\d -]*\d)$/u;
 const MAX_GEO_VALUE_LENGTH = 64;
 
 type RequestWithCloudflareProperties = Request & {
@@ -20,10 +22,18 @@ export interface CloudflareGeography {
 	readonly countryCode?: string;
 }
 
-function safeGeoValue(value: unknown): string | undefined {
-	if (typeof value !== "string") return undefined;
+/**
+ * Sanitize a Cloudflare-provided locality or region without allowing
+ * identifier-shaped values such as IP addresses, coordinates, or postal codes.
+ */
+export function sanitizeCloudflareGeographyValue(
+	value: unknown,
+): string | undefined {
+	if (typeof value !== "string" || value.length > MAX_GEO_VALUE_LENGTH)
+		return undefined;
 	const normalized = value.trim().replace(/\s+/gu, " ");
 	return normalized.length <= MAX_GEO_VALUE_LENGTH &&
+		!IDENTIFIER_SHAPED_GEO_VALUE_PATTERN.test(normalized) &&
 		GEO_VALUE_PATTERN.test(normalized)
 		? normalized
 		: undefined;
@@ -36,17 +46,16 @@ function safeGeoValue(value: unknown): string | undefined {
 export function getCloudflareGeography(request: Request): CloudflareGeography {
 	try {
 		const cf = (request as RequestWithCloudflareProperties).cf;
+		const country = cf?.country;
 		const countryCode =
-			typeof cf?.country === "string" && COUNTRY_CODE_PATTERN.test(cf.country)
-				? cf.country
+			typeof country === "string" && COUNTRY_CODE_PATTERN.test(country)
+				? country
 				: undefined;
+		const localityName = sanitizeCloudflareGeographyValue(cf?.city);
+		const localityRegion = sanitizeCloudflareGeographyValue(cf?.region);
 		return {
-			...(safeGeoValue(cf?.city)
-				? { localityName: safeGeoValue(cf?.city) }
-				: {}),
-			...(safeGeoValue(cf?.region)
-				? { localityRegion: safeGeoValue(cf?.region) }
-				: {}),
+			...(localityName ? { localityName } : {}),
+			...(localityRegion ? { localityRegion } : {}),
 			...(countryCode ? { countryCode } : {}),
 		};
 	} catch {

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -441,7 +441,13 @@ describe("real stateless SDK transport", () => {
 
 	it("passes the user hash and Cloudflare colo to activity observation", async () => {
 		let observerOptions:
-			| { userHash?: string; cloudflareColo?: string }
+			| {
+					userHash?: string;
+					cloudflareColo?: string;
+					geoLocalityName?: string;
+					geoLocalityRegion?: string;
+					geoCountryCode?: string;
+			  }
 			| undefined;
 		const request = mcpRequest({
 			jsonrpc: "2.0",
@@ -453,7 +459,14 @@ describe("real stateless SDK transport", () => {
 				clientInfo: { name: "telemetry-context-test", version: "1" },
 			},
 		});
-		Object.defineProperty(request, "cf", { value: { colo: "SFO" } });
+		Object.defineProperty(request, "cf", {
+			value: {
+				colo: "SFO",
+				city: "San Francisco",
+				region: "California",
+				country: "US",
+			},
+		});
 		const handler = createWorkerHandler({
 			createValidationClient: () => createMockClient(),
 			createObserver: (options) => {
@@ -466,6 +479,9 @@ describe("real stateless SDK transport", () => {
 		expect(observerOptions).toEqual({
 			userHash: "2cb0b5f95a",
 			cloudflareColo: "SFO",
+			geoLocalityName: "San Francisco",
+			geoLocalityRegion: "California",
+			geoCountryCode: "US",
 		});
 	});
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -25,7 +25,11 @@ import {
 	createWorkerToolObserver,
 	type WorkerToolObserverOptions,
 } from "./worker-observer.js";
-import { createWorkerUserHash, getCloudflareColo } from "./worker-telemetry.js";
+import {
+	createWorkerUserHash,
+	getCloudflareColo,
+	getCloudflareGeography,
+} from "./worker-telemetry.js";
 
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
@@ -342,9 +346,13 @@ async function serveMcpRequest(
 	deadline: number,
 ): Promise<Response> {
 	try {
+		const geography = getCloudflareGeography(request);
 		const observer = dependencies.createObserver({
 			userHash: await createWorkerUserHash(apiKey),
 			cloudflareColo: getCloudflareColo(request),
+			geoLocalityName: geography.localityName,
+			geoLocalityRegion: geography.localityRegion,
+			geoCountryCode: geography.countryCode,
 		});
 		const server = dependencies.createServer(
 			({ onLog }) =>


### PR DESCRIPTION
## Primary changes
- propagate bounded Cloudflare city, region, and country metadata to hosted Worker activity spans
- retain the existing HMAC user pseudonym and colo correlation
- add taxonomy attributes to Worker activity spans for trace-derived tool metrics
- document the approximate geography fields and retention/access semantics

## Reviewer walkthrough
- `packages/worker/src/worker-telemetry.ts` extracts and bounds Cloudflare locality, region, and country metadata.
- `packages/worker/src/worker.ts` forwards sanitized geography alongside the existing user hash and colo values.
- `packages/worker/src/worker-observer.ts` applies defense-in-depth validation and emits taxonomy and geography attributes; focused tests cover extraction, propagation, and omission.
- Documentation and the changeset describe approximate geography, retention and access semantics, dashboard aggregation, and the Worker release impact.

## Correctness and invariants
- Geography remains optional and bounded; invalid, oversized, identifier-shaped, or unavailable values are omitted.
- The existing HMAC user pseudonym and Cloudflare colo correlation remain intact.
- Raw IP addresses, exact location data, latitude/longitude, and postal codes are not emitted.

## Testing and QA
- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run worker:dry-run`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

This PR is the Worker-side prerequisite for the separate cardinality-conscious Collector span-metrics pipelines.

## Summary by Sourcery

Propagate bounded Cloudflare IP-geolocation metadata into hosted Worker MCP activity spans and document the new privacy-reviewed telemetry fields and retention semantics.

New Features:
- Expose approximate Cloudflare geography (city, region, country code) on Worker requests via a safe helper for use in telemetry.
- Attach tool taxonomy attributes and approximate geography fields to Worker activity spans for trace-derived metrics aggregation.

Enhancements:
- Validate and normalize Cloudflare geography metadata in the Worker observer to ensure bounded, safe span attributes.
- Extend Worker observer options and wiring so locality information flows from incoming requests into span attributes.

Documentation:
- Update telemetry dashboards documentation to describe new geography span attributes and recommended aggregation strategies that avoid series explosion.
- Expand the telemetry data dictionary and privacy policy to cover approximate geography fields, clarify that they are not exact location data, and document retention and access constraints.

Tests:
- Add unit tests for Cloudflare geography extraction, safe normalization of geography fields, and propagation into Worker observer span attributes and options.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add bounded Cloudflare IP-geolocation attributes (city, region, country) to hosted MCP activity spans for privacy-reviewed geographic usage aggregation.

Main changes:
- Added `safeGeoValue()` and `safeCountryCode()` validation functions with regex patterns to sanitize and bound geographic fields in worker-observer.ts and worker-telemetry.ts
- Extended `WorkerToolObserverOptions` interface with `geoLocalityName`, `geoLocalityRegion`, `geoCountryCode` fields and span attribute emission logic
- Implemented `getCloudflareGeography()` function extracting bounded Cloudflare IP-geolocation from request metadata, integrated into MCP request handler

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using [Guidelines](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted activity telemetry now includes sanitized, approximate city, region, and country information when available.
  * Geographic values are validated and limited to protect privacy; raw IP addresses and precise location data are not collected.

* **Documentation**
  * Updated privacy, telemetry dashboard, and data dictionary documentation to describe geographic metadata, access controls, and 30-day retention.
  * Added guidance for grouping activity by approximate location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
