### PR TITLE
fix: increase Hevy API request deadline #1022

### DIFF
--- a/.changeset/fix-hevy-api-deadline.md
+++ b/.changeset/fix-hevy-api-deadline.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Increase the default Hevy API operation deadline to accommodate slow, large collection responses.

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -151,7 +151,9 @@ export interface HevyClientOptions {
 	timeoutMs?: number;
 }
 
-export const DEFAULT_API_TIMEOUT_MS = 30_000;
+// Hevy's larger collection endpoints can take longer than the usual HTTP
+// request window, especially when returning exercise templates or workouts.
+export const DEFAULT_API_TIMEOUT_MS = 60_000;
 export const MAX_GET_RETRIES = 3;
 export const RETRY_BACKOFF_BASE_MS = 300;
 export { HEVY_RETRY_EXHAUSTED_ERROR_CODE };

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -7,6 +7,7 @@ import {
 	HevyHttpError,
 } from "./hevy-http-error.js";
 import { createExecutionSignal, isAbortLike } from "./execution.js";
+import { DEFAULT_API_TIMEOUT_MS } from "./hevy-client-kubb.js";
 
 type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
 type JsonObject = { readonly [key: string]: JsonValue };
@@ -30,6 +31,10 @@ function hangingResponse(): Response {
 }
 
 describe("@hevy-mcp/hevy-client", () => {
+	it("allows slow collection endpoints a one-minute default deadline", () => {
+		expect(DEFAULT_API_TIMEOUT_MS).toBe(60_000);
+	});
+
 	it("uses object-form options and safely encodes requests", async () => {
 		const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
 			const requestUrl =


### PR DESCRIPTION
## Primary changes

Increase the default Hevy API operation deadline from 30 seconds to 60 seconds so slow, large collection responses have more time to complete. Add a changeset for the affected packages.

## Reviewer walkthrough

- `packages/hevy-client/src/hevy-client-kubb.ts`: raise `DEFAULT_API_TIMEOUT_MS` from `30_000` to `60_000` and document the slow collection endpoint rationale.
- `packages/hevy-client/src/hevy-client.test.ts`: add a regression test for the one-minute default.
- `.changeset/fix-hevy-api-deadline.md`: record patch releases for the affected packages.

## Correctness and invariants

The default deadline is `60_000` milliseconds. Existing retry and backoff settings remain unchanged, and the diff does not alter the explicit `timeoutMs` override path.

## Testing and QA

Add a unit test asserting `DEFAULT_API_TIMEOUT_MS` is `60_000` to guard the default deadline against regression.

## Summary by Sourcery

Increase the default Hevy API operation timeout to better support slow, large collection endpoints and document the change in the changeset.

Enhancements:
- Raise the default API timeout from 30 seconds to 60 seconds for Hevy client operations.

Tests:
- Add a test asserting the new default API timeout value.

Chores:
- Add a changeset describing the timeout increase and bump patch versions for affected packages.

----
## Summary by Gitar

- **API improvements:**
    - Increased `DEFAULT_API_TIMEOUT_MS` to `60_000`ms in `hevy-client-kubb.ts` to support slow collection responses.
    - Added a unit test verifying the one-minute default deadline in `hevy-client.test.ts`.

<sub>This will update automatically on new commits.</sub>

Resolves #1022
