### PR TITLE
refactor(core): single home for workout is_private quirk rule and wording

### DIFF
--- a/.changeset/workout-quirk-single-home.md
+++ b/.changeset/workout-quirk-single-home.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Give the workout is_private quirk one home in hevy-quirks; the runtime rule, user-facing error, and tool-description clauses all derive from the same constants so they cannot drift.

--- a/packages/core/src/tools/hevy-quirks.ts
+++ b/packages/core/src/tools/hevy-quirks.ts
@@ -1,0 +1,25 @@
+/**
+ * Hevy API behaviors the generated client cannot express. One home per
+ * resource quirk: the runtime rule (enforced in mutation-semantics), the
+ * user-facing error, and the tool-description clauses derive from these
+ * constants so wording and enforcement cannot drift apart.
+ */
+
+/**
+ * PUT /v1/workouts/:workoutId requires is_private, while the GET endpoint
+ * never returns the current value — callers must state it explicitly.
+ */
+export const WORKOUT_PUT_REQUIRES_IS_PRIVATE = {
+	/** Error thrown when metadata-only updates omit is_private. */
+	error:
+		"is_private is required when updating workout metadata. " +
+		"The Hevy API does not return the current privacy setting on GET, " +
+		"so it must be explicitly provided on PUT. Set to true to make the workout private, " +
+		"or false to make it public.",
+	/** Description clause for update-workout. */
+	updateClause:
+		"is_private must be supplied explicitly because the Hevy API requires it on PUT",
+	/** Description clause for replace-workout-exercises. */
+	replaceExercisesClause:
+		"is_private must be supplied explicitly and is updated with the request",
+} as const;

--- a/packages/core/src/tools/mutation-semantics.ts
+++ b/packages/core/src/tools/mutation-semantics.ts
@@ -14,13 +14,11 @@ import type {
 	WorkoutExerciseInput,
 	WorkoutMetadataPatchInput,
 } from "./input-schemas.js";
+import { WORKOUT_PUT_REQUIRES_IS_PRIVATE } from "./hevy-quirks.js";
 import { utcSecondTimestamp } from "../utils/schemas.js";
 import { isFiniteNumber, isString } from "../utils/type-predicates.js";
 import type { RuntimeValue } from "../utils/type-predicates.js";
-import {
-	SafeUserError,
-	WORKOUT_METADATA_PRIVACY_REQUIRED_ERROR,
-} from "../utils/safe-user-error.js";
+import { SafeUserError } from "../utils/safe-user-error.js";
 
 type RoutineRepRange = { start?: number; end?: number } | null;
 
@@ -263,7 +261,7 @@ export function buildWorkoutUpdatePayload(
 	// Therefore, is_private must be explicitly provided for metadata updates.
 	const isMetadataOnlyUpdate = replacementExercises === undefined;
 	if (isMetadataOnlyUpdate && patch.is_private === undefined) {
-		throw new SafeUserError(WORKOUT_METADATA_PRIVACY_REQUIRED_ERROR);
+		throw new SafeUserError(WORKOUT_PUT_REQUIRES_IS_PRIVATE.error);
 	}
 
 	const metadata = workoutUpdateMetadataSchema.parse({

--- a/packages/core/src/tools/workouts.ts
+++ b/packages/core/src/tools/workouts.ts
@@ -25,6 +25,7 @@ import {
 	readOnlyAnnotations,
 	updateAnnotations,
 } from "../utils/tool-annotations.js";
+import { WORKOUT_PUT_REQUIRES_IS_PRIVATE } from "./hevy-quirks.js";
 
 import type { InferToolParams } from "../utils/tool-helpers.js";
 import { buildWorkoutUpdatePayload } from "./mutation-semantics.js";
@@ -162,7 +163,9 @@ export const workoutToolDefinitions = [
 		feature: "workouts" as const,
 		operation: "update" as const,
 		description:
-			"Mutates workout metadata by ID. is_private must be supplied explicitly because the Hevy API requires it on PUT; omitted fields and all exercises otherwise remain unchanged.",
+			"Mutates workout metadata by ID. " +
+			WORKOUT_PUT_REQUIRES_IS_PRIVATE.updateClause +
+			"; omitted fields and all exercises otherwise remain unchanged.",
 		inputSchema: updateWorkoutSchema,
 		annotations: updateAnnotations("Update Workout"),
 		kind: "write" as const,
@@ -183,7 +186,9 @@ export const workoutToolDefinitions = [
 		feature: "workouts" as const,
 		operation: "update" as const,
 		description:
-			"Mutates a workout by replacing all exercises and sets. is_private must be supplied explicitly and is updated with the request; other workout metadata remains unchanged.",
+			"Mutates a workout by replacing all exercises and sets. " +
+			WORKOUT_PUT_REQUIRES_IS_PRIVATE.replaceExercisesClause +
+			"; other workout metadata remains unchanged.",
 		inputSchema: replaceWorkoutExercisesSchema,
 		annotations: updateAnnotations("Replace Workout Exercises"),
 		kind: "write" as const,

--- a/packages/core/src/utils/safe-user-error.ts
+++ b/packages/core/src/utils/safe-user-error.ts
@@ -1,9 +1,3 @@
-export const WORKOUT_METADATA_PRIVACY_REQUIRED_ERROR =
-	"is_private is required when updating workout metadata. " +
-	"The Hevy API does not return the current privacy setting on GET, " +
-	"so it must be explicitly provided on PUT. Set to true to make the workout private, " +
-	"or false to make it public.";
-
 export class SafeUserError extends Error {
 	public readonly safeForUser = true;
 


### PR DESCRIPTION
Architecture review candidate 2. Stacks on #1054.

## Primary changes

**Problem:** the Hevy quirk "PUT requires `is_private`, GET never returns it" was encoded four times — schema requirement, payload-builder throw, two tool-description strings, message constant. The original fix (#1049) touched 5 files to change one fact.

**What:**
- New `tools/hevy-quirks.ts` owns the rule's error text and both description clauses as one constant object.
- `buildWorkoutUpdatePayload` throws with the shared error; `workouts.ts` descriptions interpolate the shared clauses (exact wording preserved — pinned by existing annotations/workout tests).
- The constant moved out of `safe-user-error.ts` (class-only now).

## Reviewer walkthrough

- `tools/hevy-quirks.ts` is the single home for the workout `is_private` quirk's error text and tool-description clauses.
- `mutation-semantics.ts` uses the shared error when metadata-only updates omit `is_private`.
- `workouts.ts` derives both affected tool descriptions from the shared clauses.
- `safe-user-error.ts` now contains only the `SafeUserError` class.

## Correctness and invariants

- The existing `is_private` validation requirement remains enforced; this change centralizes its representation without changing the rule.
- Existing error and description wording is preserved while the duplicated constants are removed.

## Testing and QA

- Existing annotations/workout tests pin the exact wording.
- Changeset: core cascade, patch.

## Summary by Sourcery

Centralize the workout `is_private` PUT requirement so its validation, error messaging, and tool descriptions share a single source of truth.

Enhancements:
- Centralize the workout `is_private` API quirk’s runtime error and user-facing description clauses in a shared core definition, keeping enforcement and wording aligned.
- Derive workout mutation tool descriptions from the shared quirk definition while preserving existing behavior and wording.
- Simplify safe-user-error utilities to contain only the generic `SafeUserError` class.