### PR TITLE
refactor(core): own telemetry contract constants for node and worker adapters

### DIFF
--- a/.changeset/own-telemetry-contracts.md
+++ b/.changeset/own-telemetry-contracts.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Own the telemetry contract constants (user hash context, hash shape, argument-key allowlist) in core so the Node and Worker adapters cannot drift apart.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,12 @@ export {
 	SAFE_STACK_SOURCES,
 } from "./utils/error-policy.js";
 export {
+	SAFE_USER_HASH_PATTERN,
+	TELEMETRY_ARGUMENT_KEYS,
+	USER_HASH_CONTEXT,
+	USER_HASH_LENGTH,
+} from "./utils/telemetry-contract.js";
+export {
 	createMcpToolFailureEvent,
 	createExecutionErrorProjection,
 	type McpToolFailureEvent,

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -23,31 +23,19 @@ import {
 	type ToolExecutionContext,
 } from "../execution.js";
 import { DEFAULT_API_TIMEOUT_MS } from "@hevy-mcp/hevy-client";
+import { TELEMETRY_ARGUMENT_KEYS } from "../utils/telemetry-contract.js";
 import { isBoolean, isFiniteNumber } from "../utils/type-predicates.js";
 
 interface ArgumentKeySet {
 	readonly [key: string]: true;
 }
 
-const STRUCTURAL_ARGUMENT_KEYS: Readonly<ArgumentKeySet> = {
-	page: true,
-	page_size: true,
-	since: true,
-	workout_id: true,
-	routine_id: true,
-	folder_id: true,
-	exercise_template_id: true,
-	date: true,
-	start_date: true,
-	end_date: true,
-	updated_since: true,
-	include_custom: true,
-	limit: true,
-	offset: true,
-	refresh: true,
-	query: true,
-	primary_muscle_group: true,
-};
+const toKeySet = (keys: readonly string[]): Readonly<ArgumentKeySet> =>
+	Object.fromEntries(keys.map((key) => [key, true as const]));
+
+const STRUCTURAL_ARGUMENT_KEYS: Readonly<ArgumentKeySet> = toKeySet(
+	TELEMETRY_ARGUMENT_KEYS,
+);
 
 const PRESENCE_ARGUMENT_KEYS: Readonly<ArgumentKeySet> = {
 	since: true,

--- a/packages/core/src/utils/telemetry-contract.test.ts
+++ b/packages/core/src/utils/telemetry-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	SAFE_USER_HASH_PATTERN,
+	TELEMETRY_ARGUMENT_KEYS,
+	USER_HASH_CONTEXT,
+	USER_HASH_LENGTH,
+} from "./telemetry-contract.js";
+
+describe("telemetry contract", () => {
+	it("keeps the hash pattern and length in agreement", () => {
+		const sample = "a".repeat(USER_HASH_LENGTH);
+		expect(SAFE_USER_HASH_PATTERN.test(sample)).toBe(true);
+		expect(SAFE_USER_HASH_PATTERN.test("a".repeat(USER_HASH_LENGTH + 1))).toBe(
+			false,
+		);
+		expect(SAFE_USER_HASH_PATTERN.test("g".repeat(USER_HASH_LENGTH))).toBe(
+			false,
+		);
+	});
+
+	it("lists unique snake_case argument keys", () => {
+		expect(new Set(TELEMETRY_ARGUMENT_KEYS).size).toBe(
+			TELEMETRY_ARGUMENT_KEYS.length,
+		);
+		for (const key of TELEMETRY_ARGUMENT_KEYS) {
+			expect(key).toMatch(/^[a-z_]+$/);
+		}
+	});
+
+	it("pins the user hash context string", () => {
+		expect(USER_HASH_CONTEXT).toBe("hevy-mcp:sentry-user-id:v1");
+	});
+});

--- a/packages/core/src/utils/telemetry-contract.ts
+++ b/packages/core/src/utils/telemetry-contract.ts
@@ -1,0 +1,41 @@
+/**
+ * Telemetry contract constants shared by the Node and Worker adapters.
+ * The adapters own their platform crypto implementations; this module owns
+ * the contract both must satisfy so it cannot drift between them.
+ */
+
+/** HMAC message context for the pseudonymous Sentry user hash. */
+export const USER_HASH_CONTEXT = "hevy-mcp:sentry-user-id:v1";
+
+/** Length of the truncated hex digest used as the user hash. */
+export const USER_HASH_LENGTH = 10;
+
+/** Shape every emitted or consumed user hash must satisfy. */
+export const SAFE_USER_HASH_PATTERN = new RegExp(
+	`^[0-9a-f]{${USER_HASH_LENGTH}}$`,
+	"u",
+);
+
+/**
+ * Argument keys telemetry may name. Both adapters project tool arguments
+ * against this list; keys missing here are silently excluded everywhere.
+ */
+export const TELEMETRY_ARGUMENT_KEYS: readonly string[] = Object.freeze([
+	"page",
+	"page_size",
+	"since",
+	"workout_id",
+	"routine_id",
+	"folder_id",
+	"exercise_template_id",
+	"date",
+	"start_date",
+	"end_date",
+	"updated_since",
+	"include_custom",
+	"limit",
+	"offset",
+	"refresh",
+	"query",
+	"primary_muscle_group",
+]);

--- a/packages/node/src/runtime.test.ts
+++ b/packages/node/src/runtime.test.ts
@@ -116,6 +116,8 @@ vi.mock("@hevy-mcp/core", () => ({
 		UNKNOWN_ERROR: "UNKNOWN_ERROR",
 		VALIDATION_ERROR: "VALIDATION_ERROR",
 	},
+	USER_HASH_CONTEXT: "hevy-mcp:sentry-user-id:v1",
+	USER_HASH_LENGTH: 10,
 }));
 
 vi.mock("@modelcontextprotocol/server/stdio", () => ({

--- a/packages/node/src/utils/tool-observer.ts
+++ b/packages/node/src/utils/tool-observer.ts
@@ -1,4 +1,5 @@
 import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { SAFE_USER_HASH_PATTERN } from "@hevy-mcp/core";
 import type {
 	SafeToolCompletion,
 	SafeToolInvocation,
@@ -29,7 +30,6 @@ type ToolMetricAttributes = McpClientMetricAttributes & {
 	readonly tool_name: string;
 };
 const DISCOVERY_TOOL_NAMES = new Set(["search-routines"]);
-const SAFE_USER_HASH_PATTERN = /^[0-9a-f]{10}$/u;
 const stringSchema = z.string();
 
 function isString<T>(value: T): value is T & string {

--- a/packages/node/src/utils/user-hash.ts
+++ b/packages/node/src/utils/user-hash.ts
@@ -1,7 +1,6 @@
 import { createHmac } from "node:crypto";
 
-const USER_HASH_CONTEXT = "hevy-mcp:sentry-user-id:v1";
-const USER_HASH_LENGTH = 10;
+import { USER_HASH_CONTEXT, USER_HASH_LENGTH } from "@hevy-mcp/core";
 
 /**
  * Derive the short, deterministic HMAC pseudonym shared with the Worker

--- a/packages/worker/src/worker-observer.ts
+++ b/packages/worker/src/worker-observer.ts
@@ -10,6 +10,8 @@ import {
 	SAFE_ERROR_CODES,
 	SAFE_HTTP_METHODS,
 	SAFE_STACK_SOURCES,
+	SAFE_USER_HASH_PATTERN,
+	TELEMETRY_ARGUMENT_KEYS,
 	type SafeToolCompletion,
 	type SafeToolInvocation,
 	type StructuredExecutionProjection,
@@ -24,29 +26,10 @@ const MAX_STRING_LENGTH = 160;
 const MAX_ARGUMENT_KEYS = 32;
 const MAX_WORKFLOW_PAGES = 10_000;
 const MAX_WORKFLOW_ITEMS = 1_000_000;
-const SAFE_USER_HASH_PATTERN = /^[0-9a-f]{10}$/u;
 const SAFE_CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
 const SAFE_COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
 
-const SAFE_ARGUMENT_KEYS = new Set([
-	"date",
-	"end_date",
-	"exercise_template_id",
-	"folder_id",
-	"include_custom",
-	"limit",
-	"offset",
-	"page",
-	"page_size",
-	"primary_muscle_group",
-	"query",
-	"refresh",
-	"routine_id",
-	"since",
-	"start_date",
-	"updated_since",
-	"workout_id",
-]);
+const SAFE_ARGUMENT_KEYS = new Set<string>(TELEMETRY_ARGUMENT_KEYS);
 const SAFE_COUNT_BUCKETS = new Set(["0", "1", "2-10", "11-50", "51+"]);
 const SAFE_WORKFLOW_NAMES = new Set(["training-summary", "routine-discovery"]);
 const SAFE_CACHE_STATUSES = new Set(["hit", "miss", "not-used"]);

--- a/packages/worker/src/worker-telemetry.ts
+++ b/packages/worker/src/worker-telemetry.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-const USER_HASH_CONTEXT = "hevy-mcp:sentry-user-id:v1";
-const USER_HASH_LENGTH = 10;
+import { USER_HASH_CONTEXT, USER_HASH_LENGTH } from "@hevy-mcp/core";
+
 const CLOUDFLARE_COLO_PATTERN = /^[A-Z]{3}$/u;
 const COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/u;
 const GEO_VALUE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .,'’()/_-]{0,63}$/u;


### PR DESCRIPTION
Architecture review candidate 6. Stacks on #1053.

## Primary changes

The telemetry contract had no owner — `USER_HASH_CONTEXT`, hash length, the `/^[0-9a-f]{10}$/` shape, and the 17-key argument allowlist were each written twice (node + worker). Adding a tool argument in one set silently dropped it from the other adapter's telemetry.

- New core module `utils/telemetry-contract.ts` owns `USER_HASH_CONTEXT`, `USER_HASH_LENGTH`, `SAFE_USER_HASH_PATTERN`, `TELEMETRY_ARGUMENT_KEYS` — exported from `@hevy-mcp/core`.

## Reviewer walkthrough

- `tool-runtime.ts` derives its structural key set from the shared list; node's `user-hash.ts`/`tool-observer.ts` and worker's `worker-telemetry.ts`/`worker-observer.ts` import instead of copying.

## Correctness and invariants

- The two crypto implementations stay as the two adapters that make the seam real.

## Testing and QA

- Co-located contract test pins hash-shape/length agreement and key-list sanity.

Changeset: core cascade, patch.

## Summary by Sourcery

Centralize telemetry contract constants in core so all adapters consistently enforce the same user-hash and argument-key rules.

Bug Fixes:
- Prevent telemetry contract drift between the Node and Worker adapters by centralizing shared user-hash and argument allowlist definitions.

Enhancements:
- Add a core-owned telemetry contract covering user-hash context, length, format, and telemetry argument keys.
- Derive telemetry argument filtering from the shared core contract across runtime and adapter observers.
- Add contract tests validating user-hash invariants and argument-key quality.

Tests:
- Add coverage for telemetry hash shape and length agreement, pinned hash context, and unique snake_case argument keys.
