### PR TITLE
fix: align create-routine contract

### DIFF
--- a/.changeset/fix-create-routine-contract.md
+++ b/.changeset/fix-create-routine-contract.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Advertise required routine exercise arrays consistently and document the wrapped snake_case `create-routine` payload.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,35 @@ can request confirmation.
 | Body measurements | `create-body-measurement` | Create a dated body measurement. |
 | Body measurements | `update-body-measurement` | Update the body measurement for an existing date. |
 
+`create-routine` uses a required top-level `routine` envelope and snake_case fields at every level:
+
+```json
+{
+	"routine": {
+		"title": "Full Body A",
+		"folder_id": 123,
+		"notes": "First four exercises are the minimum viable workout",
+		"exercises": [
+			{
+				"exercise_template_id": "30E293E3",
+				"superset_id": null,
+				"rest_seconds": 120,
+				"notes": "Controlled active ROM",
+				"sets": [
+					{
+						"type": "normal",
+						"rep_range": {
+							"start": 6,
+							"end": 10
+						}
+					}
+				]
+			}
+		]
+	}
+}
+```
+
 The Hevy API currently exposes no delete endpoints for workouts, routines,
 routine folders, exercise templates, or body measurements, so there are no
 corresponding delete tools.

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ can request confirmation.
 | Body measurements | `create-body-measurement` | Create a dated body measurement. |
 | Body measurements | `update-body-measurement` | Update the body measurement for an existing date. |
 
