### PR TITLE
feat(node): propagate user.hash to activity spans #988

### DIFF
--- a/.changeset/steady-hashes-trace.md
+++ b/.changeset/steady-hashes-trace.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Propagate the bounded HMAC `user.hash` pseudonym onto Node tool, discovery, and prompt activity spans without exporting raw Hevy API keys.

--- a/docs/telemetry-data-dictionary.md
+++ b/docs/telemetry-data-dictionary.md
@@ -26,7 +26,7 @@ final defense-in-depth scrubber.
 | HTTP status                    | Numeric status code                                                                          | API diagnostics and metrics                   |
 | Error expectedness             | Boolean; expected failures are not sent to Sentry                                            | Failure spans                                 |
 | Correlation IDs                | OTel trace/span IDs, Sentry event ID, and opaque per-failure ID; never a user identity       | Failure events and traces                     |
-| `user.hash`                    | Ten-character lowercase HMAC pseudonym; never the raw Hevy API key                           | Hosted Worker MCP activity spans              |
+| `user.hash`                    | Ten-character lowercase HMAC pseudonym; never the raw Hevy API key                           | Node and hosted Worker MCP activity spans     |
 | `cloudflare.colo`              | Three-letter Cloudflare edge colo; a regional proxy, not exact user geography                | Hosted Worker MCP activity spans              |
 | `geo.locality.name`            | Bounded approximate Cloudflare IP-geolocation city                                           | Hosted Worker MCP activity spans              |
 | `geo.locality.region`          | Bounded approximate Cloudflare IP-geolocation region                                         | Hosted Worker MCP activity spans              |
@@ -64,12 +64,13 @@ The stdio initialize message may provide client name, client version, and MCP
 protocol version. Each value is trimmed, restricted to the safe token
 character set `[A-Za-z0-9._+:/@-]`, and limited to 64 characters; malformed or
 missing values become `unknown`. The transport is always `stdio` for this
