### PR TITLE
refactor(core): split response-contracts into output-schemas and formatters

### DIFF
--- a/.changeset/split-response-contracts.md
+++ b/.changeset/split-response-contracts.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Split response-contracts into output-schemas and formatters modules with no behavior change; response contract wiring stays in response-contracts.

--- a/packages/core/src/resources/hevy.test.ts
+++ b/packages/core/src/resources/hevy.test.ts
@@ -11,7 +11,7 @@ import type {
 	RoutineFolder,
 } from "@hevy-mcp/hevy-client/types";
 import { HevyHttpError, type HevyClient } from "@hevy-mcp/hevy-client";
-import { projectRoutineFolder } from "../utils/response-contracts.js";
+import { projectRoutineFolder } from "../utils/formatters.js";
 import {
 	createExerciseTemplateCatalog,
 	type ExerciseTemplateCatalog,

--- a/packages/core/src/resources/hevy.ts
+++ b/packages/core/src/resources/hevy.ts
@@ -10,7 +10,7 @@ import type {
 } from "@hevy-mcp/hevy-client/types";
 import type { ToolRuntime } from "../tools/tool-runtime.js";
 import { fetchAllPages } from "../utils/pagination.js";
-import { projectRoutineFolder } from "../utils/response-contracts.js";
+import { projectRoutineFolder } from "../utils/formatters.js";
 import { createExecutionErrorProjection } from "../utils/error-handler.js";
 import type { RuntimeValue } from "../utils/type-predicates.js";
 

--- a/packages/core/src/tools/routine-discovery.ts
+++ b/packages/core/src/tools/routine-discovery.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import type { GetV1Routines200, Routine } from "@hevy-mcp/hevy-client/types";
 import {
 	compactRoutinesResponse,
-	summarizeRoutine,
 	type CompactRoutinesResult,
 } from "../utils/response-contracts.js";
+import { summarizeRoutine } from "../utils/formatters.js";
 import { readOnlyAnnotations } from "../utils/tool-annotations.js";
 import { isFiniteNumber } from "../utils/type-predicates.js";
 

--- a/packages/core/src/tools/routines.ts
+++ b/packages/core/src/tools/routines.ts
@@ -2,8 +2,8 @@ import type {
 	PutV1RoutinesRoutineid200,
 	Routine,
 } from "@hevy-mcp/hevy-client/types";
+import { createRoutineOutputSchema } from "../utils/output-schemas.js";
 import {
-	createRoutineOutputSchema,
 	createRoutineResponse,
 	routineResponse,
 	routinesResponse,

--- a/packages/core/src/utils/formatters.test.ts
+++ b/packages/core/src/utils/formatters.test.ts
@@ -7,7 +7,7 @@ import {
 	projectRoutine,
 	projectRoutineFolder,
 	projectWorkout,
-} from "./response-contracts.js";
+} from "./formatters.js";
 
 describe("snake_case response projections", () => {
 	it("projects workouts without camelCase members", () => {

--- a/packages/core/src/utils/formatters.ts
+++ b/packages/core/src/utils/formatters.ts
@@ -1,0 +1,271 @@
+/**
+ * Projections from Hevy API types to the sparse snake_case MCP contract.
+ * Pure functions over their input; schemas they fill live in output-schemas.ts.
+ */
+import type {
+	BodyMeasurement,
+	ExerciseHistoryEntry,
+	Routine,
+	RoutineFolder,
+	Workout,
+} from "@hevy-mcp/hevy-client/types";
+import type {
+	CompactRoutine,
+	FormattedBodyMeasurement,
+	FormattedExerciseHistoryEntry,
+	FormattedRoutine,
+	FormattedRoutineExercise,
+	FormattedRoutineFolder,
+	FormattedRoutineSet,
+	FormattedWorkout,
+	FormattedWorkoutExercise,
+	FormattedWorkoutSet,
+	FormattedWorkoutSummary,
+} from "./output-schemas.js";
+import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+
+type ExerciseWithSupersetVariants = {
+	supersets_id?: number | null;
+	superset_id?: number | null;
+};
+
+function getSupersetId(exercise: ExerciseWithSupersetVariants): number | null {
+	if (exercise.superset_id !== undefined) {
+		return exercise.superset_id;
+	}
+
+	if (exercise.supersets_id !== undefined) {
+		return exercise.supersets_id;
+	}
+
+	return null;
+}
+
+/**
+ * Project a workout into the sparse snake_case MCP contract.
+ */
+export function projectWorkout(workout: Workout): FormattedWorkout {
+	const result: FormattedWorkout = {
+		duration: calculateDuration(workout.start_time, workout.end_time),
+	};
+	if (workout.id != null) result.id = workout.id;
+	if (workout.routine_id != null) result.routine_id = workout.routine_id;
+	if (workout.title != null) result.title = workout.title;
+	if (workout.description != null) result.description = workout.description;
+	if (workout.start_time != null) result.start_time = workout.start_time;
+	if (workout.end_time != null) result.end_time = workout.end_time;
+	if (workout.created_at != null) result.created_at = workout.created_at;
+	if (workout.updated_at != null) result.updated_at = workout.updated_at;
+	if (workout.exercises) {
+		result.exercises = workout.exercises.map((exercise) => {
+			const projected: FormattedWorkoutExercise = {};
+			if (exercise.index !== undefined) projected.index = exercise.index;
+			if (exercise.title != null) projected.title = exercise.title;
+			if (exercise.exercise_template_id != null)
+				projected.exercise_template_id = exercise.exercise_template_id;
+			if (exercise.notes != null) projected.notes = exercise.notes;
+			const supersetId = getSupersetId(exercise);
+			if (supersetId != null) projected.supersets_id = supersetId;
+			if (exercise.sets)
+				projected.sets = exercise.sets.map((set) => {
+					const projectedSet: FormattedWorkoutSet = {};
+					if (set.index !== undefined) projectedSet.index = set.index;
+					if (set.type != null) projectedSet.type = set.type;
+					if (set.weight_kg != null) projectedSet.weight_kg = set.weight_kg;
+					if (set.reps != null) projectedSet.reps = set.reps;
+					if (set.distance_meters != null)
+						projectedSet.distance_meters = set.distance_meters;
+					if (set.duration_seconds != null)
+						projectedSet.duration_seconds = set.duration_seconds;
+					if (set.rpe != null) projectedSet.rpe = set.rpe;
+					if (set.custom_metric != null)
+						projectedSet.custom_metric = set.custom_metric;
+					return projectedSet;
+				});
+			return projected;
+		});
+	}
+	return result;
+}
+
+export function summarizeWorkout(workout: Workout): FormattedWorkoutSummary {
+	const exercises = workout.exercises ?? [];
+	const result: FormattedWorkoutSummary = {
+		duration: calculateDuration(workout.start_time, workout.end_time),
+		exercise_count: exercises.length,
+		set_count: exercises.reduce(
+			(total, exercise) => total + (exercise.sets?.length ?? 0),
+			0,
+		),
+	};
+	if (workout.id != null) result.id = workout.id;
+	if (workout.title != null) result.title = workout.title;
+	if (workout.start_time != null) result.start_time = workout.start_time;
+	if (workout.end_time != null) result.end_time = workout.end_time;
+	return result;
+}
+
+export function projectRoutine(routine: Routine): FormattedRoutine {
+	const result: FormattedRoutine = {};
+	if (routine.id != null) result.id = routine.id;
+	if (routine.title != null) result.title = routine.title;
+	if (routine.folder_id != null) result.folder_id = routine.folder_id;
+	if (routine.created_at != null) result.created_at = routine.created_at;
+	if (routine.updated_at != null) result.updated_at = routine.updated_at;
+	if (routine.exercises)
+		result.exercises = routine.exercises.map((exercise) => {
+			const projected: FormattedRoutineExercise = {};
+			if (exercise.title != null) projected.title = exercise.title;
+			if (exercise.index !== undefined) projected.index = exercise.index;
+			if (exercise.exercise_template_id != null)
+				projected.exercise_template_id = exercise.exercise_template_id;
+			if (exercise.notes != null) projected.notes = exercise.notes;
+			const supersetId = getSupersetId(exercise);
+			if (supersetId != null) projected.supersets_id = supersetId;
+			if (exercise.rest_seconds != null)
+				projected.rest_seconds = exercise.rest_seconds;
+			if (exercise.sets)
+				projected.sets = exercise.sets.map((set) => {
+					const projectedSet: FormattedRoutineSet = {};
+					if (set.index !== undefined) projectedSet.index = set.index;
+					if (set.type != null) projectedSet.type = set.type;
+					if (set.weight_kg != null) projectedSet.weight_kg = set.weight_kg;
+					if (set.reps != null) projectedSet.reps = set.reps;
+					if (set.distance_meters != null)
+						projectedSet.distance_meters = set.distance_meters;
+					if (set.duration_seconds != null)
+						projectedSet.duration_seconds = set.duration_seconds;
+					if (set.rpe != null) projectedSet.rpe = set.rpe;
+					if (set.custom_metric != null)
+						projectedSet.custom_metric = set.custom_metric;
+					if (
+						set.rep_range &&
+						(set.rep_range.start != null || set.rep_range.end != null)
+					) {
+						const repRange: NonNullable<FormattedRoutineSet["rep_range"]> = {};
+						if (set.rep_range.start != null)
+							repRange.start = set.rep_range.start;
+						if (set.rep_range.end != null) repRange.end = set.rep_range.end;
+						projectedSet.rep_range = repRange;
+					}
+					return projectedSet;
+				});
+			return projected;
+		});
+	return result;
+}
+
+export function summarizeRoutine(routine: Routine): CompactRoutine {
+	const exercises = routine.exercises ?? [];
+	const result: CompactRoutine = {
+		exercise_count: exercises.length,
+		set_count: exercises.reduce(
+			(total, exercise) => total + (exercise.sets?.length ?? 0),
+			0,
+		),
+	};
+	if (routine.id != null) result.id = routine.id;
+	if (routine.title != null) result.title = routine.title;
+	if (routine.folder_id != null) result.folder_id = routine.folder_id;
+	if (routine.updated_at != null) result.updated_at = routine.updated_at;
+	return result;
+}
+
+export function projectRoutineFolder(
+	folder: RoutineFolder,
+): FormattedRoutineFolder {
+	return {
+		id: folder.id,
+		title: folder.title,
+		created_at: folder.created_at,
+		updated_at: folder.updated_at,
+	};
+}
+
+export function calculateDuration(
+	startTime: string | number | null | undefined,
+	endTime: string | number | null | undefined,
+): string {
+	if (!startTime || !endTime) return "Unknown duration";
+
+	try {
+		const start = new Date(startTime);
+		const end = new Date(endTime);
+		if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+			return "Unknown duration";
+		}
+		const durationMs = end.getTime() - start.getTime();
+		if (durationMs < 0) {
+			return "Invalid duration (end time before start time)";
+		}
+		const hours = Math.floor(durationMs / (1000 * 60 * 60));
+		const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
+		const seconds = Math.floor((durationMs % (1000 * 60)) / 1000);
+		return `${hours}h ${minutes}m ${seconds}s`;
+	} catch (error) {
+		console.error(
+			"Error calculating duration",
+			createSafeErrorDiagnostic(error),
+		);
+		return "Unknown duration";
+	}
+}
+
+export function normalizeExerciseHistoryEntry(
+	entry: ExerciseHistoryEntry,
+): FormattedExerciseHistoryEntry {
+	const result: FormattedExerciseHistoryEntry = {};
+	if (entry.workout_id != null) result.workout_id = entry.workout_id;
+	if (entry.workout_title != null) result.workout_title = entry.workout_title;
+	if (entry.workout_start_time != null)
+		result.workout_start_time = entry.workout_start_time;
+	if (entry.workout_end_time != null)
+		result.workout_end_time = entry.workout_end_time;
+	if (entry.exercise_template_id != null)
+		result.exercise_template_id = entry.exercise_template_id;
+	if (entry.weight_kg != null) result.weight_kg = entry.weight_kg;
+	if (entry.reps != null) result.reps = entry.reps;
+	if (entry.distance_meters != null)
+		result.distance_meters = entry.distance_meters;
+	if (entry.duration_seconds != null)
+		result.duration_seconds = entry.duration_seconds;
+	if (entry.rpe != null) result.rpe = entry.rpe;
+	if (entry.custom_metric != null) result.custom_metric = entry.custom_metric;
+	if (entry.set_type != null) result.set_type = entry.set_type;
+	return result;
+}
+
+export function normalizeBodyMeasurement(
+	measurement: BodyMeasurement,
+): FormattedBodyMeasurement {
+	const result: FormattedBodyMeasurement = { date: measurement.date };
+	if (measurement.weight_kg != null) result.weight_kg = measurement.weight_kg;
+	if (measurement.lean_mass_kg != null)
+		result.lean_mass_kg = measurement.lean_mass_kg;
+	if (measurement.fat_percent != null)
+		result.fat_percent = measurement.fat_percent;
+	if (measurement.neck_cm != null) result.neck_cm = measurement.neck_cm;
+	if (measurement.shoulder_cm != null)
+		result.shoulder_cm = measurement.shoulder_cm;
+	if (measurement.chest_cm != null) result.chest_cm = measurement.chest_cm;
+	if (measurement.left_bicep_cm != null)
+		result.left_bicep_cm = measurement.left_bicep_cm;
+	if (measurement.right_bicep_cm != null)
+		result.right_bicep_cm = measurement.right_bicep_cm;
+	if (measurement.left_forearm_cm != null)
+		result.left_forearm_cm = measurement.left_forearm_cm;
+	if (measurement.right_forearm_cm != null)
+		result.right_forearm_cm = measurement.right_forearm_cm;
+	if (measurement.abdomen != null) result.abdomen = measurement.abdomen;
+	if (measurement.waist != null) result.waist = measurement.waist;
+	if (measurement.hips != null) result.hips = measurement.hips;
+	if (measurement.left_thigh != null)
+		result.left_thigh_cm = measurement.left_thigh;
+	if (measurement.right_thigh != null)
+		result.right_thigh_cm = measurement.right_thigh;
+	if (measurement.left_calf != null)
+		result.left_calf_cm = measurement.left_calf;
+	if (measurement.right_calf != null)
+		result.right_calf_cm = measurement.right_calf;
+	return result;
+}

--- a/packages/core/src/utils/output-schemas.test.ts
+++ b/packages/core/src/utils/output-schemas.test.ts
@@ -6,8 +6,8 @@ import {
 	formattedRoutineFolderSchema,
 	formattedRoutineSchema,
 	formattedWorkoutSchema,
-	workoutEventsResponse,
-} from "./response-contracts.js";
+} from "./output-schemas.js";
+import { workoutEventsResponse } from "./response-contracts.js";
 
 describe("snake_case formatted output schemas", () => {
 	it("accepts generated-aligned workout and routine projections", () => {

--- a/packages/core/src/utils/output-schemas.ts
+++ b/packages/core/src/utils/output-schemas.ts
@@ -1,0 +1,207 @@
+/**
+ * Snake_case zod schemas describing MCP tool output shapes, plus the types
+ * inferred from them. Schemas only: projection logic lives in formatters.ts,
+ * contract wiring lives in response-contracts.ts.
+ */
+import { z } from "zod";
+
+export const optionalNumber = z.number().optional();
+
+export const formattedWorkoutSetSchema = z.object({
+	index: z.number().optional(),
+	type: z.string().optional(),
+	weight_kg: optionalNumber,
+	reps: optionalNumber,
+	distance_meters: optionalNumber,
+	duration_seconds: optionalNumber,
+	rpe: optionalNumber,
+	custom_metric: optionalNumber,
+});
+
+export const formattedWorkoutExerciseSchema = z.object({
+	index: z.number().optional(),
+	title: z.string().optional(),
+	exercise_template_id: z.string().optional(),
+	notes: z.string().optional(),
+	supersets_id: optionalNumber,
+	sets: z.array(formattedWorkoutSetSchema).optional(),
+});
+
+export const formattedWorkoutSchema = z.object({
+	id: z.string().optional(),
+	routine_id: z.string().optional(),
+	title: z.string().optional(),
+	description: z.string().optional(),
+	start_time: z.string().optional(),
+	end_time: z.string().optional(),
+	created_at: z.string().optional(),
+	updated_at: z.string().optional(),
+	duration: z.string(),
+	exercises: z.array(formattedWorkoutExerciseSchema).optional(),
+});
+
+export const formattedRoutineSetSchema = z.object({
+	index: z.number().optional(),
+	type: z.string().optional(),
+	weight_kg: optionalNumber,
+	reps: optionalNumber,
+	distance_meters: optionalNumber,
+	duration_seconds: optionalNumber,
+	custom_metric: optionalNumber,
+	rep_range: z
+		.object({
+			start: z.number().optional(),
+			end: z.number().optional(),
+		})
+		.optional(),
+	rpe: optionalNumber,
+});
+
+export const formattedRoutineExerciseSchema = z.object({
+	title: z.string().optional(),
+	index: z.number().optional(),
+	exercise_template_id: z.string().optional(),
+	notes: z.string().optional(),
+	supersets_id: optionalNumber,
+	rest_seconds: z.number().int().optional(),
+	sets: z.array(formattedRoutineSetSchema).optional(),
+});
+
+export const formattedRoutineSchema = z.object({
+	id: z.string().optional(),
+	title: z.string().optional(),
+	folder_id: z.number().optional(),
+	created_at: z.string().optional(),
+	updated_at: z.string().optional(),
+	exercises: z.array(formattedRoutineExerciseSchema).optional(),
+});
+
+export const createRoutineOutputSchema = {
+	created: z.literal(true),
+	commit_state: z.literal("confirmed"),
+	routine: formattedRoutineSchema.nullable(),
+	routine_id: z.string().nullable(),
+	uses_rep_ranges: z.boolean(),
+} as const;
+
+export const formattedRoutineFolderSchema = z.object({
+	id: z.number().optional(),
+	title: z.string().optional(),
+	created_at: z.string().optional(),
+	updated_at: z.string().optional(),
+});
+
+export const formattedExerciseTemplateSchema = z.object({
+	id: z.string().optional(),
+	title: z.string().optional(),
+	type: z.string().optional(),
+	primary_muscle_group: z.string().optional(),
+	secondary_muscle_groups: z.array(z.string()).optional(),
+	is_custom: z.boolean().optional(),
+});
+
+export const formattedExerciseHistoryEntrySchema = z.object({
+	workout_id: z.string().optional(),
+	workout_title: z.string().optional(),
+	workout_start_time: z.string().optional(),
+	workout_end_time: z.string().optional(),
+	exercise_template_id: z.string().optional(),
+	weight_kg: optionalNumber,
+	reps: optionalNumber,
+	distance_meters: optionalNumber,
+	duration_seconds: optionalNumber,
+	rpe: optionalNumber,
+	custom_metric: optionalNumber,
+	set_type: z.string().optional(),
+});
+
+export const formattedBodyMeasurementSchema = z.object({
+	date: z.string(),
+	weight_kg: optionalNumber,
+	lean_mass_kg: optionalNumber,
+	fat_percent: optionalNumber,
+	neck_cm: optionalNumber,
+	shoulder_cm: optionalNumber,
+	chest_cm: optionalNumber,
+	left_bicep_cm: optionalNumber,
+	right_bicep_cm: optionalNumber,
+	left_forearm_cm: optionalNumber,
+	right_forearm_cm: optionalNumber,
+	abdomen: optionalNumber,
+	waist: optionalNumber,
+	hips: optionalNumber,
+	left_thigh_cm: optionalNumber,
+	right_thigh_cm: optionalNumber,
+	left_calf_cm: optionalNumber,
+	right_calf_cm: optionalNumber,
+});
+export const scanSchema = z.object({
+	pages: z.record(z.string(), z.number().int().nonnegative()),
+	items: z.number().int().nonnegative(),
+});
+
+export const trainingSummarySessionSchema = z.object({
+	id: z.string().optional(),
+	title: z.string().optional(),
+	start_time: z.string().optional(),
+	end_time: z.string().optional(),
+	duration_seconds: z.number().int().nonnegative().optional(),
+	exercise_count: z.number().int().nonnegative(),
+	set_count: z.number().int().nonnegative(),
+});
+
+export const compactRoutineSchema = z.object({
+	id: z.string().optional(),
+	title: z.string().optional(),
+	folder_id: z.number().optional(),
+	updated_at: z.string().optional(),
+	exercise_count: z.number().int().nonnegative(),
+	set_count: z.number().int().nonnegative(),
+});
+
+export type CompactRoutine = z.infer<typeof compactRoutineSchema>;
+
+export type FormattedWorkoutSet = z.infer<typeof formattedWorkoutSetSchema>;
+export type FormattedWorkoutExercise = z.infer<
+	typeof formattedWorkoutExerciseSchema
+>;
+export type FormattedWorkout = z.infer<typeof formattedWorkoutSchema>;
+export type FormattedRoutineSet = z.infer<typeof formattedRoutineSetSchema>;
+export type FormattedRoutineExercise = z.infer<
+	typeof formattedRoutineExerciseSchema
+>;
+export type FormattedRoutine = z.infer<typeof formattedRoutineSchema>;
+export type FormattedRoutineFolder = z.infer<
+	typeof formattedRoutineFolderSchema
+>;
+export type FormattedExerciseTemplate = z.infer<
+	typeof formattedExerciseTemplateSchema
+>;
+export type FormattedExerciseHistoryEntry = z.infer<
+	typeof formattedExerciseHistoryEntrySchema
+>;
+export type FormattedBodyMeasurement = z.infer<
+	typeof formattedBodyMeasurementSchema
+>;
+
+export const formattedWorkoutSummarySchema = z.object({
+	id: z.string().optional(),
+	title: z.string().optional(),
+	start_time: z.string().optional(),
+	end_time: z.string().optional(),
+	duration: z.string(),
+	exercise_count: z.number().int().nonnegative(),
+	set_count: z.number().int().nonnegative(),
+});
+export type FormattedWorkoutSummary = z.infer<
+	typeof formattedWorkoutSummarySchema
+>;
+export const formattedUpdatedWorkoutSchema = z.object({
+	type: z.literal("updated"),
+	workout: formattedWorkoutSchema,
+});
+export const formattedDeletedWorkoutSchema = z.object({
+	type: z.literal("deleted"),
+	id: z.string(),
+	deleted_at: z.string().optional(),
+});

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -15,12 +15,36 @@ import type {
 	Workout,
 } from "@hevy-mcp/hevy-client/types";
 import type { StructuredExecutionError } from "../execution.js";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
 import {
 	attachResultTelemetry,
 	bucketCount,
 	type ToolResultTelemetry,
 } from "./result-telemetry.js";
+import {
+	createRoutineOutputSchema,
+	optionalNumber,
+	formattedBodyMeasurementSchema,
+	formattedDeletedWorkoutSchema,
+	formattedExerciseHistoryEntrySchema,
+	formattedExerciseTemplateSchema,
+	formattedRoutineFolderSchema,
+	formattedRoutineSchema,
+	formattedUpdatedWorkoutSchema,
+	formattedWorkoutSchema,
+	formattedWorkoutSummarySchema,
+	compactRoutineSchema,
+	scanSchema,
+	trainingSummarySessionSchema,
+} from "./output-schemas.js";
+import {
+	normalizeBodyMeasurement,
+	normalizeExerciseHistoryEntry,
+	projectRoutine,
+	projectRoutineFolder,
+	projectWorkout,
+	summarizeRoutine,
+	summarizeWorkout,
+} from "./formatters.js";
 
 /**
  * MCP tool response type aligned with MCP SDK CallToolResult while keeping
@@ -135,136 +159,6 @@ export function respond<TData>(
 	return contract.render(data);
 }
 
-const optionalNumber = z.number().optional();
-
-export const formattedWorkoutSetSchema = z.object({
-	index: z.number().optional(),
-	type: z.string().optional(),
-	weight_kg: optionalNumber,
-	reps: optionalNumber,
-	distance_meters: optionalNumber,
-	duration_seconds: optionalNumber,
-	rpe: optionalNumber,
-	custom_metric: optionalNumber,
-});
-
-export const formattedWorkoutExerciseSchema = z.object({
-	index: z.number().optional(),
-	title: z.string().optional(),
-	exercise_template_id: z.string().optional(),
-	notes: z.string().optional(),
-	supersets_id: optionalNumber,
-	sets: z.array(formattedWorkoutSetSchema).optional(),
-});
-
-export const formattedWorkoutSchema = z.object({
-	id: z.string().optional(),
-	routine_id: z.string().optional(),
-	title: z.string().optional(),
-	description: z.string().optional(),
-	start_time: z.string().optional(),
-	end_time: z.string().optional(),
-	created_at: z.string().optional(),
-	updated_at: z.string().optional(),
-	duration: z.string(),
-	exercises: z.array(formattedWorkoutExerciseSchema).optional(),
-});
-
-export const formattedRoutineSetSchema = z.object({
-	index: z.number().optional(),
-	type: z.string().optional(),
-	weight_kg: optionalNumber,
-	reps: optionalNumber,
-	distance_meters: optionalNumber,
-	duration_seconds: optionalNumber,
-	custom_metric: optionalNumber,
-	rep_range: z
-		.object({
-			start: z.number().optional(),
-			end: z.number().optional(),
-		})
-		.optional(),
-	rpe: optionalNumber,
-});
-
-export const formattedRoutineExerciseSchema = z.object({
-	title: z.string().optional(),
-	index: z.number().optional(),
-	exercise_template_id: z.string().optional(),
-	notes: z.string().optional(),
-	supersets_id: optionalNumber,
-	rest_seconds: z.number().int().optional(),
-	sets: z.array(formattedRoutineSetSchema).optional(),
-});
-
-export const formattedRoutineSchema = z.object({
-	id: z.string().optional(),
-	title: z.string().optional(),
-	folder_id: z.number().optional(),
-	created_at: z.string().optional(),
-	updated_at: z.string().optional(),
-	exercises: z.array(formattedRoutineExerciseSchema).optional(),
-});
-
-export const createRoutineOutputSchema = {
-	created: z.literal(true),
-	commit_state: z.literal("confirmed"),
-	routine: formattedRoutineSchema.nullable(),
-	routine_id: z.string().nullable(),
-	uses_rep_ranges: z.boolean(),
-} as const;
-
-export const formattedRoutineFolderSchema = z.object({
-	id: z.number().optional(),
-	title: z.string().optional(),
-	created_at: z.string().optional(),
-	updated_at: z.string().optional(),
-});
-
-export const formattedExerciseTemplateSchema = z.object({
-	id: z.string().optional(),
-	title: z.string().optional(),
-	type: z.string().optional(),
-	primary_muscle_group: z.string().optional(),
-	secondary_muscle_groups: z.array(z.string()).optional(),
-	is_custom: z.boolean().optional(),
-});
-
-export const formattedExerciseHistoryEntrySchema = z.object({
-	workout_id: z.string().optional(),
-	workout_title: z.string().optional(),
-	workout_start_time: z.string().optional(),
-	workout_end_time: z.string().optional(),
-	exercise_template_id: z.string().optional(),
-	weight_kg: optionalNumber,
-	reps: optionalNumber,
-	distance_meters: optionalNumber,
-	duration_seconds: optionalNumber,
-	rpe: optionalNumber,
-	custom_metric: optionalNumber,
-	set_type: z.string().optional(),
-});
-
-export const formattedBodyMeasurementSchema = z.object({
-	date: z.string(),
-	weight_kg: optionalNumber,
-	lean_mass_kg: optionalNumber,
-	fat_percent: optionalNumber,
-	neck_cm: optionalNumber,
-	shoulder_cm: optionalNumber,
-	chest_cm: optionalNumber,
-	left_bicep_cm: optionalNumber,
-	right_bicep_cm: optionalNumber,
-	left_forearm_cm: optionalNumber,
-	right_forearm_cm: optionalNumber,
-	abdomen: optionalNumber,
-	waist: optionalNumber,
-	hips: optionalNumber,
-	left_thigh_cm: optionalNumber,
-	right_thigh_cm: optionalNumber,
-	left_calf_cm: optionalNumber,
-	right_calf_cm: optionalNumber,
-});
 export interface WorkflowTelemetry {
 	name: "training-summary" | "routine-discovery";
 	pagination: Readonly<Record<string, number>>;
@@ -272,65 +166,6 @@ export interface WorkflowTelemetry {
 	itemsScanned: number;
 }
 
-export const scanSchema = z.object({
-	pages: z.record(z.string(), z.number().int().nonnegative()),
-	items: z.number().int().nonnegative(),
-});
-
-export const trainingSummarySessionSchema = z.object({
-	id: z.string().optional(),
-	title: z.string().optional(),
-	start_time: z.string().optional(),
-	end_time: z.string().optional(),
-	duration_seconds: z.number().int().nonnegative().optional(),
-	exercise_count: z.number().int().nonnegative(),
-	set_count: z.number().int().nonnegative(),
-});
-
-export const compactRoutineSchema = z.object({
-	id: z.string().optional(),
-	title: z.string().optional(),
-	folder_id: z.number().optional(),
-	updated_at: z.string().optional(),
-	exercise_count: z.number().int().nonnegative(),
-	set_count: z.number().int().nonnegative(),
-});
-
-export type FormattedWorkoutSet = z.infer<typeof formattedWorkoutSetSchema>;
-export type FormattedWorkoutExercise = z.infer<
-	typeof formattedWorkoutExerciseSchema
->;
-export type FormattedWorkout = z.infer<typeof formattedWorkoutSchema>;
-export type FormattedRoutineSet = z.infer<typeof formattedRoutineSetSchema>;
-export type FormattedRoutineExercise = z.infer<
-	typeof formattedRoutineExerciseSchema
->;
-export type FormattedRoutine = z.infer<typeof formattedRoutineSchema>;
-export type FormattedRoutineFolder = z.infer<
-	typeof formattedRoutineFolderSchema
->;
-export type FormattedExerciseTemplate = z.infer<
-	typeof formattedExerciseTemplateSchema
->;
-export type FormattedExerciseHistoryEntry = z.infer<
-	typeof formattedExerciseHistoryEntrySchema
->;
-export type FormattedBodyMeasurement = z.infer<
-	typeof formattedBodyMeasurementSchema
->;
-
-export const formattedWorkoutSummarySchema = z.object({
-	id: z.string().optional(),
-	title: z.string().optional(),
-	start_time: z.string().optional(),
-	end_time: z.string().optional(),
-	duration: z.string(),
-	exercise_count: z.number().int().nonnegative(),
-	set_count: z.number().int().nonnegative(),
-});
-export type FormattedWorkoutSummary = z.infer<
-	typeof formattedWorkoutSummarySchema
->;
 const paginationOutputSchema = {
 	page: z.number().int().positive(),
 	page_count: z.number().int().nonnegative().optional(),
@@ -359,15 +194,6 @@ const workoutOutputSchema = {
 	workout: formattedWorkoutSchema.nullable(),
 } as const;
 const workoutCountOutputSchema = { workout_count: z.number().int() } as const;
-export const formattedUpdatedWorkoutSchema = z.object({
-	type: z.literal("updated"),
-	workout: formattedWorkoutSchema,
-});
-export const formattedDeletedWorkoutSchema = z.object({
-	type: z.literal("deleted"),
-	id: z.string(),
-	deleted_at: z.string().optional(),
-});
 const workoutEventsOutputSchema = {
 	events: z.array(
 		z.union([formattedUpdatedWorkoutSchema, formattedDeletedWorkoutSchema]),
@@ -449,254 +275,6 @@ const compactRoutinesOutputSchema = {
 	routines: z.array(compactRoutineSchema),
 	scan: scanSchema,
 } as const;
-
-type ExerciseWithSupersetVariants = {
-	supersets_id?: number | null;
-	superset_id?: number | null;
-};
-
-function getSupersetId(exercise: ExerciseWithSupersetVariants): number | null {
-	if (exercise.superset_id !== undefined) {
-		return exercise.superset_id;
-	}
-
-	if (exercise.supersets_id !== undefined) {
-		return exercise.supersets_id;
-	}
-
-	return null;
-}
-
-/**
- * Project a workout into the sparse snake_case MCP contract.
- */
-export function projectWorkout(workout: Workout): FormattedWorkout {
-	const result: FormattedWorkout = {
-		duration: calculateDuration(workout.start_time, workout.end_time),
-	};
-	if (workout.id != null) result.id = workout.id;
-	if (workout.routine_id != null) result.routine_id = workout.routine_id;
-	if (workout.title != null) result.title = workout.title;
-	if (workout.description != null) result.description = workout.description;
-	if (workout.start_time != null) result.start_time = workout.start_time;
-	if (workout.end_time != null) result.end_time = workout.end_time;
-	if (workout.created_at != null) result.created_at = workout.created_at;
-	if (workout.updated_at != null) result.updated_at = workout.updated_at;
-	if (workout.exercises) {
-		result.exercises = workout.exercises.map((exercise) => {
-			const projected: FormattedWorkoutExercise = {};
-			if (exercise.index !== undefined) projected.index = exercise.index;
-			if (exercise.title != null) projected.title = exercise.title;
-			if (exercise.exercise_template_id != null)
-				projected.exercise_template_id = exercise.exercise_template_id;
-			if (exercise.notes != null) projected.notes = exercise.notes;
-			const supersetId = getSupersetId(exercise);
-			if (supersetId != null) projected.supersets_id = supersetId;
-			if (exercise.sets)
-				projected.sets = exercise.sets.map((set) => {
-					const projectedSet: FormattedWorkoutSet = {};
-					if (set.index !== undefined) projectedSet.index = set.index;
-					if (set.type != null) projectedSet.type = set.type;
-					if (set.weight_kg != null) projectedSet.weight_kg = set.weight_kg;
-					if (set.reps != null) projectedSet.reps = set.reps;
-					if (set.distance_meters != null)
-						projectedSet.distance_meters = set.distance_meters;
-					if (set.duration_seconds != null)
-						projectedSet.duration_seconds = set.duration_seconds;
-					if (set.rpe != null) projectedSet.rpe = set.rpe;
-					if (set.custom_metric != null)
-						projectedSet.custom_metric = set.custom_metric;
-					return projectedSet;
-				});
-			return projected;
-		});
-	}
-	return result;
-}
-
-export function summarizeWorkout(workout: Workout): FormattedWorkoutSummary {
-	const exercises = workout.exercises ?? [];
-	const result: FormattedWorkoutSummary = {
-		duration: calculateDuration(workout.start_time, workout.end_time),
-		exercise_count: exercises.length,
-		set_count: exercises.reduce(
-			(total, exercise) => total + (exercise.sets?.length ?? 0),
-			0,
-		),
-	};
-	if (workout.id != null) result.id = workout.id;
-	if (workout.title != null) result.title = workout.title;
-	if (workout.start_time != null) result.start_time = workout.start_time;
-	if (workout.end_time != null) result.end_time = workout.end_time;
-	return result;
-}
-
-export function projectRoutine(routine: Routine): FormattedRoutine {
-	const result: FormattedRoutine = {};
-	if (routine.id != null) result.id = routine.id;
-	if (routine.title != null) result.title = routine.title;
-	if (routine.folder_id != null) result.folder_id = routine.folder_id;
-	if (routine.created_at != null) result.created_at = routine.created_at;
-	if (routine.updated_at != null) result.updated_at = routine.updated_at;
-	if (routine.exercises)
-		result.exercises = routine.exercises.map((exercise) => {
-			const projected: FormattedRoutineExercise = {};
-			if (exercise.title != null) projected.title = exercise.title;
-			if (exercise.index !== undefined) projected.index = exercise.index;
-			if (exercise.exercise_template_id != null)
-				projected.exercise_template_id = exercise.exercise_template_id;
-			if (exercise.notes != null) projected.notes = exercise.notes;
-			const supersetId = getSupersetId(exercise);
-			if (supersetId != null) projected.supersets_id = supersetId;
-			if (exercise.rest_seconds != null)
-				projected.rest_seconds = exercise.rest_seconds;
-			if (exercise.sets)
-				projected.sets = exercise.sets.map((set) => {
-					const projectedSet: FormattedRoutineSet = {};
-					if (set.index !== undefined) projectedSet.index = set.index;
-					if (set.type != null) projectedSet.type = set.type;
-					if (set.weight_kg != null) projectedSet.weight_kg = set.weight_kg;
-					if (set.reps != null) projectedSet.reps = set.reps;
-					if (set.distance_meters != null)
-						projectedSet.distance_meters = set.distance_meters;
-					if (set.duration_seconds != null)
-						projectedSet.duration_seconds = set.duration_seconds;
-					if (set.rpe != null) projectedSet.rpe = set.rpe;
-					if (set.custom_metric != null)
-						projectedSet.custom_metric = set.custom_metric;
-					if (
-						set.rep_range &&
-						(set.rep_range.start != null || set.rep_range.end != null)
-					) {
-						const repRange: NonNullable<FormattedRoutineSet["rep_range"]> = {};
-						if (set.rep_range.start != null)
-							repRange.start = set.rep_range.start;
-						if (set.rep_range.end != null) repRange.end = set.rep_range.end;
-						projectedSet.rep_range = repRange;
-					}
-					return projectedSet;
-				});
-			return projected;
-		});
-	return result;
-}
-
-export function summarizeRoutine(
-	routine: Routine,
-): z.output<typeof compactRoutineSchema> {
-	const exercises = routine.exercises ?? [];
-	const result: z.output<typeof compactRoutineSchema> = {
-		exercise_count: exercises.length,
-		set_count: exercises.reduce(
-			(total, exercise) => total + (exercise.sets?.length ?? 0),
-			0,
-		),
-	};
-	if (routine.id != null) result.id = routine.id;
-	if (routine.title != null) result.title = routine.title;
-	if (routine.folder_id != null) result.folder_id = routine.folder_id;
-	if (routine.updated_at != null) result.updated_at = routine.updated_at;
-	return result;
-}
-
-export function projectRoutineFolder(
-	folder: RoutineFolder,
-): FormattedRoutineFolder {
-	return {
-		id: folder.id,
-		title: folder.title,
-		created_at: folder.created_at,
-		updated_at: folder.updated_at,
-	};
-}
-
-export function calculateDuration(
-	startTime: string | number | null | undefined,
-	endTime: string | number | null | undefined,
-): string {
-	if (!startTime || !endTime) return "Unknown duration";
-
-	try {
-		const start = new Date(startTime);
-		const end = new Date(endTime);
-		if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-			return "Unknown duration";
-		}
-		const durationMs = end.getTime() - start.getTime();
-		if (durationMs < 0) {
-			return "Invalid duration (end time before start time)";
-		}
-		const hours = Math.floor(durationMs / (1000 * 60 * 60));
-		const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
-		const seconds = Math.floor((durationMs % (1000 * 60)) / 1000);
-		return `${hours}h ${minutes}m ${seconds}s`;
-	} catch (error) {
-		console.error(
-			"Error calculating duration",
-			createSafeErrorDiagnostic(error),
-		);
-		return "Unknown duration";
-	}
-}
-
-export function normalizeExerciseHistoryEntry(
-	entry: ExerciseHistoryEntry,
-): FormattedExerciseHistoryEntry {
-	const result: FormattedExerciseHistoryEntry = {};
-	if (entry.workout_id != null) result.workout_id = entry.workout_id;
-	if (entry.workout_title != null) result.workout_title = entry.workout_title;
-	if (entry.workout_start_time != null)
-		result.workout_start_time = entry.workout_start_time;
-	if (entry.workout_end_time != null)
-		result.workout_end_time = entry.workout_end_time;
-	if (entry.exercise_template_id != null)
-		result.exercise_template_id = entry.exercise_template_id;
-	if (entry.weight_kg != null) result.weight_kg = entry.weight_kg;
-	if (entry.reps != null) result.reps = entry.reps;
-	if (entry.distance_meters != null)
-		result.distance_meters = entry.distance_meters;
-	if (entry.duration_seconds != null)
-		result.duration_seconds = entry.duration_seconds;
-	if (entry.rpe != null) result.rpe = entry.rpe;
-	if (entry.custom_metric != null) result.custom_metric = entry.custom_metric;
-	if (entry.set_type != null) result.set_type = entry.set_type;
-	return result;
-}
-
-export function normalizeBodyMeasurement(
-	measurement: BodyMeasurement,
-): FormattedBodyMeasurement {
-	const result: FormattedBodyMeasurement = { date: measurement.date };
-	if (measurement.weight_kg != null) result.weight_kg = measurement.weight_kg;
-	if (measurement.lean_mass_kg != null)
-		result.lean_mass_kg = measurement.lean_mass_kg;
-	if (measurement.fat_percent != null)
-		result.fat_percent = measurement.fat_percent;
-	if (measurement.neck_cm != null) result.neck_cm = measurement.neck_cm;
-	if (measurement.shoulder_cm != null)
-		result.shoulder_cm = measurement.shoulder_cm;
-	if (measurement.chest_cm != null) result.chest_cm = measurement.chest_cm;
-	if (measurement.left_bicep_cm != null)
-		result.left_bicep_cm = measurement.left_bicep_cm;
-	if (measurement.right_bicep_cm != null)
-		result.right_bicep_cm = measurement.right_bicep_cm;
-	if (measurement.left_forearm_cm != null)
-		result.left_forearm_cm = measurement.left_forearm_cm;
-	if (measurement.right_forearm_cm != null)
-		result.right_forearm_cm = measurement.right_forearm_cm;
-	if (measurement.abdomen != null) result.abdomen = measurement.abdomen;
-	if (measurement.waist != null) result.waist = measurement.waist;
-	if (measurement.hips != null) result.hips = measurement.hips;
-	if (measurement.left_thigh != null)
-		result.left_thigh_cm = measurement.left_thigh;
-	if (measurement.right_thigh != null)
-		result.right_thigh_cm = measurement.right_thigh;
-	if (measurement.left_calf != null)
-		result.left_calf_cm = measurement.left_calf;
-	if (measurement.right_calf != null)
-		result.right_calf_cm = measurement.right_calf;
-	return result;
-}
 
 type WorkoutEvent = GetV1WorkoutsEvents200["events"][number];
 


### PR DESCRIPTION
Architecture review candidate 5 (https://github.com/chrisdoc/hevy-mcp/issues — deepening pass).

## Primary changes

Split `response-contracts.ts` (1227 LOC, 71 exports) into three focused modules along the seam its own tests already named:

- `output-schemas.ts` — snake_case zod output shapes + inferred types
- `formatters.ts` — projections (`projectWorkout`, `summarizeRoutine`, …)
- `response-contracts.ts` — contract helpers + per-tool contract instances

## Reviewer walkthrough

- Direct schema and formatter importers now use `output-schemas.ts` and `formatters.ts`.
- Contract-instance importers remain unchanged; `response-contracts.ts` assembles the per-tool contracts from the extracted modules.
- The formatter and schema tests were updated to import from their dedicated modules.

## Correctness and invariants

Importers of contract instances are unchanged; direct schema/formatter importers were updated. No behavior change.

## Testing and QA

The formatter and schema test imports were updated with the module split. A patch changeset covers the core package and its dependent packages.

**Why:** one file, three modules — importers pulled a slice and paid for the whole namespace; navigation now matches the test split.

Base: `main`. Next PR stacks on this branch.

## Summary by Sourcery

Refactor response contracts into focused schema, formatter, and contract-wiring modules without changing behavior.

Enhancements:
- Split response formatting responsibilities into dedicated output-schema and formatter modules while retaining response-contract wiring in its existing module.

Tests:
- Update schema and formatter tests and their consumers to use the new focused module imports.

Chores:
- Add patch changesets for the core package and dependent packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the consistency of workout, routine, exercise history, and body measurement results.
  * Added clearer handling for workout durations, including missing or invalid timing data.
  * Standardized structured output for routines, folders, summaries, scans, and workout events.
* **Bug Fixes**
  * Improved resilience when processing incomplete or unexpected fitness data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->