### PR TITLE
fix: clarify missing routine update errors

### DIFF
--- a/.changeset/friendly-routines-find.md
+++ b/.changeset/friendly-routines-find.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Improve the error guidance when updating a routine that no longer exists in Hevy.

--- a/packages/core/src/utils/error-handler.test.ts
+++ b/packages/core/src/utils/error-handler.test.ts
@@ -5,14 +5,20 @@ import { createErrorResponse, withErrorHandling } from "./error-handler.js";
 
 type ErrorPayload = { readonly error: string };
 
-function httpError(status: number, data?: ErrorPayload, headers?: Headers) {
+function httpError(
+	status: number,
+	data?: ErrorPayload,
+	headers?: Headers,
+	method = "GET",
+	endpoint = "/v1/user/info",
+) {
 	return new HevyHttpError(`HTTP ${status}`, {
 		status,
 		statusText: "Error",
 		data,
 		headers,
-		method: "GET",
-		endpoint: "/v1/user/info",
+		method,
+		endpoint,
 	});
 }
 
@@ -67,6 +73,15 @@ describe("createErrorResponse", () => {
 		expect(result.errorContext).toMatchObject({
 			errorType: ErrorType.VALIDATION_ERROR,
 		});
+	});
+
+	it("gives routine update 404s actionable guidance", () => {
+		const result = createErrorResponse(
+			httpError(404, undefined, undefined, "PUT", "/v1/routines/:routineId"),
+		);
+		expect(result.content[0]?.text).toContain(
+			"The requested routine was not found in Hevy. It may have been deleted or the routine ID is incorrect.",
+		);
 	});
 
 	it.each([

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -237,7 +237,18 @@ export function getRetryAfterSeconds(
 }
 
 /** Map bounded Hevy HTTP statuses to stable user-facing messages. */
-export function getStatusErrorMessage(status?: number): string | null {
+export function getStatusErrorMessage(
+	status?: number,
+	method?: string,
+	endpoint?: string,
+): string | null {
+	if (
+		status === 404 &&
+		method?.toUpperCase() === "PUT" &&
+		endpoint === "/v1/routines/:routineId"
+	) {
+		return "The requested routine was not found in Hevy. It may have been deleted or the routine ID is incorrect.";
+	}
 	if (status === 401 || status === 403) {
 		return "The Hevy API key is invalid or has expired. Check HEVY_API_KEY.";
 	}
@@ -495,7 +506,11 @@ export function resolveErrorPolicy(
 	notInitializedMessage?: string,
 ): ErrorPolicyResult {
 	const diagnostic = createSafeErrorDiagnostic(error);
-	const mappedMessage = getStatusErrorMessage(diagnostic.status);
+	const mappedMessage = getStatusErrorMessage(
+		diagnostic.status,
+		diagnostic.method,
+		diagnostic.endpoint,
+	);
 	let message =
 		mappedMessage ??
 		(diagnostic.status !== undefined


### PR DESCRIPTION
Closes #1026

## Summary by Sourcery

Clarify 404 error messaging when updating routines that no longer exist in Hevy.

New Features:
- Add a specific user-facing error message for 404 responses on routine update requests to indicate the routine may have been deleted or the ID is incorrect.

Tests:
- Add a test to verify routine update 404 errors return the new actionable guidance message.

Chores:
- Add a changeset to release patch updates for affected Hevy MCP packages.

----
## Summary by Gitar

- **Error Handling:**
    - Added specific error messaging for `PUT` requests to `/v1/routines/:routineId` returning a `404` status in `getStatusErrorMessage`
    - Added test coverage verifying actionable guidance for routine update `404` errors

<sub>This will update automatically on new commits.</sub>