### PR TITLE
fix(node): clarify non-loopback HTTP token guard #1023

### DIFF
--- a/.changeset/http-bearer-token-guidance.md
+++ b/.changeset/http-bearer-token-guidance.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Improve the startup guidance when non-loopback HTTP mode is missing its bearer token.

--- a/packages/node/src/utils/streamable-http.test.ts
+++ b/packages/node/src/utils/streamable-http.test.ts
@@ -628,6 +628,8 @@ describe("Streamable HTTP server", () => {
 				"test-key",
 				createMcpServer,
 			),
-		).rejects.toThrow("HEVY_MCP_HTTP_BEARER_TOKEN");
+		).rejects.toThrow(
+			"Set HEVY_MCP_HTTP_BEARER_TOKEN to a secure random value, then retry.",
+		);
 	});
 });

--- a/packages/node/src/utils/streamable-http.ts
+++ b/packages/node/src/utils/streamable-http.ts
@@ -441,7 +441,7 @@ export async function startStreamableHttpServer(
 	const bearerToken = process.env[HTTP_BEARER_TOKEN];
 	if (!loopback && !bearerToken) {
 		throw new Error(
-			`Non-loopback HTTP mode requires ${HTTP_BEARER_TOKEN} to protect the shared Hevy account.`,
+			`Non-loopback HTTP mode requires ${HTTP_BEARER_TOKEN} to protect the shared Hevy account. Set ${HTTP_BEARER_TOKEN} to a secure random value, then retry.`,
 		);
 	}
 


### PR DESCRIPTION
## Primary changes

Clarify the startup error for non-loopback HTTP mode when `HEVY_MCP_HTTP_BEARER_TOKEN` is missing by instructing users to set it to a secure random value and retry.

## Reviewer walkthrough

- `.changeset/http-bearer-token-guidance.md`: document the improved startup guidance.
- `packages/node/src/utils/streamable-http.ts`: extend the non-loopback token error with the actionable setup instruction.
- `packages/node/src/utils/streamable-http.test.ts`: update the expectation for the clarified error message.

## Correctness and invariants

The non-loopback guard still rejects startup without a bearer token; this change only improves its error guidance. Loopback behavior and the requirement to protect the shared Hevy account remain unchanged.

## Testing and QA

Update the Streamable HTTP unit test to assert the complete clarified error message.

## Summary by Sourcery

Clarify guidance for configuring the HTTP bearer token when starting the Streamable HTTP server in non-loopback mode.

Enhancements:
- Refine the error message thrown when non-loopback HTTP mode is used without a bearer token to include explicit instructions to set a secure random value.

Documentation:
- Add a changeset entry describing the improved startup guidance for missing HTTP bearer tokens in non-loopback HTTP mode.

Tests:
- Update the corresponding Streamable HTTP server test expectation to match the clarified error message.

Resolves #1023
