### PR TITLE
fix: guard telemetry session ID generation #1024

### DIFF
--- a/.changeset/fix-telemetry-session-id.md
+++ b/.changeset/fix-telemetry-session-id.md
@@ -1,0 +1,5 @@
+---
+"hevy-mcp": patch
+---
+
+Guard MCP telemetry session ID generation when `node:crypto.randomUUID` is unavailable.

--- a/packages/node/src/utils/mcp-session-observability.randomUUID.test.ts
+++ b/packages/node/src/utils/mcp-session-observability.randomUUID.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:crypto", async (importOriginal) => ({
+	...(await importOriginal<typeof import("node:crypto")>()),
+	randomUUID: undefined,
+}));
+
+const { createMcpSessionContext } =
+	await import("./mcp-session-observability.js");
+
+describe("MCP session telemetry ID fallback", () => {
+	it("creates an ID when node:crypto.randomUUID is unavailable", () => {
+		const context = createMcpSessionContext({ method: "initialize" });
+
+		expect(context.telemetrySessionId).toMatch(/^[a-z0-9]+-[a-z0-9]+$/u);
+	});
+});

--- a/packages/node/src/utils/mcp-session-observability.ts
+++ b/packages/node/src/utils/mcp-session-observability.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import * as crypto from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { sessionEnded, sessionStarted } from "./metrics.js";
 import { bucketCount } from "./result-telemetry.js";
@@ -55,6 +55,21 @@ const UNKNOWN_METADATA = "unknown";
 const MAX_METADATA_LENGTH = 64;
 const SAFE_METADATA_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:/@-]{0,63}$/u;
 const contextStorage = new AsyncLocalStorage<McpSessionContext>();
+
+function generateFallbackTelemetrySessionId(): string {
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+const parsedRandomUUID = z
+	.function()
+	.output(z.string())
+	.safeParse(crypto.randomUUID);
+
+function generateTelemetrySessionId(): string {
+	return parsedRandomUUID.success
+		? parsedRandomUUID.data()
+		: generateFallbackTelemetrySessionId();
+}
 // Stdio has one process-wide connection and its parser callbacks are not
 // attached to an AsyncLocalStorage scope. HTTP never uses this fallback: every
 // request is explicitly run with its own session context.
@@ -142,7 +157,10 @@ export function createMcpSessionContext(
 		transport,
 		telemetrySessionId:
 			normalizedOptions.telemetrySessionId ??
-			(normalizedOptions.generateTelemetrySessionId ?? randomUUID)(),
+			(
+				normalizedOptions.generateTelemetrySessionId ??
+				generateTelemetrySessionId
+			)(),
 	};
 }
 

--- a/packages/node/src/utils/mcp-session-observability.ts
+++ b/packages/node/src/utils/mcp-session-observability.ts
@@ -57,7 +57,7 @@ const SAFE_METADATA_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:/@-]{0,63}$/u;
 const contextStorage = new AsyncLocalStorage<McpSessionContext>();
 
 function generateFallbackTelemetrySessionId(): string {
-	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+	return `${Date.now().toString(36)}-${crypto.randomBytes(16).toString("hex")}`;
 }
 
 const parsedRandomUUID = z


### PR DESCRIPTION
## Primary changes

Guard MCP telemetry session ID generation when `node:crypto.randomUUID` is unavailable by routing it through a safe fallback generator. The fallback now combines a timestamp with cryptographically strong random bytes, while explicit telemetry IDs and custom generators retain precedence.

## Reviewer walkthrough

- `packages/node/src/utils/mcp-session-observability.ts`: replace the direct UUID import with a guarded `node:crypto` namespace import, add the timestamp/random-bytes fallback, and use it when `randomUUID` is unavailable.
- `packages/node/src/utils/mcp-session-observability.randomUUID.test.ts`: verify that session context creation still produces a valid telemetry ID when `randomUUID` is unavailable.
- `.changeset/fix-telemetry-session-id.md`: document the patch-level fix for telemetry session ID generation.

## Correctness and invariants

- Explicit `telemetrySessionId` values and custom `generateTelemetrySessionId` functions continue to take precedence over the default generator.
- Available `crypto.randomUUID` remains the preferred generator; environments without it receive a non-empty, URL-safe fallback ID.
- Session context creation continues to produce a telemetry session ID instead of failing during MCP message deserialization.

## Testing and QA

- Add regression coverage for telemetry session ID generation when `node:crypto.randomUUID` is unavailable.
- The test asserts the fallback ID matches the expected lowercase alphanumeric format with a non-empty suffix.

## Summary by Sourcery

Guard MCP telemetry session telemetrySessionId generation against environments where node:crypto.randomUUID is unavailable by introducing a safe fallback generator and wiring it into session context creation.

Bug Fixes:
- Ensure MCP telemetry session IDs are still generated when node:crypto.randomUUID is missing or undefined.

Documentation:
- Add a changeset entry documenting the patch-level fix for telemetry session ID generation.

Tests:
- Add a test verifying that a valid telemetry session ID is produced when node:crypto.randomUUID is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry session ID generation when UUID support is unavailable.
  * Added a fallback ID format to ensure session initialization continues reliably.

* **Tests**
  * Added regression coverage for environments without UUID generation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #1024
