### PR TITLE
fix: return structured routine creation acknowledgement #1029

### DIFF
--- a/.changeset/fix-routine-creation-response.md
+++ b/.changeset/fix-routine-creation-response.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Return a structured, confirmed acknowledgement from `create-routine`, including the authoritative routine when Hevy provides one.

--- a/.cm/plugins/filters/findDiffLocation/package.json
+++ b/.cm/plugins/filters/findDiffLocation/package.json
@@ -1,3 +1,6 @@
 {
-	"type": "commonjs"
+	"type": "commonjs",
+	"dependencies": {
+		"zod": "^4.4.3"
+	}
 }

--- a/openapi-spec.json
+++ b/openapi-spec.json
@@ -462,7 +462,16 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Routine"
+									"oneOf": [
+										{
+											"$ref": "#/components/schemas/Routine"
+										},
+										{
+											"type": "object",
+											"properties": {},
+											"additionalProperties": false
+										}
+									]
 								}
 							}
 						}

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -44,7 +44,7 @@ export type ToolDefinition<
 		  }
 		| {
 				readonly kind: "write";
-				readonly outputSchema?: never;
+				readonly outputSchema?: z.ZodRawShape;
 		  }
 	);
 
@@ -77,10 +77,8 @@ export function registerToolDefinition(
 		inputSchema,
 		annotations: definition.annotations,
 	};