-`create-routine` uses a required top-level `routine` envelope and snake_case fields at every level:
+`create-routine` requires a top-level `routine` envelope with a required `exercises` array; fields use snake_case at every level:
 
 ```json
 {

--- a/packages/core/src/tools/input-schemas.ts
+++ b/packages/core/src/tools/input-schemas.ts
@@ -198,10 +198,9 @@ export const routineExerciseFields = {
 
 const routineExerciseSchema = z.strictObject(routineExerciseFields);
 
-const routineExercisesSchema = z.preprocess(
-	parseJsonArray,
-	z.array(routineExerciseSchema),
-);
+const routineExercisesSchema = z
+	.preprocess(parseJsonArray, z.array(routineExerciseSchema))
+	.nonoptional();
 
 export const routinePayloadFields = {
 	title: z.string().min(1),

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -1,14 +1,19 @@
 import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
 import { Client } from "@modelcontextprotocol/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { HevyClient } from "@hevy-mcp/hevy-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { createToolRuntime } from "./tool-runtime.js";
 import { registerHevyTools, hevyToolDefinitions } from "./register.js";
 import type { ExerciseTemplateCatalog } from "../utils/exercise-template-catalog.js";
 
 type SchemaObject = {
+	readonly type?: string | readonly string[];
 	readonly properties?: Record<string, SchemaObject>;
 	readonly items?: SchemaObject;
+	readonly anyOf?: readonly SchemaObject[];
+	readonly required?: readonly string[];
+	readonly additionalProperties?: boolean;
 };
 
 const schemaObjectSchema: z.ZodType<SchemaObject> = z.lazy(() =>
@@ -19,6 +24,44 @@ const schemaObjectSchema: z.ZodType<SchemaObject> = z.lazy(() =>
 		})
 		.passthrough(),
 );
+
+function createMockHevyClient() {
+	return {
+		getWorkouts: vi.fn(),
+		getWorkout: vi.fn(),
+		createWorkout: vi.fn(),
+		updateWorkout: vi.fn(),
+		getWorkoutCount: vi.fn(),
+		getWorkoutEvents: vi.fn(),
+		getRoutines: vi.fn(),
+		getRoutineById: vi.fn(),
+		createRoutine: vi.fn(),
+		updateRoutine: vi.fn(),
+		getExerciseTemplates: vi.fn(),
+		getExerciseTemplate: vi.fn(),
+		getExerciseHistory: vi.fn(),
+		createExerciseTemplate: vi.fn(),
+		getRoutineFolders: vi.fn(),
+		createRoutineFolder: vi.fn(),
+		getRoutineFolder: vi.fn(),
+		getBodyMeasurements: vi.fn(),
+		getBodyMeasurement: vi.fn(),
+		createBodyMeasurement: vi.fn(),
+		updateBodyMeasurement: vi.fn(),
+		getUserInfo: vi.fn(),
+	} satisfies HevyClient;
+}
+
+function schemaProperty(schema: SchemaObject, name: string): SchemaObject {
+	const property = schema.properties?.[name];
+	if (!property) throw new Error(`Schema property ${name} is missing`);
+	return property;
+}
+
+function schemaItems(schema: SchemaObject): SchemaObject {
+	if (!schema.items) throw new Error("Schema items are missing");
+	return schema.items;
+}
 
 const EXPECTED_TOOL_NAMES = [
 	"get-workouts",
@@ -104,6 +147,203 @@ describe("registerHevyTools", () => {
 				}),
 			}),
 		);
+	});
+	it("keeps the serialized create-routine contract aligned with dispatch", async () => {
+		const mockClient = createMockHevyClient();
+		const productionServer = new McpServer({
+			name: "create-routine-contract-server",
+			version: "1.0.0",
+		});
+		const catalog: ExerciseTemplateCatalog = {
+			get: () => Promise.resolve([]),
+			reset: () => {},
+		};
+		registerHevyTools(
+			productionServer,
+			createToolRuntime({
+				client: mockClient,
+				catalog,
+			}),
+		);
+		const protocolClient = new Client({
+			name: "create-routine-contract-client",
+			version: "1.0.0",
+		});
+		const [clientTransport, serverTransport] =
+			InMemoryTransport.createLinkedPair();
+
+		try {
+			await Promise.all([
+				productionServer.connect(serverTransport),
+				protocolClient.connect(clientTransport),
+			]);
+
+			const { tools } = await protocolClient.listTools();
+			const createRoutineTool = tools.find(
+				({ name }) => name === "create-routine",
+			);
+			const updateRoutineTool = tools.find(
+				({ name }) => name === "update-routine",
+			);
+			if (!createRoutineTool || !updateRoutineTool) {
+				throw new Error("Routine mutation tools are missing");
+			}
+
+			const createSchema = createRoutineTool.inputSchema as SchemaObject;
+			const updateSchema = updateRoutineTool.inputSchema as SchemaObject;
+			expect(createSchema).toEqual(
+				expect.objectContaining({
+					additionalProperties: false,
+					required: ["routine"],
+				}),
+			);
+			expect(updateSchema).toEqual(
+				expect.objectContaining({
+					additionalProperties: false,
+					required: ["routine_id", "routine"],
+				}),
+			);
+
+			const createRoutineSchema = schemaProperty(createSchema, "routine");
+			const updateRoutineSchema = schemaProperty(updateSchema, "routine");
+			expect(createRoutineSchema).toEqual(
+				expect.objectContaining({
+					additionalProperties: false,
+					required: expect.arrayContaining(["title", "exercises"]),
+				}),
+			);
+			expect(updateRoutineSchema).toEqual(
+				expect.objectContaining({
+					additionalProperties: false,
+					required: expect.arrayContaining(["title", "exercises"]),
+				}),
+			);
+
+			const exerciseSchema = schemaItems(
+				schemaProperty(createRoutineSchema, "exercises"),
+			);
+			expect(exerciseSchema).toEqual(
+				expect.objectContaining({
+					additionalProperties: false,
+					required: expect.arrayContaining(["exercise_template_id", "sets"]),
+				}),
+			);
+			expect(schemaProperty(exerciseSchema, "superset_id")).toEqual(
+				expect.objectContaining({
+					type: expect.arrayContaining(["number", "null"]),
+				}),
+			);
+			expect(schemaProperty(exerciseSchema, "rest_seconds")).toEqual(
+				expect.objectContaining({ type: "integer" }),
+			);
+			const repRangeSchema = schemaProperty(
+				schemaItems(schemaProperty(exerciseSchema, "sets")),
+				"rep_range",
+			);
+			expect(repRangeSchema).toEqual(
+				expect.objectContaining({
+					type: "object",
+					additionalProperties: false,
+					properties: expect.objectContaining({
+						start: expect.objectContaining({
+							type: expect.arrayContaining(["integer", "null"]),
+						}),
+						end: expect.objectContaining({
+							type: expect.arrayContaining(["integer", "null"]),
+						}),
+					}),
+				}),
+			);
+
+			const payload = {
+				routine: {
+					title: "Full Body A",
+					folder_id: 123,
+					notes: "First four exercises are the minimum viable workout",
+					exercises: [
+						{
+							exercise_template_id: "30E293E3",
+							superset_id: null,
+							rest_seconds: 120,
+							notes: "Controlled active ROM",
+							sets: [
+								{
+									type: "normal",
+									rep_range: {
+										start: 6,
+										end: 10,
+									},
+								},
+							],
+						},
+					],
+				},
+			};
+			mockClient.createRoutine.mockResolvedValue(payload.routine);
+
+			const result = await protocolClient.callTool({
+				name: "create-routine",
+				arguments: payload,
+			});
+			expect(result).not.toMatchObject({ isError: true });
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+			expect(mockClient.createRoutine.mock.calls[0]?.[0]).toEqual({
+				routine: {
+					title: "Full Body A",
+					folder_id: 123,
+					notes: "First four exercises are the minimum viable workout",
+					exercises: [
+						{
+							exercise_template_id: "30E293E3",
+							superset_id: null,
+							rest_seconds: 120,
+							notes: "Controlled active ROM",
+							sets: [
+								{
+									type: "normal",
+									weight_kg: null,
+									reps: null,
+									distance_meters: null,
+									duration_seconds: null,
+									custom_metric: null,
+									rep_range: {
+										start: 6,
+										end: 10,
+									},
+								},
+							],
+						},
+					],
+				},
+			});
+
+			const invalidResult = await protocolClient.callTool({
+				name: "create-routine",
+				arguments: {
+					routine: {
+						title: "SECRET-TITLE-SENTINEL",
+						notes: "SECRET-NOTES-SENTINEL",
+						exercises: [
+							{
+								exercise_template_id: "SECRET-TEMPLATE-SENTINEL",
+								restSeconds: 120,
+								sets: [{ type: "normal" }],
+							},
+						],
+					},
+				},
+			});
+			const invalidText = JSON.stringify(invalidResult);
+			expect(invalidResult).toMatchObject({ isError: true });
+			expect(invalidText).toContain("routine.exercises.0");
+			expect(invalidText).toContain("restSeconds");
+			expect(invalidText).not.toContain("SECRET-TITLE-SENTINEL");
+			expect(invalidText).not.toContain("SECRET-NOTES-SENTINEL");
+			expect(invalidText).not.toContain("SECRET-TEMPLATE-SENTINEL");
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+		} finally {
+			await Promise.all([protocolClient.close(), productionServer.close()]);
+		}
 	});
 
 	it("declares bounded feature, kind, and operation metadata for every tool", () => {

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -1,11 +1,12 @@
 import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
 import { Client } from "@modelcontextprotocol/client";
-import type { HevyClient } from "@hevy-mcp/hevy-client";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Routine } from "@hevy-mcp/hevy-client/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 import { createToolRuntime } from "./tool-runtime.js";
 import { registerHevyTools, hevyToolDefinitions } from "./register.js";
 import type { ExerciseTemplateCatalog } from "../utils/exercise-template-catalog.js";
+import { createMockHevyClient } from "../../test-fixtures/mock-hevy.js";
 
 type SchemaObject = {
 	readonly type?: string | readonly string[];
@@ -21,36 +22,10 @@ const schemaObjectSchema: z.ZodType<SchemaObject> = z.lazy(() =>
 		.object({
 			properties: z.record(z.string(), schemaObjectSchema).optional(),
 			items: schemaObjectSchema.optional(),
+			anyOf: z.array(schemaObjectSchema).optional(),
 		})
 		.passthrough(),
 );
-
-function createMockHevyClient() {
-	return {
-		getWorkouts: vi.fn(),
-		getWorkout: vi.fn(),
-		createWorkout: vi.fn(),
-		updateWorkout: vi.fn(),
-		getWorkoutCount: vi.fn(),
-		getWorkoutEvents: vi.fn(),
-		getRoutines: vi.fn(),
-		getRoutineById: vi.fn(),
-		createRoutine: vi.fn(),
-		updateRoutine: vi.fn(),
-		getExerciseTemplates: vi.fn(),
-		getExerciseTemplate: vi.fn(),
-		getExerciseHistory: vi.fn(),
-		createExerciseTemplate: vi.fn(),
-		getRoutineFolders: vi.fn(),
-		createRoutineFolder: vi.fn(),
-		getRoutineFolder: vi.fn(),
-		getBodyMeasurements: vi.fn(),
-		getBodyMeasurement: vi.fn(),
-		createBodyMeasurement: vi.fn(),
-		updateBodyMeasurement: vi.fn(),
-		getUserInfo: vi.fn(),
-	} satisfies HevyClient;
-}
 
 function schemaProperty(schema: SchemaObject, name: string): SchemaObject {
 	const property = schema.properties?.[name];
@@ -62,6 +37,171 @@ function schemaItems(schema: SchemaObject): SchemaObject {
 	if (!schema.items) throw new Error("Schema items are missing");
 	return schema.items;
 }
+
+type ListedTool = {
+	readonly name: string;
+	readonly inputSchema: unknown;
+};
+
+function schemaFor(tools: readonly ListedTool[], name: string): SchemaObject {
+	const tool = tools.find(({ name: toolName }) => toolName === name);
+	if (!tool) throw new Error(`Tool ${name} is missing`);
+	return schemaObjectSchema.parse(tool.inputSchema);
+}
+
+function assertRoutineSchemas(tools: readonly ListedTool[]): void {
+	const createSchema = schemaFor(tools, "create-routine");
+	const updateSchema = schemaFor(tools, "update-routine");
+	expect(createSchema).toEqual(
+		expect.objectContaining({
+			additionalProperties: false,
+			required: ["routine"],
+		}),
+	);
+	expect(updateSchema).toEqual(
+		expect.objectContaining({
+			additionalProperties: false,
+			required: ["routine_id", "routine"],
+		}),
+	);
+
+	const createRoutineSchema = schemaProperty(createSchema, "routine");
+	const updateRoutineSchema = schemaProperty(updateSchema, "routine");
+	expect(createRoutineSchema).toEqual(
+		expect.objectContaining({
+			additionalProperties: false,
+			required: expect.arrayContaining(["title", "exercises"]),
+		}),
+	);
+	expect(updateRoutineSchema).toEqual(
+		expect.objectContaining({
+			additionalProperties: false,
+			required: expect.arrayContaining(["title", "exercises"]),
+		}),
+	);
+
+	const exerciseSchema = schemaItems(
+		schemaProperty(createRoutineSchema, "exercises"),
+	);
+	expect(exerciseSchema).toEqual(
+		expect.objectContaining({
+			additionalProperties: false,
+			required: expect.arrayContaining(["exercise_template_id", "sets"]),
+		}),
+	);
+	expect(schemaProperty(exerciseSchema, "superset_id")).toEqual(
+		expect.objectContaining({
+			type: expect.arrayContaining(["number", "null"]),
+		}),
+	);
+	expect(schemaProperty(exerciseSchema, "rest_seconds")).toEqual(
+		expect.objectContaining({ type: "integer" }),
+	);
+	const repRangeSchema = schemaProperty(
+		schemaItems(schemaProperty(exerciseSchema, "sets")),
+		"rep_range",
+	);
+	expect(repRangeSchema).toEqual(
+		expect.objectContaining({
+			type: "object",
+			additionalProperties: false,
+			properties: expect.objectContaining({
+				start: expect.objectContaining({
+					type: expect.arrayContaining(["integer", "null"]),
+				}),
+				end: expect.objectContaining({
+					type: expect.arrayContaining(["integer", "null"]),
+				}),
+			}),
+		}),
+	);
+}
+
+const createRoutinePayload = {
+	routine: {
+		title: "Full Body A",
+		folder_id: 123,
+		notes: "First four exercises are the minimum viable workout",
+		exercises: [
+			{
+				exercise_template_id: "30E293E3",
+				superset_id: null,
+				rest_seconds: 120,
+				notes: "Controlled active ROM",
+				sets: [
+					{
+						type: "normal",
+						rep_range: {
+							start: 6,
+							end: 10,
+						},
+					},
+				],
+			},
+		],
+	},
+};
+
+const expectedCreateRoutineRequest = {
+	routine: {
+		title: "Full Body A",
+		folder_id: 123,
+		notes: "First four exercises are the minimum viable workout",
+		exercises: [
+			{
+				exercise_template_id: "30E293E3",
+				superset_id: null,
+				rest_seconds: 120,
+				notes: "Controlled active ROM",
+				sets: [
+					{
+						type: "normal",
+						weight_kg: null,
+						reps: null,
+						distance_meters: null,
+						duration_seconds: null,
+						custom_metric: null,
+						rep_range: {
+							start: 6,
+							end: 10,
+						},
+					},
+				],
+			},
+		],
+	},
+};
+
+const createdRoutineResponse = {
+	id: "routine-1",
+	title: "Full Body A",
+	folder_id: 123,
+	created_at: "2026-08-15T09:00:00Z",
+	updated_at: "2026-08-15T09:00:00Z",
+	exercises: [
+		{
+			index: 0,
+			title: "Bench Press",
+			exercise_template_id: "30E293E3",
+			rest_seconds: 120,
+			notes: "Controlled active ROM",
+			supersets_id: null,
+			sets: [
+				{
+					index: 0,
+					type: "normal",
+					weight_kg: null,
+					reps: null,
+					rep_range: { start: 6, end: 10 },
+					distance_meters: null,
+					duration_seconds: null,
+					rpe: null,
+					custom_metric: null,
+				},
+			],
+		},
+	],
+} satisfies Routine;
 
 const EXPECTED_TOOL_NAMES = [
 	"get-workouts",
@@ -179,143 +319,27 @@ describe("registerHevyTools", () => {
 			]);
 
 			const { tools } = await protocolClient.listTools();
-			const createRoutineTool = tools.find(
-				({ name }) => name === "create-routine",
-			);
-			const updateRoutineTool = tools.find(
-				({ name }) => name === "update-routine",
-			);
-			if (!createRoutineTool || !updateRoutineTool) {
-				throw new Error("Routine mutation tools are missing");
-			}
+			assertRoutineSchemas(tools);
 
-			const createSchema = createRoutineTool.inputSchema as SchemaObject;
-			const updateSchema = updateRoutineTool.inputSchema as SchemaObject;
-			expect(createSchema).toEqual(
-				expect.objectContaining({
-					additionalProperties: false,
-					required: ["routine"],
-				}),
-			);
-			expect(updateSchema).toEqual(
-				expect.objectContaining({
-					additionalProperties: false,
-					required: ["routine_id", "routine"],
-				}),
-			);
-
-			const createRoutineSchema = schemaProperty(createSchema, "routine");
-			const updateRoutineSchema = schemaProperty(updateSchema, "routine");
-			expect(createRoutineSchema).toEqual(
-				expect.objectContaining({
-					additionalProperties: false,
-					required: expect.arrayContaining(["title", "exercises"]),
-				}),
-			);
-			expect(updateRoutineSchema).toEqual(
-				expect.objectContaining({
-					additionalProperties: false,
-					required: expect.arrayContaining(["title", "exercises"]),
-				}),
-			);
-
-			const exerciseSchema = schemaItems(
-				schemaProperty(createRoutineSchema, "exercises"),
-			);
-			expect(exerciseSchema).toEqual(
-				expect.objectContaining({
-					additionalProperties: false,
-					required: expect.arrayContaining(["exercise_template_id", "sets"]),
-				}),
-			);
-			expect(schemaProperty(exerciseSchema, "superset_id")).toEqual(
-				expect.objectContaining({
-					type: expect.arrayContaining(["number", "null"]),
-				}),
-			);
-			expect(schemaProperty(exerciseSchema, "rest_seconds")).toEqual(
-				expect.objectContaining({ type: "integer" }),
-			);
-			const repRangeSchema = schemaProperty(
-				schemaItems(schemaProperty(exerciseSchema, "sets")),
-				"rep_range",
-			);
-			expect(repRangeSchema).toEqual(
-				expect.objectContaining({
-					type: "object",
-					additionalProperties: false,
-					properties: expect.objectContaining({
-						start: expect.objectContaining({
-							type: expect.arrayContaining(["integer", "null"]),
-						}),
-						end: expect.objectContaining({
-							type: expect.arrayContaining(["integer", "null"]),
-						}),
-					}),
-				}),
-			);
-
-			const payload = {
-				routine: {
-					title: "Full Body A",
-					folder_id: 123,
-					notes: "First four exercises are the minimum viable workout",
-					exercises: [
-						{
-							exercise_template_id: "30E293E3",
-							superset_id: null,
-							rest_seconds: 120,
-							notes: "Controlled active ROM",
-							sets: [
-								{
-									type: "normal",
-									rep_range: {
-										start: 6,
-										end: 10,
-									},
-								},
-							],
-						},
-					],
-				},
-			};
-			mockClient.createRoutine.mockResolvedValue(payload.routine);
+			const payload = createRoutinePayload;
+			mockClient.createRoutine.mockResolvedValue(createdRoutineResponse);
 
 			const result = await protocolClient.callTool({
 				name: "create-routine",
 				arguments: payload,
 			});
 			expect(result).not.toMatchObject({ isError: true });
-			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
-			expect(mockClient.createRoutine.mock.calls[0]?.[0]).toEqual({
-				routine: {
-					title: "Full Body A",
-					folder_id: 123,
-					notes: "First four exercises are the minimum viable workout",
-					exercises: [
-						{
-							exercise_template_id: "30E293E3",
-							superset_id: null,
-							rest_seconds: 120,
-							notes: "Controlled active ROM",
-							sets: [
-								{
-									type: "normal",
-									weight_kg: null,
-									reps: null,
-									distance_meters: null,
-									duration_seconds: null,
-									custom_metric: null,
-									rep_range: {
-										start: 6,
-										end: 10,
-									},
-								},
-							],
-						},
-					],
-				},
+			expect(result.content[0]).toMatchObject({
+				type: "text",
+				text: expect.stringContaining('"id": "routine-1"'),
 			});
+			expect(result.content[0]).toMatchObject({
+				text: expect.stringContaining('"exercise_template_id": "30E293E3"'),
+			});
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+			expect(mockClient.createRoutine.mock.calls[0]?.[0]).toEqual(
+				expectedCreateRoutineRequest,
+			);
 
 			const invalidResult = await protocolClient.callTool({
 				name: "create-routine",
@@ -340,6 +364,15 @@ describe("registerHevyTools", () => {
 			expect(invalidText).not.toContain("SECRET-TITLE-SENTINEL");
 			expect(invalidText).not.toContain("SECRET-NOTES-SENTINEL");
 			expect(invalidText).not.toContain("SECRET-TEMPLATE-SENTINEL");
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+
+			const missingExercisesResult = await protocolClient.callTool({
+				name: "create-routine",
+				arguments: { routine: { title: "No Exercises" } },
+			});
+			const missingExercisesText = JSON.stringify(missingExercisesResult);
+			expect(missingExercisesResult).toMatchObject({ isError: true });
+			expect(missingExercisesText).toContain("routine.exercises");
 			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
 		} finally {
 			await Promise.all([protocolClient.close(), productionServer.close()]);
@@ -388,10 +421,12 @@ describe("registerHevyTools", () => {
 				}
 			}
 			if (schema.items) visit(schema.items);
+			if (schema.anyOf) {
+				for (const branch of schema.anyOf) visit(branch);
+			}
 		};
 		for (const tool of tools) {
-			const parsed = schemaObjectSchema.safeParse(tool.inputSchema);
-			if (parsed.success) visit(parsed.data);
+			visit(schemaObjectSchema.parse(tool.inputSchema));
 		}
 		expect(
 			propertyNames.filter((name) => !/^[a-z][a-z0-9_]*$/u.test(name)),

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -345,7 +345,7 @@ can request confirmation.
 | Body measurements  | `create-body-measurement`   | Create a dated body measurement.                                                  |
 | Body measurements  | `update-body-measurement`   | Update the body measurement for an existing date.                                 |
 
-`create-routine` uses a required top-level `routine` envelope and snake_case fields at every level:
+`create-routine` requires a top-level `routine` envelope with a required `exercises` array; fields use snake_case at every level:
 
 ```json
 {

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -345,6 +345,35 @@ can request confirmation.
 | Body measurements  | `create-body-measurement`   | Create a dated body measurement.                                                  |
 | Body measurements  | `update-body-measurement`   | Update the body measurement for an existing date.                                 |
 
+`create-routine` uses a required top-level `routine` envelope and snake_case fields at every level:
+
+```json
+{
+	"routine": {
+		"title": "Full Body A",
+		"folder_id": 123,
+		"notes": "First four exercises are the minimum viable workout",
+		"exercises": [
+			{
+				"exercise_template_id": "30E293E3",
+				"superset_id": null,
+				"rest_seconds": 120,
+				"notes": "Controlled active ROM",
+				"sets": [
+					{
+						"type": "normal",
+						"rep_range": {
+							"start": 6,
+							"end": 10
+						}
+					}
+				]
+			}
+		]
+	}
+}
+```
+
 The Hevy API currently exposes no delete endpoints for workouts, routines,
 routine folders, exercise templates, or body measurements, so there are no
 corresponding delete tools.


### PR DESCRIPTION
## Primary changes
- Make serialized create/update routine schemas require `exercises`.
- Add protocol-level list/call regression coverage for normalized payloads and redacted validation diagnostics.
- Document the wrapped snake_case `create-routine` payload.

## Reviewer walkthrough
- `packages/core/src/tools/input-schemas.ts`: require routine `exercises` in the serialized create/update schemas.
- `packages/core/src/tools/register.test.ts`: cover protocol-level tool schemas, normalized payload dispatch, and redacted validation diagnostics.
- `README.md` and `packages/node/README.md`: document the wrapped snake_case `create-routine` payload.
- `.changeset/fix-create-routine-contract.md`: record the package documentation and schema contract change.

## Correctness and invariants
- Create and update routine payloads require the routine exercise array expected by dispatch.
- Regression coverage verifies normalized payloads and ensures validation diagnostics do not expose user-provided values.

## Testing and QA
- `mise exec -- npm run check`
- `mise exec -- npm run check:types`
- `mise exec -- npm run build`
- `mise exec -- npm run test:pr`
- `mise exec -- npm run test:performance`
- `mise exec -- npm run check:changeset`

## Summary by Sourcery

Align the serialized create-routine and update-routine tool contracts with the dispatched payloads and enforce required routine exercises.

Bug Fixes:
- Ensure routine exercise arrays are consistently required in the create-routine payload schema.

Enhancements:
- Add protocol-level tests to verify create/update routine tool schemas, normalized payloads, and redacted validation diagnostics.

Documentation:
- Document the wrapped snake_case create-routine payload format in the core and node READMEs.

Tests:
- Introduce integration-style tests that validate the create-routine tool schema, its required fields, and error redaction behavior in the MCP protocol.

Chores:
- Add a changeset to release schema and documentation adjustments across affected packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `create-routine` validation to require exercise arrays and reject incomplete or invalid requests.
  * Standardized payload handling with the required `routine` envelope and snake_case fields.
  * Ensured default set values are applied consistently.

* **Documentation**
  * Added request format examples and requirements to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->