-path. Emitted metrics never contain a session ID, request ID, progress token, prompt,
-argument, result, or API-key-derived identity. TraceQL-derived metrics may
-aggregate the approved attributes from hosted Worker activity spans. Hosted
-Worker MCP activity spans may carry `user.hash` for distinct-user analysis,
-`cloudflare.colo` for the edge point of presence, and bounded approximate
-Cloudflare IP-geolocation fields (`geo.locality.name`,
+path. Emitted metrics never contain a session ID, request ID, progress token,
+prompt, argument, result, or API-key-derived identity. TraceQL-derived metrics
+may aggregate the approved attributes from hosted Worker activity spans. Node
+MCP activity spans carry `user.hash` when the authenticated Hevy API key is
+available. Hosted Worker MCP activity spans may carry `user.hash` for
+distinct-user analysis, `cloudflare.colo` for the edge point of presence, and
+bounded approximate Cloudflare IP-geolocation fields (`geo.locality.name`,
 `geo.locality.region`, and `geo.country.code`) when Cloudflare supplies them.
 The hash is pseudonymous; the colo is an edge point of presence; and the
 geography fields are approximate request location, not verified residence.

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -223,6 +223,12 @@ describe("Node package entrypoint", () => {
 			"mcp.tools.count",
 			25,
 		);
+		expect(testDoubles.createNodeToolObserver).toHaveBeenCalledWith({
+			userHash: "0b633a8f53",
+		});
+		expect(
+			JSON.stringify(testDoubles.createNodeToolObserver.mock.calls),
+		).not.toContain("programmatic-key");
 		expect(testDoubles.server.connect).not.toHaveBeenCalled();
 	});
 	it("enriches initialize and tool SDK spans", async () => {

--- a/packages/node/src/runtime.ts
+++ b/packages/node/src/runtime.ts
@@ -14,6 +14,7 @@ import {
 	createNodeHevyClientOptions,
 } from "./utils/hevy-client-observability.js";
 import { createNodeToolObserver } from "./utils/tool-observer.js";
+import { createNodeUserHash } from "./utils/user-hash.js";
 import { createInstrumentedStdioTransport } from "./utils/stdio-observability.js";
 import {
 	recordMcpSessionTermination,
@@ -186,7 +187,9 @@ function buildServer(
 					lifecycleSignal,
 					onToolsRegistered: (count) =>
 						span.setAttribute("mcp.tools.count", count),
-					observer: createNodeToolObserver(),
+					observer: createNodeToolObserver({
+						userHash: createNodeUserHash(apiKey),
+					}),
 					cacheObserver: createNodeCacheObserver(),
 				});
 				installSdkErrorTracking(server, transport);

--- a/packages/node/src/utils/tool-observer.test.ts
+++ b/packages/node/src/utils/tool-observer.test.ts
@@ -179,6 +179,52 @@ describe("createNodeToolObserver", () => {
 		expect(testDoubles.span.end).toHaveBeenCalledOnce();
 	});
 
+	it.each([
+		{ name: "get-workouts", category: "tool" },
+		{ name: "search-routines", category: "discovery" },
+		{
+			name: "create-workout-from-routine",
+			kind: "prompt" as const,
+			category: "tool",
+		},
+	])("propagates user.hash to $name activity spans", async (caseData) => {
+		const userHash = "2cb0b5f95a";
+		const { category, ...invocation } = caseData;
+		const typedInvocation = invocation satisfies SafeToolInvocation;
+		const scope = createNodeToolObserver({ userHash }).start(typedInvocation);
+		if (!scope) throw new Error("Expected the Node observer to create a scope");
+
+		await scope.run(() => Promise.resolve("result"));
+		await scope.finish({ outcome: "success", durationMs: 1 });
+
+		const spanOptions = testDoubles.startActiveSpan.mock.calls[0]?.[1] as {
+			attributes: Record<string, string | number | boolean>;
+		};
+		expect(spanOptions.attributes).toEqual(
+			expect.objectContaining({
+				"mcp.span.category": category,
+				"user.hash": userHash,
+			}),
+		);
+	});
+
+	it("does not attach raw API keys to activity spans", async () => {
+		const secret = "node-api-key-secret-sentinel";
+		const scope = createNodeToolObserver({ userHash: secret }).start(
+			invocation,
+		);
+		if (!scope) throw new Error("Expected the Node observer to create a scope");
+
+		await scope.run(() => Promise.resolve("result"));
+		await scope.finish({ outcome: "success", durationMs: 1 });
+
+		const spanOptions = testDoubles.startActiveSpan.mock.calls[0]?.[1] as {
+			attributes: Record<string, string | number | boolean>;
+		};
+		expect(spanOptions.attributes).not.toHaveProperty("user.hash");
+		expect(JSON.stringify(spanOptions)).not.toContain(secret);
+	});
+
 	it("records only core-sanitized diagnostics for thrown errors", async () => {
 		const secret = "private-error-message-and-stack";
 		const error = new Error(secret);

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -25,6 +25,7 @@ import { captureFailure, tracer } from "./telemetry.js";
 
 type AttributeValue = string | number | boolean;
 const DISCOVERY_TOOL_NAMES = new Set(["search-routines"]);
+const SAFE_USER_HASH_PATTERN = /^[0-9a-f]{10}$/u;
 
 const WORKFLOW_PAGINATION_RESOURCES = new Set([
 	"workouts",
@@ -58,6 +59,7 @@ function metricAttributes(
 
 function createAttributes(
 	invocation: SafeToolInvocation,
+	userHash?: string,
 ): Record<string, AttributeValue> {
 	const clientMetadata = getCurrentMcpClientMetadata();
 	const isPrompt = invocation.kind === "prompt";
@@ -73,6 +75,7 @@ function createAttributes(
 		"mcp.client.version": clientMetadata.version,
 		"mcp.protocol.version": clientMetadata.protocolVersion,
 		"mcp.transport": getCurrentMcpTransport(),
+		...(userHash ? { "user.hash": userHash } : {}),
 		"mcp.tool.args.key_count_bucket":
 			invocation.argumentKeyCountBucket ?? "unknown",
 		"mcp.tool.args.keys": invocation.argumentKeys?.join(",") ?? "",
@@ -199,8 +202,20 @@ function bestEffort(operation: () => void): void {
 	}
 }
 
+export interface NodeToolObserverOptions {
+	/** HMAC pseudonym derived from the authenticated Hevy API key. */
+	readonly userHash?: string;
+}
+
 /** Node-only adapter from core's privacy-safe observation contract to OTel. */
-export function createNodeToolObserver(): ToolObserver {
+export function createNodeToolObserver(
+	options: NodeToolObserverOptions = {},
+): ToolObserver {
+	const userHash =
+		typeof options.userHash === "string" &&
+		SAFE_USER_HASH_PATTERN.test(options.userHash)
+			? options.userHash
+			: undefined;
 	return {
 		start(invocation): ToolObservationScope {
 			const startedAt = Date.now();
@@ -214,7 +229,7 @@ export function createNodeToolObserver(): ToolObserver {
 				run<T>(operation: () => Promise<T>): Promise<T> {
 					return tracer.startActiveSpan(
 						`mcp.tool.${invocation.name}`,
-						{ attributes: createAttributes(invocation) },
+						{ attributes: createAttributes(invocation, userHash) },
 						async (span) => {
 							activeSpan = span;
 							try {

--- a/packages/node/src/utils/user-hash.test.ts
+++ b/packages/node/src/utils/user-hash.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createNodeUserHash } from "./user-hash.js";
+
+describe("Node telemetry user hash", () => {
+	it("matches the Worker HMAC pseudonym contract", () => {
+		expect(createNodeUserHash("test-key")).toBe("2cb0b5f95a");
+		expect(createNodeUserHash("another-key")).toBe("0ddf86a356");
+	});
+
+	it("returns no identity for an empty credential", () => {
+		expect(createNodeUserHash("")).toBeUndefined();
+	});
+
+	it("returns only a bounded lowercase pseudonym", () => {
+		const secret = "node-api-key-secret-sentinel";
+		const hash = createNodeUserHash(secret);
+
+		expect(hash).toMatch(/^[0-9a-f]{10}$/u);
+		expect(hash).not.toContain(secret);
+	});
+});

--- a/packages/node/src/utils/user-hash.ts
+++ b/packages/node/src/utils/user-hash.ts
@@ -1,0 +1,21 @@
+import { createHmac } from "node:crypto";
+
+const USER_HASH_CONTEXT = "hevy-mcp:sentry-user-id:v1";
+const USER_HASH_LENGTH = 10;
+
+/**
+ * Derive the short, deterministic HMAC pseudonym shared with the Worker
+ * telemetry contract without exporting or logging the caller's Hevy API key.
+ */
+export function createNodeUserHash(apiKey: string): string | undefined {
+	if (apiKey.length === 0) return undefined;
+	try {
+		return createHmac("sha256", apiKey)
+			.update(USER_HASH_CONTEXT, "utf8")
+			.digest("hex")
+			.slice(0, USER_HASH_LENGTH);
+	} catch {
+		// Telemetry enrichment must never make an authenticated request fail.
+		return undefined;
+	}
+}


### PR DESCRIPTION
## Summary

- Derive the same ten-character HMAC `user.hash` pseudonym used by the Worker without exporting the raw Hevy API key.
- Attach the bounded pseudonym to Node tool, discovery, and prompt activity spans when the authenticated key is available.
- Add parity, propagation, and secret-sentinel regression tests and update the telemetry data dictionary.



## Validation

- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run build`
- `mise exec -- npm run test:stdio`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Propagate a bounded HMAC-based user hash from Node API keys into MCP activity spans while preserving privacy guarantees.

New Features:
- Introduce Node-side user hash derivation that matches the Worker HMAC pseudonym contract.
- Attach user hash attributes to Node tool, discovery, and prompt activity spans when an authenticated Hevy API key is present.

Enhancements:
- Ensure Node telemetry never exposes raw API keys by validating user hash format and omitting invalid values.
- Extend telemetry data dictionary to document Node MCP user hash usage alongside Worker spans.

Documentation:
- Update telemetry data dictionary to describe Node MCP user hash behavior and its privacy characteristics.

Tests:
- Add parity tests ensuring Node user hash derivation matches Worker pseudonym values and remains bounded and non-secret.
- Add regression tests validating user hash propagation to activity spans and guarding against raw API key leakage in Node telemetry.

Chores:
- Add a changeset entry documenting the user hash propagation change for the Node package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pseudonymous user identifiers to Node activity telemetry for tool, discovery, and prompt spans.
  - User identifiers are deterministic and bounded, without exposing raw API credentials.
- **Bug Fixes**
  - Improved telemetry privacy by preventing API keys from being recorded or serialized in activity data.
- **Documentation**
  - Updated the telemetry data dictionary to describe Node and hosted Worker pseudonymous user-hash coverage and data handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable user identification in activity spans via HMAC pseudonym derived from Hevy API key, without exposing raw credentials.

Main changes:
- Created `createNodeUserHash()` function generating 10-character SHA256 HMAC pseudonym from API key with validation pattern
- Updated `createNodeToolObserver()` to accept `userHash` option and propagate it to span attributes via `createAttributes()`
- Integrated user hash into Node runtime tool observer initialization and updated telemetry documentation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

## Primary changes

- Derive the Worker-compatible ten-character HMAC `user.hash` pseudonym from the Node Hevy API key without exporting the raw key.
- Propagate the bounded pseudonym to Node tool, discovery, and prompt activity spans when an authenticated key is available.
- Document the Node telemetry field and add parity, propagation, and secret-sentinel regression coverage.

## Reviewer walkthrough

- `packages/node/src/utils/user-hash.ts` derives the deterministic HMAC pseudonym, while `packages/node/src/runtime.ts` passes it into the Node observer.
- `packages/node/src/utils/tool-observer.ts` validates the ten-character lowercase hexadecimal format before attaching `user.hash` to activity span attributes.
- Co-located tests cover derivation, runtime wiring, tool/discovery/prompt propagation, and raw-key exclusion; the telemetry dictionary and changeset document the behavior.

## Correctness and invariants

- The derived value is a bounded lowercase hexadecimal pseudonym matching the Worker contract; empty or failed derivations omit the identity.
- Invalid observer values are ignored, and raw API keys are never added to span attributes or emitted telemetry.

## Testing and QA

- Validation reported by the PR: `mise exec -- npm run check`, `mise exec -- npm run check:types`, `mise exec -- npm run build`, `mise exec -- npm run test:stdio`, `mise exec -- npm run test:pr`, `mise exec -- npm run test:performance`, and `mise exec -- npm run check:changeset`.

Resolves #988