### PR TITLE
refactor(operations): narrow interface to consumed exports

### DIFF
--- a/.changeset/narrow-operations-interface.md
+++ b/.changeset/narrow-operations-interface.md
@@ -1,5 +1,4 @@
 ---
-"@hevy-mcp/hevy-client": patch
 "@hevy-mcp/operations": patch
 "@hevy-mcp/core": patch
 "hevy-mcp": patch

--- a/.changeset/narrow-operations-interface.md
+++ b/.changeset/narrow-operations-interface.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Narrow the operations interface to the names consumers actually use; remove four dead exported predicates and stop re-exporting internal operation plumbing.

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -12,42 +12,8 @@ import {
 	type WorkoutsListOperation,
 } from "./workouts.js";
 
-export {
-	createRoutinesGetOperation,
-	createRoutinesListOperation,
-	isRoutinesGetNotFound,
-	isRoutinesListEndOfList,
-	routinesGetDescriptor,
-	routinesListDescriptor,
-	type RoutinesGetAdapter,
-	type RoutinesGetDescriptor,
-	type RoutinesGetInput,
-	type RoutinesGetOperation,
-	type RoutinesGetOutput,
-	type RoutinesListAdapter,
-	type RoutinesListDescriptor,
-	type RoutinesListInput,
-	type RoutinesListOperation,
-	type RoutinesListOutput,
-} from "./routines.js";
-export {
-	createWorkoutsGetOperation,
-	createWorkoutsListOperation,
-	isWorkoutsGetNotFound,
-	isWorkoutsListEndOfList,
-	workoutsGetDescriptor,
-	workoutsListDescriptor,
-	type WorkoutsGetAdapter,
-	type WorkoutsGetDescriptor,
-	type WorkoutsGetInput,
-	type WorkoutsGetOperation,
-	type WorkoutsGetOutput,
-	type WorkoutsListAdapter,
-	type WorkoutsListDescriptor,
-	type WorkoutsListInput,
-	type WorkoutsListOperation,
-	type WorkoutsListOutput,
-} from "./workouts.js";
+export { routinesGetDescriptor, routinesListDescriptor } from "./routines.js";
+export { workoutsGetDescriptor, workoutsListDescriptor } from "./workouts.js";
 
 export interface HevyOperations {
 	readonly routines: {

--- a/packages/operations/src/routines.ts
+++ b/packages/operations/src/routines.ts
@@ -109,12 +109,6 @@ function isExpectedRoutineNotFound(error: ErrorInput): boolean {
 	);
 }
 
-export function isRoutinesGetNotFound(
-	error: ErrorInput,
-): error is HevyHttpError {
-	return isExpectedRoutineNotFound(error);
-}
-
 export function createRoutinesGetOperation(
 	adapter: RoutinesGetAdapter,
 ): RoutinesGetOperation {
@@ -129,7 +123,9 @@ export function createRoutinesGetOperation(
 				return { routine: response.routine ?? null };
 			} catch (error) {
 				if (
-					isRoutinesGetNotFound(error instanceof Error ? error : String(error))
+					isExpectedRoutineNotFound(
+						error instanceof Error ? error : String(error),
+					)
 				) {
 					return {
 						routine: null,

--- a/packages/operations/src/routines.ts
+++ b/packages/operations/src/routines.ts
@@ -1,7 +1,6 @@
 import type {
 	HevyClient,
 	HevyExecutionOptions,
-	HevyHttpError,
 	HevyOperationSafety,
 } from "@hevy-mcp/hevy-client";
 import type { GetV1Routines200, Routine } from "@hevy-mcp/hevy-client/types";
@@ -169,11 +168,4 @@ export function createRoutinesListOperation(
 			}
 		},
 	};
-}
-
-export function isRoutinesListEndOfList(
-	error: ErrorInput,
-	page: number,
-): error is HevyHttpError {
-	return isExpectedEndOfList(error, page);
 }

--- a/packages/operations/src/workouts.ts
+++ b/packages/operations/src/workouts.ts
@@ -1,7 +1,6 @@
 import type {
 	HevyClient,
 	HevyExecutionOptions,
-	HevyHttpError,
 	HevyOperationSafety,
 } from "@hevy-mcp/hevy-client";
 import type { GetV1Workouts200, Workout } from "@hevy-mcp/hevy-client/types";
@@ -83,12 +82,6 @@ function isExpectedWorkoutNotFound(error: ErrorInput): boolean {
 	);
 }
 
-export function isWorkoutsGetNotFound(
-	error: ErrorInput,
-): error is HevyHttpError {
-	return isExpectedWorkoutNotFound(error);
-}
-
 function isExpectedEndOfList(error: ErrorInput, page: number): boolean {
 	return (
 		page > 1 &&
@@ -129,7 +122,9 @@ export function createWorkoutsGetOperation(
 				return { workout: response ?? null };
 			} catch (error) {
 				if (
-					isWorkoutsGetNotFound(error instanceof Error ? error : String(error))
+					isExpectedWorkoutNotFound(
+						error instanceof Error ? error : String(error),
+					)
 				) {
 					return {
 						workout: null,
@@ -173,11 +168,4 @@ export function createWorkoutsListOperation(
 			}
 		},
 	};
-}
-
-export function isWorkoutsListEndOfList(
-	error: ErrorInput,
-	page: number,
-): error is HevyHttpError {
-	return isExpectedEndOfList(error, page);
 }


### PR DESCRIPTION
Architecture review candidate 3. Stacks on #1055.

## Primary changes

**Problem:** 28 of operations' 34 exported names had zero consumers outside the package (verified by grep across core/cli/node). The interface was ceremony around four read operations.

**What:**
- `operations` index now exports exactly what is consumed: `createOperations`, `HevyOperations`, and the four descriptors used by tests.
- Four dead predicate exports deleted (`isWorkoutsGetNotFound`, `isWorkoutsListEndOfList`, `isRoutinesGetNotFound`, `isRoutinesListEndOfList`); internal helpers stay.
- Deliberately kept: the per-operation canonical-endpoint checks — tests pin them as defense-in-depth so a workout get cannot swallow another resource's 404. Also kept: core's `hevy-error-policy.ts` wrappers, whose `page > 1` and status-extraction decisions serve six real call sites.

## Reviewer walkthrough

- `packages/operations/src/index.ts` now re-exports only the consumed operation factory, interface, and descriptor surface.
- `packages/operations/src/routines.ts` and `packages/operations/src/workouts.ts` keep the canonical-endpoint checks local to their operations while removing the unused public predicate wrappers.
- The changeset records patch bumps for operations, core, Node, Worker, and CLI packages; the current diff has no client changeset entry.

## Correctness and invariants

- Not-found handling remains guarded by the resource-specific canonical endpoint checks, so a workout operation cannot consume another resource's 404.
- The list-operation end-of-list and get-operation not-found behavior remains internal; only the unused exports are removed.
- Core's `hevy-error-policy.ts` wrappers are unchanged because their pagination and status-extraction behavior has six downstream call sites.

## Testing and QA

- Existing operation tests continue to pin the canonical-endpoint checks as defense-in-depth.
- The diff includes patch changeset entries for `@hevy-mcp/operations`, `@hevy-mcp/core`, `hevy-mcp`, `@hevy-mcp/worker`, and `@chrisdoc/hevy-cli`; it has no `@hevy-mcp/hevy-client` entry.

Changeset: patch entries for operations → core → hevy-mcp, worker, and CLI; the current diff does not include a client entry.

## Summary by Sourcery

Reduce the operations package’s public API to the exports required by its consumers while preserving internal error-handling behavior.

Enhancements:
- Narrow the operations package interface to the factory, interface, and operation descriptors consumed by downstream packages and tests.
- Remove four unused public not-found and end-of-list predicate exports while retaining resource-specific handling internally.

Chores:
- Add patch changeset entries for the operations, core, server, worker, and CLI packages.