### PR TITLE
refactor(core): own safe-error vocabulary; worker imports it

### DIFF
--- a/.changeset/own-safe-error-vocabulary.md
+++ b/.changeset/own-safe-error-vocabulary.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Export the safe-error diagnostic vocabulary (codes, methods, categories, stack sources) from core as its interface; the Worker adapter validates against the shared vocabulary instead of private copies. Folds the safe-error-diagnostic re-export into error-policy.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,13 @@ export {
 	type CacheObservationState,
 	type CacheObserver,
 } from "./utils/cache.js";
-export { createSafeErrorDiagnostic } from "./utils/safe-error-diagnostic.js";
+export {
+	createSafeErrorDiagnostic,
+	SAFE_ERROR_CATEGORIES,
+	SAFE_ERROR_CODES,
+	SAFE_HTTP_METHODS,
+	SAFE_STACK_SOURCES,
+} from "./utils/error-policy.js";
 export {
 	createMcpToolFailureEvent,
 	createExecutionErrorProjection,

--- a/packages/core/src/tools/templates.ts
+++ b/packages/core/src/tools/templates.ts
@@ -11,7 +11,7 @@ import {
 	exerciseTemplateResponse,
 	searchExerciseTemplatesResponse,
 } from "../utils/response-contracts.js";
-import { createSafeErrorDiagnostic } from "../utils/safe-error-diagnostic.js";
+import { createSafeErrorDiagnostic } from "../utils/error-policy.js";
 import {
 	createAnnotations,
 	readOnlyAnnotations,

--- a/packages/core/src/utils/cache.test.ts
+++ b/packages/core/src/utils/cache.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+import { createSafeErrorDiagnostic } from "./error-policy.js";
 import { AsyncTtlCache } from "./cache.js";
 
 describe("AsyncTtlCache", () => {

--- a/packages/core/src/utils/error-handler.ts
+++ b/packages/core/src/utils/error-handler.ts
@@ -11,7 +11,7 @@ import {
 	type StructuredExecutionProjection,
 	type ToolExecutionContext,
 } from "../execution.js";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+import { createSafeErrorDiagnostic } from "./error-policy.js";
 import type { RuntimeValue } from "./type-predicates.js";
 
 export { ErrorType } from "./error-policy.js";

--- a/packages/core/src/utils/error-policy.test.ts
+++ b/packages/core/src/utils/error-policy.test.ts
@@ -1,6 +1,71 @@
 import { describe, expect, it } from "vitest";
 import { HevyHttpError } from "@hevy-mcp/hevy-client";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+
+import {
+	createSafeErrorDiagnostic,
+	SAFE_ERROR_CATEGORIES,
+	SAFE_ERROR_CODES,
+	SAFE_HTTP_METHODS,
+	SAFE_STACK_SOURCES,
+} from "./error-policy.js";
+
+/** A category with no corresponding JS constructor (produced by fallthrough). */
+const LAST_RESORT_CATEGORY = "UnknownError" as const;
+
+describe("safe-error diagnostic vocabulary", () => {
+	it("freezes the exported allowlists so adapters cannot widen them", () => {
+		expect(Object.isFrozen(SAFE_ERROR_CODES)).toBe(true);
+		expect(Object.isFrozen(SAFE_HTTP_METHODS)).toBe(true);
+		expect(Object.isFrozen(SAFE_ERROR_CATEGORIES)).toBe(true);
+		expect(Object.isFrozen(SAFE_STACK_SOURCES)).toBe(true);
+	});
+
+	it("covers every category createSafeErrorDiagnostic can classify", () => {
+		const samples: unknown[] = [
+			new TypeError("t"),
+			new RangeError("r"),
+			new ReferenceError("ref"),
+			new SyntaxError("s"),
+			new URIError("u"),
+			new EvalError("e"),
+			new AggregateError([]),
+			new DOMException("d", "AbortError"),
+			new Error("plain"),
+			"not-an-error",
+		];
+		for (const sample of samples) {
+			const { category } = createSafeErrorDiagnostic(sample);
+			expect(SAFE_ERROR_CATEGORIES.has(category)).toBe(true);
+		}
+		expect(SAFE_ERROR_CATEGORIES.has(LAST_RESORT_CATEGORY)).toBe(true);
+		expect(SAFE_ERROR_CATEGORIES.has("HevyHttpError")).toBe(true);
+	});
+
+	it("emits only codes from the shared allowlist", () => {
+		const allowed = createSafeErrorDiagnostic(
+			Object.assign(new Error("net"), { code: "ECONNRESET" }),
+		);
+		expect(allowed.code).toBe("ECONNRESET");
+		expect(SAFE_ERROR_CODES.has(allowed.code ?? "")).toBe(true);
+
+		const rejected = createSafeErrorDiagnostic(
+			Object.assign(new Error("secret"), { code: "INTERNAL_TOKEN_XY" }),
+		);
+		expect(rejected.code).toBeUndefined();
+	});
+
+	it("emits only HTTP methods from the shared allowlist", () => {
+		const method = createSafeErrorDiagnostic(
+			Object.assign(new Error("http"), {
+				status: 500,
+				method: "TRACE",
+				endpoint: "/v1/workouts",
+			}),
+		).method;
+		expect(method).toBeUndefined();
+		expect(SAFE_HTTP_METHODS.has("GET")).toBe(true);
+	});
+});
 
 const SECRET = "sentinel-api-key-value";
 

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -74,6 +74,24 @@ type SafeSourceId =
 	| "server"
 	| "worker";
 
+/** Categories createSafeErrorDiagnostic may emit; part of the module's interface. */
+export const SAFE_ERROR_CATEGORIES: ReadonlySet<SafeErrorCategory> =
+	Object.freeze(
+		new Set<SafeErrorCategory>([
+			"AggregateError",
+			"DOMException",
+			"Error",
+			"EvalError",
+			"HevyHttpError",
+			"RangeError",
+			"ReferenceError",
+			"SyntaxError",
+			"TypeError",
+			"URIError",
+			"UnknownError",
+		]),
+	);
+
 type RetryAwareError = {
 	hevyRetryCount?: number;
 	hevyRetryExhausted?: boolean;
@@ -109,31 +127,29 @@ function getAbortTimeoutErrorMetadata(
 	}
 }
 
-const SAFE_ERROR_CODES = new Set([
-	"EAI_AGAIN",
-	"ECONNABORTED",
-	"ECONNREFUSED",
-	"ECONNRESET",
-	"ENETUNREACH",
-	"ENOTFOUND",
-	"ERR_NETWORK",
-	"ERR_SOCKET_TIMEOUT",
-	"ETIMEDOUT",
-	"HEVY_INVALID_ENDPOINT",
-	HEVY_REQUEST_ABORTED_ERROR_CODE,
-	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
-	HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
-]);
+/** Bounded error codes diagnostics may carry; adapters validate against this. */
+export const SAFE_ERROR_CODES: ReadonlySet<string> = Object.freeze(
+	new Set([
+		"EAI_AGAIN",
+		"ECONNABORTED",
+		"ECONNREFUSED",
+		"ECONNRESET",
+		"ENETUNREACH",
+		"ENOTFOUND",
+		"ERR_NETWORK",
+		"ERR_SOCKET_TIMEOUT",
+		"ETIMEDOUT",
+		"HEVY_INVALID_ENDPOINT",
+		HEVY_REQUEST_ABORTED_ERROR_CODE,
+		HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		HEVY_DEADLINE_EXCEEDED_ERROR_CODE,
+	]),
+);
 
-const SAFE_HTTP_METHODS = new Set([
-	"DELETE",
-	"GET",
-	"HEAD",
-	"OPTIONS",
-	"PATCH",
-	"POST",
-	"PUT",
-]);
+/** Bounded HTTP methods diagnostics may carry. */
+export const SAFE_HTTP_METHODS: ReadonlySet<string> = Object.freeze(
+	new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]),
+);
 
 const SAFE_SOURCE_SUFFIXES: ReadonlyArray<readonly [string, SafeSourceId]> = [
 	["/packages/core/src/utils/error-handler.ts", "error-handler"],
@@ -144,6 +160,11 @@ const SAFE_SOURCE_SUFFIXES: ReadonlyArray<readonly [string, SafeSourceId]> = [
 ];
 
 const PROJECT_PATH_MARKER = "/hevy-mcp/";
+
+/** Stack-frame sources diagnostics may name; adapters validate against this. */
+export const SAFE_STACK_SOURCES: ReadonlySet<SafeSourceId> = Object.freeze(
+	new Set(SAFE_SOURCE_SUFFIXES.map(([, id]) => id)),
+);
 const MAX_STACK_POSITION = 1_000_000;
 
 function normalizeHeaderValue(value: RuntimeValue): string | undefined {

--- a/packages/core/src/utils/formatters.ts
+++ b/packages/core/src/utils/formatters.ts
@@ -22,7 +22,7 @@ import type {
 	FormattedWorkoutSet,
 	FormattedWorkoutSummary,
 } from "./output-schemas.js";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+import { createSafeErrorDiagnostic } from "./error-policy.js";
 
 type ExerciseWithSupersetVariants = {
 	supersets_id?: number | null;

--- a/packages/core/src/utils/mcp-client-logger.ts
+++ b/packages/core/src/utils/mcp-client-logger.ts
@@ -1,5 +1,5 @@
 import type { LoggingMessageNotification } from "@modelcontextprotocol/server";
-import { createSafeErrorDiagnostic } from "./safe-error-diagnostic.js";
+import { createSafeErrorDiagnostic } from "./error-policy.js";
 import type { RuntimeValue } from "./type-predicates.js";
 
 export type McpClientLogMessage = LoggingMessageNotification["params"];

--- a/packages/core/src/utils/safe-error-diagnostic.ts
+++ b/packages/core/src/utils/safe-error-diagnostic.ts
@@ -1,6 +1,0 @@
-export {
-	createSafeErrorDiagnostic,
-	type SafeErrorCategory,
-	type SafeErrorDiagnostic,
-	type SafeStackFrame,
-} from "./error-policy.js";

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -2,9 +2,14 @@ import type { Span } from "@cloudflare/workers-types";
 import { z } from "zod";
 import * as cloudflareWorkers from "cloudflare:workers";
 import { sanitizeCloudflareGeographyValue } from "./worker-telemetry.js";
+import { HEVY_ENDPOINT_TEMPLATES } from "@hevy-mcp/hevy-client";
 import {
 	createExecutionProjection,
 	createSafeErrorDiagnostic,
+	SAFE_ERROR_CATEGORIES,
+	SAFE_ERROR_CODES,
+	SAFE_HTTP_METHODS,
+	SAFE_STACK_SOURCES,
 	type SafeToolCompletion,
 	type SafeToolInvocation,
 	type StructuredExecutionProjection,
@@ -53,59 +58,7 @@ const SAFE_ERROR_TYPES = new Set([
 	"NETWORK_ERROR",
 	"UNKNOWN_ERROR",
 ]);
-const SAFE_ERROR_CATEGORIES = new Set([
-	"AggregateError",
-	"DOMException",
-	"Error",
-	"EvalError",
-	"HevyHttpError",
-	"RangeError",
-	"ReferenceError",
-	"SyntaxError",
-	"TypeError",
-	"URIError",
-	"UnknownError",
-]);
-const SAFE_ERROR_CODES = new Set([
-	"EAI_AGAIN",
-	"ECONNABORTED",
-	"ECONNREFUSED",
-	"ECONNRESET",
-	"ENETUNREACH",
-	"ENOTFOUND",
-	"ERR_NETWORK",
-	"ERR_SOCKET_TIMEOUT",
-	"ETIMEDOUT",
-	"HEVY_INVALID_ENDPOINT",
-	"HEVY_REQUEST_ABORTED",
-	"HEVY_RETRY_EXHAUSTED",
-	"HEVY_DEADLINE_EXCEEDED",
-]);
-const SAFE_HTTP_METHODS = new Set([
-	"DELETE",
-	"GET",
-	"HEAD",
-	"OPTIONS",
-	"PATCH",
-	"POST",
-	"PUT",
-]);
-const SAFE_ENDPOINTS = new Set([
-	"/v1/body_measurements",
-	"/v1/body_measurements/:date",
-	"/v1/exercise_history/:exerciseTemplateId",
-	"/v1/exercise_templates",
-	"/v1/exercise_templates/:exerciseTemplateId",
-	"/v1/routine_folders",
-	"/v1/routine_folders/:folderId",
-	"/v1/routines",
-	"/v1/routines/:routineId",
-	"/v1/user/info",
-	"/v1/workouts",
-	"/v1/workouts/:workoutId",
-	"/v1/workouts/count",
-	"/v1/workouts/events",
-]);
+const SAFE_ENDPOINTS = new Set<string>(HEVY_ENDPOINT_TEMPLATES);
 const SAFE_EXECUTION_OUTCOMES = new Set([
 	"success",
 	"expected",
@@ -128,13 +81,6 @@ const SAFE_OPERATION_SAFETY = new Set([
 	"non-idempotent-write",
 ]);
 const SAFE_COMMIT_STATES = new Set(["not_sent", "confirmed", "unknown"]);
-const SAFE_STACK_SOURCES = new Set([
-	"error-handler",
-	"hevy-client",
-	"index",
-	"server",
-	"worker",
-]);
 
 /** Structured events emitted by the Worker adapter's private observation sink. */
 export interface WorkerObservationEvent {


### PR DESCRIPTION
Architecture review candidate 1. Stacks on #1052.

## Primary changes

**Problem:** the Worker adapter received core's already-sanitized `SafeErrorDiagnostic` but re-validated every field against ~90 LOC of private allowlist copies (`worker-observer.ts`), so the vocabulary could drift. `safe-error-diagnostic.ts` was a pure re-export shim (fails the deletion test). `error-policy.ts` had no co-located test.

**What:**
- Core exports the diagnostic vocabulary as its interface: `SAFE_ERROR_CODES`, `SAFE_HTTP_METHODS`, `SAFE_ERROR_CATEGORIES`, `SAFE_STACK_SOURCES` (frozen).
- `worker-observer.ts` imports the shared vocabulary; endpoint allowlist now derives from the client's `HEVY_ENDPOINT_TEMPLATES` instead of a hand-listed copy.
- Shim folded into `error-policy.ts`; its tests merged into a new co-located `error-policy.test.ts` (8 tests) that pins the freeze + coverage guarantees.

## Reviewer walkthrough

- Core exports the diagnostic vocabulary as its interface: `SAFE_ERROR_CODES`, `SAFE_HTTP_METHODS`, `SAFE_ERROR_CATEGORIES`, `SAFE_STACK_SOURCES` (frozen).
- `worker-observer.ts` imports the shared vocabulary; endpoint allowlist now derives from the client's `HEVY_ENDPOINT_TEMPLATES` instead of a hand-listed copy.
- Shim folded into `error-policy.ts`; its tests merged into a new co-located `error-policy.test.ts` (8 tests) that pins the freeze + coverage guarantees.

## Correctness and invariants

Known non-goal: `resolveErrorPolicy` still runs twice per failed call (telemetry + response). It is pure, so outputs cannot diverge; unifying means threading one result through tool-runtime → error-handler interfaces for no behavioral gain.

## Testing and QA

- The new co-located `error-policy.test.ts` covers frozen vocabularies and classification, code, and method guarantees.
- Changeset: core cascade, patch.

## Summary by Sourcery

Centralize the safe-error diagnostic vocabulary in core and have the Worker adapter consume the shared definitions.

Enhancements:
- Expose the safe-error diagnostic vocabulary from core as a shared, immutable interface for adapters.
- Make Worker endpoint validation derive from the client endpoint templates and use core’s shared diagnostic allowlists.
- Consolidate safe-error diagnostic creation into the error-policy module and remove the redundant re-export shim.

Tests:
- Add co-located coverage for vocabulary immutability and diagnostic category, code, and HTTP method guarantees.
