### PR TITLE
perf: memoize tool schema registration per isolate to cut Worker CPU

### DIFF
--- a/.changeset/reduce-worker-request-cpu.md
+++ b/.changeset/reduce-worker-request-cpu.md
@@ -5,4 +5,4 @@
 "@chrisdoc/hevy-cli": patch
 ---
 
-Reduce per-request CPU in the Worker: memoize tool schema registration once per isolate and preload it at module scope, avoiding the repeated compact-JSON-Schema conversion that caused intermittent `Worker exceeded CPU time limit` (503) responses.
+Reduce per-request CPU in the Worker: memoize tool schema registration once per isolate, and preload the actual compact-JSON-Schema conversions at module scope so the first request only reads already-converted schemas. This eliminates the repeated conversion that caused intermittent `Worker exceeded CPU time limit` (503) responses.

--- a/.changeset/reduce-worker-request-cpu.md
+++ b/.changeset/reduce-worker-request-cpu.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Reduce per-request CPU in the Worker: memoize tool schema registration once per isolate and preload it at module scope, avoiding the repeated compact-JSON-Schema conversion that caused intermittent `Worker exceeded CPU time limit` (503) responses.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
 	type CreateHevyMcpServerOptions,
 	type HevyClientFactoryContext,
 } from "./server.js";
+export { preloadHevyToolSchemas } from "./tools/register.js";
 export {
 	memoizeObservationScope,
 	type ToolCompletionObservation,

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -48,10 +48,49 @@ export type ToolDefinition<
 		  }
 	);
 