-	if (definition.kind === "read") {
-		config.outputSchema = compactJsonSchema(
-			z.object(definition.outputSchema as z.ZodRawShape),
-		);
+	if (definition.outputSchema) {
+		config.outputSchema = compactJsonSchema(z.object(definition.outputSchema));
 	}
 
 	server.registerTool(definition.name, config, (args, context) =>

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -320,6 +320,18 @@ describe("registerHevyTools", () => {
 
 			const { tools } = await protocolClient.listTools();
 			assertRoutineSchemas(tools);
+			const createRoutineTool = tools.find(
+				({ name }) => name === "create-routine",
+			);
+			expect(createRoutineTool?.outputSchema).toBeDefined();
+			expect(createRoutineTool?.outputSchema).toMatchObject({
+				type: "object",
+				properties: {
+					created: { const: true },
+					commit_state: { const: "confirmed" },
+					routine_id: { type: ["string", "null"] },
+				},
+			});
 
 			const payload = createRoutinePayload;
 			mockClient.createRoutine.mockResolvedValue(createdRoutineResponse);
@@ -340,6 +352,19 @@ describe("registerHevyTools", () => {
 			expect(mockClient.createRoutine.mock.calls[0]?.[0]).toEqual(
 				expectedCreateRoutineRequest,
 			);
+
+			mockClient.createRoutine.mockResolvedValue({});
+			const emptyResult = await protocolClient.callTool({
+				name: "create-routine",
+				arguments: payload,
+			});
+			expect(emptyResult).not.toMatchObject({ isError: true });
+			expect(emptyResult.structuredContent).toMatchObject({
+				created: true,
+				commit_state: "confirmed",
+				routine: null,
+				routine_id: null,
+			});
 
 			const invalidResult = await protocolClient.callTool({
 				name: "create-routine",
@@ -364,7 +389,7 @@ describe("registerHevyTools", () => {
 			expect(invalidText).not.toContain("SECRET-TITLE-SENTINEL");
 			expect(invalidText).not.toContain("SECRET-NOTES-SENTINEL");
 			expect(invalidText).not.toContain("SECRET-TEMPLATE-SENTINEL");
-			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(2);
 
 			const missingExercisesResult = await protocolClient.callTool({
 				name: "create-routine",
@@ -373,7 +398,7 @@ describe("registerHevyTools", () => {
 			const missingExercisesText = JSON.stringify(missingExercisesResult);
 			expect(missingExercisesResult).toMatchObject({ isError: true });
 			expect(missingExercisesText).toContain("routine.exercises");
-			expect(mockClient.createRoutine).toHaveBeenCalledTimes(1);
+			expect(mockClient.createRoutine).toHaveBeenCalledTimes(2);
 		} finally {
 			await Promise.all([protocolClient.close(), productionServer.close()]);
 		}

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -353,7 +353,7 @@ describe("registerHevyTools", () => {
 				expectedCreateRoutineRequest,
 			);
 
-			mockClient.createRoutine.mockResolvedValue({});
+			mockClient.createRoutine.mockResolvedValue(undefined);
 			const emptyResult = await protocolClient.callTool({
 				name: "create-routine",
 				arguments: payload,

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -223,6 +223,43 @@ describe("routine tools", () => {
 		expect(response).toMatchObject({ isError: true });
 	});
 
+	it("returns a confirmed acknowledgement when creation has no body", async () => {
+		const client = createMockHevyClient();
+		client.createRoutine.mockResolvedValue({});
+		const tool = register(client);
+
+		const response = await handler(tool, "create-routine")(routineInput);
+
+		expect(response).toMatchObject({
+			structuredContent: {
+				created: true,
+				commit_state: "confirmed",
+				routine: null,
+				routine_id: null,
+				uses_rep_ranges: true,
+			},
+		});
+	});
+
+	it("returns the authoritative routine and ID when creation has a body", async () => {
+		const client = createMockHevyClient();
+		client.createRoutine.mockResolvedValue({
+			id: "routine-1",
+			title: "Push",
+			exercises: [],
+		});
+		const tool = register(client);
+
+		const response = await handler(tool, "create-routine")(routineInput);
+
+		expect(response.structuredContent).toMatchObject({
+			created: true,
+			commit_state: "confirmed",
+			routine_id: "routine-1",
+			routine: { id: "routine-1", title: "Push" },
+		});
+	});
+
 	it("passes nested snake_case routine payloads to create and update", async () => {
 		const client = createMockHevyClient();
 		client.createRoutine.mockResolvedValue(routineInput.routine);

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -225,7 +225,7 @@ describe("routine tools", () => {
 
 	it("returns a confirmed acknowledgement when creation has no body", async () => {
 		const client = createMockHevyClient();
-		client.createRoutine.mockResolvedValue({});
+		client.createRoutine.mockResolvedValue(undefined);
 		const tool = register(client);
 
 		const response = await handler(tool, "create-routine")(routineInput);

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -1,9 +1,9 @@
 import type {
-	PostV1Routines201,
 	PutV1RoutinesRoutineid200,
 	Routine,
 } from "@hevy-mcp/hevy-client/types";
 import {
+	createRoutineOutputSchema,
 	createRoutineResponse,
 	routineResponse,
 	routinesResponse,
@@ -84,7 +84,7 @@ const getRoutineDefinition: ToolDefinition<
 const createRoutineSchema = createRoutineInputFields;
 
 type CreateRoutineResult = {
-	routine: PostV1Routines201 | null | undefined;
+	routine: Routine | null | undefined;
 	usesRepRanges: boolean;
 };
 const createRoutineDefinition: ToolDefinition<
@@ -98,6 +98,7 @@ const createRoutineDefinition: ToolDefinition<
 		"Writes a reusable routine; use create-workout for completed sessions. Retries can create duplicates.",
 	inputSchema: createRoutineSchema,
 	kind: "write",
+	outputSchema: createRoutineOutputSchema,
 	annotations: createAnnotations("Create Routine"),
 	responseContract: createRoutineResponse,
 	execute: async (runtime, args) => {
@@ -105,10 +106,13 @@ const createRoutineDefinition: ToolDefinition<
 			args.routine,
 			"create",
 		);
-		const data: PostV1Routines201 = await runtime
+		const data: Routine | undefined = await runtime
 			.getClient()
 			.createRoutine({ routine: payload });
-		return { routine: data, usesRepRanges };
+		return {
+			routine: data && Object.keys(data).length > 0 ? data : undefined,
+			usesRepRanges,
+		};
 	},
 };
 

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -109,10 +109,7 @@ const createRoutineDefinition: ToolDefinition<
 		const data: Routine | undefined = await runtime
 			.getClient()
 			.createRoutine({ routine: payload });
-		return {
-			routine: data && Object.keys(data).length > 0 ? data : undefined,
-			usesRepRanges,
-		};
+		return { routine: data, usesRepRanges };
 	},
 };
 

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -206,6 +206,14 @@ export const formattedRoutineSchema = z.object({
 	exercises: z.array(formattedRoutineExerciseSchema).optional(),
 });
 
+export const createRoutineOutputSchema = {
+	created: z.literal(true),
+	commit_state: z.literal("confirmed"),
+	routine: formattedRoutineSchema.nullable(),
+	routine_id: z.string().nullable(),
+	uses_rep_ranges: z.boolean(),
+} as const;
+
 export const formattedRoutineFolderSchema = z.object({
 	id: z.number().optional(),
 	title: z.string().optional(),
@@ -1150,18 +1158,23 @@ const repRangeDisplayWarningText =
 	"(input_modifier). See https://github.com/chrisdoc/hevy-mcp/issues/261 for " +
 	"details/workarounds.";
 
-export const createRoutineResponse = defineJsonResponseContract(
-	(data: { routine: Routine | null | undefined; usesRepRanges: boolean }) =>
-		data.routine
-			? {
-					json: projectRoutine(data.routine),
-					additionalText: data.usesRepRanges
-						? [repRangeDisplayWarningText]
-						: [],
-				}
-			: { text: "Failed to create routine: Server returned no data" },
-	(data) => routineResultTelemetry(data.routine),
-);
+export const createRoutineResponse = defineStructuredResponseContract({
+	outputSchema: createRoutineOutputSchema,
+	normalize: (data: {
+		routine: Routine | null | undefined;
+		usesRepRanges: boolean;
+	}) => ({
+		created: true as const,
+		commit_state: "confirmed" as const,
+		routine: data.routine ? projectRoutine(data.routine) : null,
+		routine_id: data.routine?.id ?? null,
+		uses_rep_ranges: data.usesRepRanges,
+	}),
+	legacyJson: (output) => output,
+	additionalText: (_data, output) =>
+		output.uses_rep_ranges ? [repRangeDisplayWarningText] : [],
+	telemetry: (data) => routineResultTelemetry(data.routine),
+});
 
 export const updateRoutineResponse = defineJsonResponseContract(
 	(data: {

--- a/packages/hevy-client/src/generated/client/schemas/postV1RoutinesSchema.ts
+++ b/packages/hevy-client/src/generated/client/schemas/postV1RoutinesSchema.ts
@@ -14,7 +14,10 @@ export const postV1RoutinesHeaderParamsSchema = z.object({
 /**
  * @description The routine was successfully created
  */
-export const postV1Routines201Schema = z.lazy(() => routineSchema);
+export const postV1Routines201Schema = z.union([
+  z.lazy(() => routineSchema),
+  z.object({}),
+]);
 
 /**
  * @description Invalid request body

--- a/packages/hevy-client/src/generated/client/types/PostV1Routines.ts
+++ b/packages/hevy-client/src/generated/client/types/PostV1Routines.ts
@@ -16,7 +16,7 @@ export type PostV1RoutinesHeaderParams = {
 /**
  * @description The routine was successfully created
  */
-export type PostV1Routines201 = Routine;
+export type PostV1Routines201 = Routine | object;
 
 /**
  * @description Invalid request body

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -23,7 +23,9 @@ import type {
 	PostV1BodyMeasurementsMutationRequest,
 	PostV1ExerciseTemplatesMutationRequest,
 	PostV1RoutineFoldersMutationRequest,
+	PostV1Routines201,
 	PostV1RoutinesMutationRequest,
+	Routine,
 	PostV1WorkoutsMutationRequest,
 	PutV1BodyMeasurementsDateMutationRequest,
 	PutV1RoutinesRoutineidMutationRequest,
@@ -1232,11 +1234,19 @@ export function createClient(
 				headers,
 				requestOptions(options, client),
 			),
-		createRoutine: (
+		createRoutine: async (
 			data: PostV1RoutinesMutationRequest,
 			options?: HevyRequestOptions,
-		): ReturnType<typeof api.postV1Routines> =>
-			api.postV1Routines(data, headers, requestOptions(options, client)),
+		): Promise<Routine | undefined> => {
+			const response: PostV1Routines201 = await api.postV1Routines(
+				data,
+				headers,
+				requestOptions(options, client),
+			);
+			return Object.keys(response).length === 0
+				? undefined
+				: (response as Routine);
+		},
 		updateRoutine: (
 			routineId: string,
 			data: PutV1RoutinesRoutineidMutationRequest,

--- a/packages/hevy-client/src/hevy-client.ts
+++ b/packages/hevy-client/src/hevy-client.ts
@@ -27,7 +27,7 @@ import type {
 	PostV1RoutineFoldersMutationRequest,
 	PostV1RoutineFoldersMutationResponse,
 	PostV1RoutinesMutationRequest,
-	PostV1RoutinesMutationResponse,
+	Routine,
 	PostV1WorkoutsMutationRequest,
 	PostV1WorkoutsMutationResponse,
 	PutV1BodyMeasurementsDateMutationRequest,
@@ -82,7 +82,7 @@ export interface HevyClient {
 	createRoutine(
 		data: PostV1RoutinesMutationRequest,
 		options?: HevyRequestOptions,
-	): Promise<PostV1RoutinesMutationResponse>;
+	): Promise<Routine | undefined>;
 	updateRoutine(
 		routineId: string,
 		data: PutV1RoutinesRoutineidMutationRequest,

--- a/scripts/openapi-spec.js
+++ b/scripts/openapi-spec.js
@@ -122,8 +122,7 @@ export function validateOpenAPISpec(spec) {
 		(!Array.isArray(routineCreateSchema.oneOf) ||
 			!routineCreateSchema.oneOf.some(
 				(entry) =>
-					entry?.type === "object" &&
-					entry?.additionalProperties === false,
+					entry?.type === "object" && entry?.additionalProperties === false,
 			))
 	) {
 		throw new Error(

--- a/scripts/openapi-spec.js
+++ b/scripts/openapi-spec.js
@@ -32,6 +32,7 @@ export function fixOpenAPISpec(spec) {
 	fixMissingParameterSchemas(fixed.paths || {});
 	fixInvalidExamples(fixed.components?.schemas || {});
 	fixRoutineRestSecondsType(fixed.components?.schemas || {});
+	fixOptionalRoutineCreationResponse(fixed.paths || {});
 
 	if (!fixed.servers || fixed.servers.length === 0) {
 		fixed.servers = [
@@ -51,6 +52,30 @@ export function fixOpenAPISpec(spec) {
  * Upstream currently describes this field inconsistently as a string even
  * though responses contain an integer and the write schemas already use one.
  */
+/**
+ * Hevy may acknowledge routine creation with HTTP 201 and no response body.
+ * Keep that live behavior in the generated client contract while retaining the
+ * authoritative Routine body when the API returns one.
+ */
+function fixOptionalRoutineCreationResponse(paths) {
+	const response = paths["/v1/routines"]?.post?.responses?.["201"];
+	const schema = response?.content?.["application/json"]?.schema;
+	if (!schema || schema.oneOf) return;
+	response.content["application/json"].schema = {
+		oneOf: [
+			schema,
+			{
+				type: "object",
+				properties: {},
+				additionalProperties: false,
+			},
+		],
+	};
+	console.log(
+		"  Fixed: POST /v1/routines 201 - allowed an empty successful response body",
+	);
+}
+
 function fixRoutineRestSecondsType(schemas) {
 	const restSeconds =
 		schemas.Routine?.properties?.exercises?.items?.properties?.rest_seconds;
@@ -86,6 +111,22 @@ export function validateOpenAPISpec(spec) {
 	if (!restSeconds) {
 		throw new Error(
 			"Routine.exercises[].rest_seconds field is missing from the OpenAPI spec",
+		);
+	}
+	const routineCreateSchema =
+		spec.paths?.["/v1/routines"]?.post?.responses?.["201"]?.content?.[
+			"application/json"
+		]?.schema;
+	if (
+		!routineCreateSchema ||
+		!Array.isArray(routineCreateSchema.oneOf) ||
+		!routineCreateSchema.oneOf.some(
+			(entry) =>
+				entry?.type === "object" && entry?.additionalProperties === false,
+		)
+	) {
+		throw new Error(
+			"POST /v1/routines 201 must allow an empty successful response body",
 		);
 	}
 	if (restSeconds.type !== "integer") {

--- a/scripts/openapi-spec.js
+++ b/scripts/openapi-spec.js
@@ -118,12 +118,13 @@ export function validateOpenAPISpec(spec) {
 			"application/json"
 		]?.schema;
 	if (
-		!routineCreateSchema ||
-		!Array.isArray(routineCreateSchema.oneOf) ||
-		!routineCreateSchema.oneOf.some(
-			(entry) =>
-				entry?.type === "object" && entry?.additionalProperties === false,
-		)
+		routineCreateSchema &&
+		(!Array.isArray(routineCreateSchema.oneOf) ||
+			!routineCreateSchema.oneOf.some(
+				(entry) =>
+					entry?.type === "object" &&
+					entry?.additionalProperties === false,
+			))
 	) {
 		throw new Error(
 			"POST /v1/routines 201 must allow an empty successful response body",


### PR DESCRIPTION
## Primary changes

Return a structured, confirmed acknowledgement from the `create-routine` tool, including creation status, commit state, routine metadata, and rep-range usage.

- Allow successful `POST /v1/routines` 201 responses with either a `Routine` body or an empty body.
- Expose the create-routine output schema through MCP tool registration for write tools.

## Reviewer walkthrough

- `scripts/openapi-spec.js` and `openapi-spec.json`: model and validate the optional 201 response.
- `packages/hevy-client/src/hevy-client-kubb.ts` and `hevy-client.ts`: normalize empty responses to `undefined` and update the client contract.
- `packages/core/src/utils/response-contracts.ts` and `packages/core/src/tools/routines.ts`: return the structured acknowledgement while preserving routine data when present.
- `packages/core/src/tools/define-tool.ts`: register output schemas for write tools.

## Correctness and invariants

- Successful creation always returns a structured acknowledgement, including when Hevy returns no response body.
- Empty responses produce `routine: null` and `routine_id: null`; a returned routine remains authoritative and supplies its metadata.
- The acknowledgement keeps `created`, `commit_state`, and `uses_rep_ranges` stable across both response shapes.

## Testing and QA

- Add core tool tests for empty-body and populated-routine acknowledgement paths.
- Extend registration tests to verify the write-tool output schema and the empty-body success path.
- Update OpenAPI validation and generated artifacts for the optional successful response body.

## Summary by Sourcery

Return a structured acknowledgement for routine creation regardless of whether Hevy includes the created routine in its successful response.

New Features:
- Return structured, confirmed acknowledgements from `create-routine` with creation status, commit state, routine metadata, and rep-range usage.
- Expose output schemas for write tools, including the `create-routine` response contract.

Bug Fixes:
- Handle successful routine creation responses that contain no body while preserving returned routine data when available.

Enhancements:
- Update the client and OpenAPI contracts to represent optional routine-creation response bodies and normalize empty responses consistently.

Tests:
- Add coverage for empty-body and populated-routine creation acknowledgements, output-schema registration, and OpenAPI validation.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `create-routine` now returns a structured confirmation with creation status, routine details, routine ID, and rep-range information.
  * Supports successful routine creation responses with or without returned routine data.

* **Bug Fixes**
  * Improved handling of empty routine-creation responses.
  * Updated API validation to accept valid empty creation responses.

* **Tests**
  * Added coverage for confirmed responses, routine details, IDs, and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #1029