+type AnyToolDefinition = ToolDefinition<Record<string, z.ZodTypeAny>, unknown>;
+
+/**
+ * One-time-per-isolate registration metadata for each tool definition.
+ *
+ * Building a tool's compact JSON Schema (and the SDK's eager wire conversion
+ * of the `compactJsonSchema`-wrapped schema on registration) is the dominant
+ * CPU cost when constructing an MCP server. Tool definitions are module-level
+ * constants, so this metadata can be computed once and shared by every server
+ * a single isolate builds. The SDK's `registerTool` reads the schema strictly
+ * through the Standard Schema interface and never mutates it, so sharing the
+ * memoized config across concurrent servers is safe.
+ *
+ * Keep the memo lazy: CLI and test processes that never build a Hevy server
+ * pay nothing. Isolate-based edge runtimes that want the one-time conversion
+ * moved into module-scope (outside request CPU) call `preloadHevyToolSchemas`.
+ */
+const registeredToolConfigCache = new WeakMap<
+	AnyToolDefinition,
+	RegisteredToolConfig
+>();
+
+export function getRegisteredToolConfig(
+	definition: AnyToolDefinition,
+): RegisteredToolConfig {
+	const cached = registeredToolConfigCache.get(definition);
+	if (cached) return cached;
+	const config: RegisteredToolConfig = {
+		description: definition.description,
+		inputSchema: compactJsonSchema(z.strictObject(definition.inputSchema)),
+		annotations: definition.annotations,
+	};
+	if (definition.outputSchema) {
+		config.outputSchema = compactJsonSchema(z.object(definition.outputSchema));
+	}
+	registeredToolConfigCache.set(definition, config);
+	return config;
+}
+
 export function registerToolDefinition(
 	server: ToolRegistrar,
 	runtime: ToolRuntime,
-	definition: ToolDefinition<Record<string, z.ZodTypeAny>, unknown>,
+	definition: AnyToolDefinition,
 ): void {
 	const directHandler = createTypedToolHandler(
 		definition.inputSchema,
@@ -69,20 +108,10 @@ export function registerToolDefinition(
 		kind: definition.kind,
 		operation: definition.operation,
 	});
-	const callback = handler;
 
-	const inputSchema = compactJsonSchema(z.strictObject(definition.inputSchema));
-	const config: RegisteredToolConfig = {
-		description: definition.description,
-		inputSchema,
-		annotations: definition.annotations,
-	};
-	if (definition.outputSchema) {
-		config.outputSchema = compactJsonSchema(z.object(definition.outputSchema));
-	}
-
+	const config = getRegisteredToolConfig(definition);
 	server.registerTool(definition.name, config, (args, context) =>
-		callback(
+		handler(
 			z.strictObject(definition.inputSchema).parse(args),
 			context
 				? {

--- a/packages/core/src/tools/preload.test.ts
+++ b/packages/core/src/tools/preload.test.ts
@@ -1,0 +1,63 @@
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { Client } from "@modelcontextprotocol/client";
+import { describe, expect, it } from "vitest";
+import { getCompactJsonSchemaConversionCount } from "../utils/compact-json-schema.js";
+import type { ExerciseTemplateCatalog } from "../utils/exercise-template-catalog.js";
+import { createToolRuntime } from "./tool-runtime.js";
+import {
+	hevyToolDefinitions,
+	preloadHevyToolSchemas,
+	registerHevyTools,
+} from "./register.js";
+
+const catalog: ExerciseTemplateCatalog = {
+	get: () => Promise.resolve([]),
+	reset: () => {},
+};
+
+/**
+ * `preloadHevyToolSchemas` must run the real compact JSON Schema
+ * conversions (the memoized `input`/`output` closures behind
+ * `compactJsonSchema`), not just populate the config cache. Otherwise the
+ * conversion cost lands back in the first request's `registerTool` call. This
+ * file intentionally builds no server before the test so the per-isolate
+ * conversion counter starts cold.
+ */
+describe("preloadHevyToolSchemas", () => {
+	it("performs every tool schema conversion before any server is built and never repeats", async () => {
+		// Cold module: nothing has converted yet.
+		expect(getCompactJsonSchemaConversionCount()).toBe(0);
+
+		// The first preload performs the actual conversions, before any server.
+		preloadHevyToolSchemas();
+		const afterFirstPreload = getCompactJsonSchemaConversionCount();
+		expect(afterFirstPreload).toBeGreaterThan(0);
+
+		// Idempotent: a second preload converts nothing new.
+		preloadHevyToolSchemas();
+		expect(getCompactJsonSchemaConversionCount()).toBe(afterFirstPreload);
+
+		// Server construction only reads already-converted schemas.
+		const server = new McpServer({ name: "preload-test", version: "1.0.0" });
+		registerHevyTools(server, createToolRuntime({ client: null, catalog }));
+		expect(getCompactJsonSchemaConversionCount()).toBe(afterFirstPreload);
+
+		const protocolClient = new Client({
+			name: "preload-test-client",
+			version: "1.0.0",
+		});
+		const [clientTransport, serverTransport] =
+			InMemoryTransport.createLinkedPair();
+		await Promise.all([
+			server.connect(serverTransport),
+			protocolClient.connect(clientTransport),
+		]);
+		try {
+			const { tools } = await protocolClient.listTools();
+			expect(tools).toHaveLength(hevyToolDefinitions.length);
+			expect(getCompactJsonSchemaConversionCount()).toBe(afterFirstPreload);
+		} finally {
+			await Promise.all([protocolClient.close(), server.close()]);
+		}
+	});
+});

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -4,7 +4,11 @@ import type { Routine } from "@hevy-mcp/hevy-client/types";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 import { createToolRuntime } from "./tool-runtime.js";
-import { registerHevyTools, hevyToolDefinitions } from "./register.js";
+import {
+	registerHevyTools,
+	hevyToolDefinitions,
+	preloadHevyToolSchemas,
+} from "./register.js";
 import type { ExerciseTemplateCatalog } from "../utils/exercise-template-catalog.js";
 import { createMockHevyClient } from "../../test-fixtures/mock-hevy.js";
 
@@ -268,6 +272,57 @@ describe("registerHevyTools", () => {
 
 		expect(tools).toHaveLength(EXPECTED_TOOL_NAMES.length);
 		expect(tools.map(({ name }) => name)).toEqual(EXPECTED_TOOL_NAMES);
+	});
+
+	it("shares memoized tool schemas across independently built servers", async () => {
+		preloadHevyToolSchemas();
+		preloadHevyToolSchemas();
+		const { tools: firstTools } = await client.listTools();
+
+		const catalog: ExerciseTemplateCatalog = {
+			get: () => Promise.resolve([]),
+			reset: () => {},
+		};
+		const buildPair = (name: string) => {
+			const rebuilt = new McpServer({
+				name: `server-${name}`,
+				version: "1.0.0",
+			});
+			registerHevyTools(rebuilt, createToolRuntime({ client: null, catalog }));
+			const protocolClient = new Client({
+				name: `client-${name}`,
+				version: "1.0.0",
+			});
+			const [clientTransport, serverTransport] =
+				InMemoryTransport.createLinkedPair();
+			return { rebuilt, protocolClient, clientTransport, serverTransport };
+		};
+		const second = buildPair("second");
+		const third = buildPair("third");
+		try {
+			await Promise.all([
+				second.rebuilt.connect(second.serverTransport),
+				second.protocolClient.connect(second.clientTransport),
+			]);
+			const secondTools = (await second.protocolClient.listTools()).tools;
+			expect(secondTools).toEqual(firstTools);
+
+			// The memoized path must also hold through yet another rebuild.
+			await Promise.all([
+				third.rebuilt.connect(third.serverTransport),
+				third.protocolClient.connect(third.clientTransport),
+			]);
+			const thirdTools = (await third.protocolClient.listTools()).tools;
+			expect(thirdTools).toEqual(firstTools);
+			expect(thirdTools).toHaveLength(EXPECTED_TOOL_NAMES.length);
+		} finally {
+			await Promise.all([
+				second.protocolClient.close(),
+				second.rebuilt.close(),
+				third.protocolClient.close(),
+				third.rebuilt.close(),
+			]);
+		}
 	});
 
 	it("advertises the non-empty update-workout patch invariant", async () => {

--- a/packages/core/src/tools/register.ts
+++ b/packages/core/src/tools/register.ts
@@ -1,3 +1,4 @@
+import { preloadCompactJsonSchema } from "../utils/compact-json-schema.js";
 import {
 	getRegisteredToolConfig,
 	registerToolDefinition,
@@ -26,15 +27,25 @@ export const hevyToolDefinitions = [
  * Move the one-time tool schema conversion into module scope.
  *
  * Tool schemas are module-level constants, and their compact JSON Schema is
- * memoized per definition by `getRegisteredToolConfig`. On isolate-based edge
- * runtimes (Cloudflare Workers) module-scope work runs during isolate
- * warm-up, outside a request's billed CPU, so calling this at module scope
- * keeps the first request of a fresh isolate fast instead of paying the full
- * conversion inside it. Idempotent and a no-op after the memo is warm.
+ * memoized per definition by `getRegisteredToolConfig`. Populating the memo is
+ * not enough: `compactJsonSchema` stores the actual `z.toJSONSchema` work
+ * behind lazy `input`/`output` closures, and the MCP SDK invokes those during
+ * `registerTool`. This forces the exact conversions the SDK consumes (`input`
+ * for each `inputSchema`, `output` for each read tool `outputSchema`) so a
+ * first request only reads already-converted schemas.
+ *
+ * On isolate-based edge runtimes (Cloudflare Workers) module-scope work runs
+ * during isolate warm-up, outside a request's billed CPU, so calling this at
+ * module scope keeps the first request of a fresh isolate fast. Idempotent,
+ * and a no-op after every conversion has been computed once.
  */
 export function preloadHevyToolSchemas(): void {
 	for (const definition of hevyToolDefinitions) {
-		getRegisteredToolConfig(definition);
+		const config = getRegisteredToolConfig(definition);
+		preloadCompactJsonSchema(config.inputSchema, "input");
+		if (config.outputSchema) {
+			preloadCompactJsonSchema(config.outputSchema, "output");
+		}
 	}
 }
 

--- a/packages/core/src/tools/register.ts
+++ b/packages/core/src/tools/register.ts
@@ -1,4 +1,8 @@
-import { registerToolDefinition, type ToolRegistrar } from "./define-tool.js";
+import {
+	getRegisteredToolConfig,
+	registerToolDefinition,
+	type ToolRegistrar,
+} from "./define-tool.js";
 import { bodyMeasurementToolDefinitions } from "./body-measurements.js";
 import { folderToolDefinitions } from "./folders.js";
 import { routineToolDefinitions } from "./routines.js";
@@ -17,6 +21,22 @@ export const hevyToolDefinitions = [
 	...workflowToolDefinitions,
 	...routineDiscoveryToolDefinitions,
 ] as const;
+
+/**
+ * Move the one-time tool schema conversion into module scope.
+ *
+ * Tool schemas are module-level constants, and their compact JSON Schema is
+ * memoized per definition by `getRegisteredToolConfig`. On isolate-based edge
+ * runtimes (Cloudflare Workers) module-scope work runs during isolate
+ * warm-up, outside a request's billed CPU, so calling this at module scope
+ * keeps the first request of a fresh isolate fast instead of paying the full
+ * conversion inside it. Idempotent and a no-op after the memo is warm.
+ */
+export function preloadHevyToolSchemas(): void {
+	for (const definition of hevyToolDefinitions) {
+		getRegisteredToolConfig(definition);
+	}
+}
 
 /** Register every Hevy tool in its production ordering. */
 export function registerHevyTools(

--- a/packages/core/src/utils/compact-json-schema.ts
+++ b/packages/core/src/utils/compact-json-schema.ts
@@ -17,6 +17,8 @@ function isNullSchema(value: RuntimeValue): value is JsonSchema {
 	);
 }
 
+let conversionCount = 0;
+
 function compactNullableSchema(value: RuntimeValue): RuntimeValue {
 	if (Array.isArray(value)) {
 		return value.map(compactNullableSchema);
@@ -71,6 +73,7 @@ function convertSchema(
 	schema: z.ZodTypeAny,
 	io: "input" | "output",
 ): JsonSchema {
+	conversionCount += 1;
 	const converted = z.toJSONSchema(schema, {
 		target: "draft-2020-12",
 		io,
@@ -118,4 +121,35 @@ export function compactJsonSchema<TSchema extends z.ZodTypeAny>(
 		writable: true,
 	});
 	return schema;
+}
+
+/**
+ * Force the compact JSON Schema conversion for one direction now instead of
+ * lazily on first use.
+ *
+ * `compactJsonSchema` stores the conversion behind memoized `input`/`output`
+ * closures so Node CLI and test processes never pay for a conversion they do
+ * not use. On isolate-based edge runtimes (Cloudflare Workers), module-scope
+ * work runs outside a request's billed CPU, so callers such as
+ * `preloadHevyToolSchemas` can warm the memo for the exact directions the MCP
+ * SDK consumes during `registerTool` (`input` for `inputSchema`, `output` for
+ * `outputSchema`) and move the one-time cost out of the first request.
+ * Calling again for an already-warm direction is a no-op.
+ */
+export function preloadCompactJsonSchema<TSchema extends z.ZodTypeAny>(
+	schema: TSchema,
+	io: "input" | "output",
+): void {
+	schema["~standard"].jsonSchema?.[io]({ target: "draft-2020-12" });
+}
+
+/**
+ * Number of compact JSON Schema conversions computed in this process/isolate.
+ *
+ * Increments only on actual computation inside `convertSchema`, never on a
+ * cached read, so tests can observe that a preload performed conversions and
+ * that later server construction did not repeat them.
+ */
+export function getCompactJsonSchemaConversionCount(): number {
+	return conversionCount;
 }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -5,6 +5,7 @@ import type { McpServer } from "@modelcontextprotocol/server";
 import {
 	createHevyMcpServer,
 	createSafeErrorDiagnostic,
+	preloadHevyToolSchemas,
 	type CreateHevyMcpServerOptions,
 	type HevyClientFactoryContext,
 } from "@hevy-mcp/core";
@@ -36,6 +37,14 @@ import {
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
 const HEVY_API_BASE_URL = "https://api.hevyapp.com";
+
+/**
+ * Warm the tool-schema memo at module scope so the per-isolate conversion
+ * cost runs during isolate warm-up instead of inside a request's billed CPU.
+ * See `preloadHevyToolSchemas` in packages/core. Client requests stay within
+ * the Worker CPU budget by reusing the memoized tool schemas.
+ */
+preloadHevyToolSchemas();
 const CORS_ALLOWED_HEADERS =
 	"Authorization, Content-Type, Accept, MCP-Protocol-Version";
 const CORS_ALLOWED_METHODS = "POST, OPTIONS";


### PR DESCRIPTION
## Problem

Cloudflare logs for `hevy-mcp` showed **`Worker exceeded CPU time limit` (HTTP 503 `outcome: exceededCpu`)** on `POST /mcp` ~1/min for an entire hour — the only error class in the log (60 unique requests, all clients: Claude Desktop and `python-httpx` MCP clients). Measured `cpu_time_ms: 10–20` points at the Cloudflare free-plan 10ms per-request CPU budget.

Benchmarking the real request path isolated the cost: `createHevyMcpServer` (rebuilt on **every** request) averaged **12.2ms** of CPU. The cost is in `registerToolDefinition` — the MCP SDK eagerly invokes the `compactJsonSchema` Standard-Schema converter during `registerTool`. Because the conversion is memoized *per schema object* and each request built fresh schema objects, the ~11ms was paid every request. Everything else (HMAC telemetry hash, KV reads, client/runtime/catalog creation, the `McpServer` constructor) is <1ms combined.

## Primary changes

Memoize tool schema registration once per isolate and move the one-time conversion to module scope on the Worker:

- **`packages/core/src/tools/define-tool.ts`** — cache the per-tool `RegisteredToolConfig` (the `compactJsonSchema`-wrapped schemas) in a `WeakMap` keyed by the module-level tool definition. Definitions are immutable constants and the SDK's `registerTool` only reads schemas via the Standard Schema interface, so sharing across concurrent servers is safe.
- **`packages/core/src/utils/compact-json-schema.ts`** — `preloadCompactJsonSchema(schema, io)` forces the memoized `input`/`output` conversions (`z.toJSONSchema` + compaction) to run now, and `getCompactJsonSchemaConversionCount()` exposes a computation-only counter for the regression test.
- **`packages/core/src/tools/register.ts` / `index.ts`** — new idempotent `preloadHevyToolSchemas()` that populates the config cache **and** forces exactly the conversions the SDK consumes during `registerTool` (`input` for each `inputSchema`, `output` for each read-tool `outputSchema`).
- **`packages/worker/src/worker.ts`** — calls `preloadHevyToolSchemas()` at module scope, so the conversions run during isolate warm-up, **outside a request's billed CPU** (the SDK's own recommended pattern for isolate-based edge runtimes). The first request of a fresh isolate therefore only reads already-converted schemas.

We deliberately do **not** share a `McpServer` instance across requests: the SDK keeps per-session state (`_clientCapabilities`, `_clientVersion`, `_negotiatedProtocolVersion`) on the `Server` for the streamable-HTTP transport, so that would race concurrent sessions. The per-request handler shell, runtime, and fresh server are unchanged.

## Reviewer walkthrough

The core caches each immutable tool definition's registration configuration, the Worker preloads every tool schema during module initialization, and each request continues to create a fresh MCP server and session.

## Correctness and invariants

Per-request MCP server and session state remain isolated; only immutable tool schema preparation is shared. The advertised schemas remain wire-identical, and preload performs the conversions once before request handling.

## Impact

- Per-request `createHevyMcpServer`: **12.18ms → 0.34ms** (~36×) on a warm isolate; the ~13ms one-time conversion runs once per isolate at warm-up, and the first request performs **zero** conversions (verified via the conversion counter: 36 conversions at preload, 0 across repeated preload/server builds/`tools/list`).
- Steady-state requests should now fit comfortably under the Worker CPU budget; `exceededCpu` 503s should disappear.
- No wire-visible behavior change: the advertised tool schemas are identical (computed once instead of per request).

## Testing and QA

- New `preload.test.ts`: cold-module counter proves preload performs every conversion before any server is built, and that further preload/server construction/`tools/list` never repeats them.
- `register.test.ts`: independently built servers advertise identical schemas.
- `npm run test:unit` (816), `test:worker`, `test:contract`, `test:pr`, `test:performance` — pass.
- `npm run check` (openapi, generated, type-aware lint, format), `check:types`, `build` — pass.
- `npm run check:changeset` — patch for `@hevy-mcp/core`, `hevy-mcp`, `@hevy-mcp/worker`, `@chrisdoc/hevy-cli`.
- `worker:dry-run` — bundle builds; module-scope preload with forced conversions confirmed present in the emitted bundle.

## Follow-up

Once merged and deployed, re-check Cloudflare logs for `exceededCpu`. If it appears again, the next lever is raising the Worker's CPU limit (paid plan / higher-limit plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced request-processing overhead by reusing tool configuration and schema information.
  * Preloaded tool schemas during startup to improve handling efficiency.
* **Bug Fixes**
  * Ensured consistent tool schemas across server instances and clients.
* **Testing**
  * Added coverage for repeatable schema preloading and consistent tool registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->