### PR TITLE
test(core): pin MCP input enums to generated client schemas

### DIFF
--- a/.changeset/pin-input-enums-to-generated.md
+++ b/.changeset/pin-input-enums-to-generated.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Export the generated workout and routine set schemas from the curated schemas entry point and pin the MCP input enum vocabularies (RPE, set type) to them with a contract test, so upstream enum changes surface at test time instead of drifting.

--- a/packages/core/src/tools/input-schemas.generated-contract.test.ts
+++ b/packages/core/src/tools/input-schemas.generated-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	postRoutinesRequestSetSchema,
+	postWorkoutsRequestSetSchema,
+} from "@hevy-mcp/hevy-client/schemas";
+import { routineSetFields, workoutSetFields } from "./input-schemas.js";
+
+/**
+ * The MCP input schemas deliberately diverge from the generated client
+ * schemas (coercion, defaults, stricter IDs) but their enum vocabularies are
+ * pure copies. These tests pin the copies to the generated source so an
+ * upstream enum change surfaces here instead of silently drifting.
+ */
+
+const ACCEPTED_RPE = [6, 7, 7.5, 8, 8.5, 9, 9.5, 10] as const;
+const REJECTED_RPE = [0, 5.5, 6.4, 11, "7", null];
+
+describe("input schema enums match the generated client", () => {
+	it("workout set RPE accepts exactly what the generated client accepts", () => {
+		for (const value of ACCEPTED_RPE) {
+			expect(workoutSetFields.rpe.safeParse(value).success).toBe(true);
+			expect(
+				postWorkoutsRequestSetSchema.shape.rpe.safeParse(value).success,
+			).toBe(true);
+		}
+		for (const value of REJECTED_RPE) {
+			expect(workoutSetFields.rpe.safeParse(value).success).toBe(
+				postWorkoutsRequestSetSchema.shape.rpe.safeParse(value).success,
+			);
+		}
+	});
+
+	it("neither side accepts RPE for routine sets; keep pinned", () => {
+		// Neither the generated client nor the MCP input contract accepts RPE
+		// on routine sets today. If upstream adds it, this forces a conscious
+		// decision to expose it through the tool surface rather than drift.
+		expect("rpe" in postRoutinesRequestSetSchema.shape).toBe(false);
+		expect("rpe" in routineSetFields).toBe(false);
+	});
+
+	it("set type vocabulary matches the generated client", () => {
+		for (const value of ["warmup", "normal", "failure", "dropset"] as const) {
+			expect(workoutSetFields.type.safeParse(value).success).toBe(true);
+			expect(
+				postWorkoutsRequestSetSchema.shape.type.safeParse(value).success,
+			).toBe(true);
+		}
+		for (const value of ["intensity", "", "NORMAL"]) {
+			expect(workoutSetFields.type.safeParse(value).success).toBe(false);
+			expect(
+				postWorkoutsRequestSetSchema.shape.type.safeParse(value).success,
+			).toBe(false);
+		}
+	});
+});

--- a/packages/hevy-client/src/schemas.ts
+++ b/packages/hevy-client/src/schemas.ts
@@ -12,3 +12,5 @@ export { getV1WorkoutsEventsQueryParamsSchema } from "./generated/client/schemas
 export { getV1WorkoutsQueryParamsSchema } from "./generated/client/schemas/getV1WorkoutsSchema.js";
 export { getV1WorkoutsWorkoutidPathParamsSchema } from "./generated/client/schemas/getV1WorkoutsWorkoutidSchema.js";
 export { bodyMeasurementSchema } from "./generated/client/schemas/bodyMeasurementSchema.js";
+export { postRoutinesRequestSetSchema } from "./generated/client/schemas/postRoutinesRequestSetSchema.js";
+export { postWorkoutsRequestSetSchema } from "./generated/client/schemas/postWorkoutsRequestSetSchema.js";


### PR DESCRIPTION
Architecture review candidate 4. Stacks on #1056.

**Problem:** the MCP input schemas hand-copy enum vocabularies (RPE union, set types) from the generated client schemas. Field keys are already drift-guarded by `satisfies` constraints against the generated types, but value-level drift (upstream adds/removes an RPE step) would pass silently.

**What:**
- Curated `@hevy-mcp/hevy-client/schemas` now exports `postWorkoutsRequestSetSchema` and `postRoutinesRequestSetSchema`.
- New contract test cross-checks `workoutSetFields` RPE and set-type acceptance against the generated schemas — upstream enum changes now fail this test instead of drifting.

**Deliberately not done:** deriving the input schemas via `.extend()`. Reading both sides showed the divergence is nearly total by design — coercion for MCP ergonomics, defaults, nonEmptyId, strict rep_range, routine sets omitting RPE entirely. Extending would override 6 of 7 fields and add indirection without reducing duplication; the contract test captures the real risk.

Changeset: client cascade, patch.

## Primary changes

- Re-export the generated workout and routine set schemas through the curated `@hevy-mcp/hevy-client/schemas` entry point.
- Add a contract test that keeps MCP workout-set RPE and set-type vocabularies aligned with the generated workout-set schema.
- Record the required patch changeset for the affected packages.

## Reviewer walkthrough

1. Start with `packages/hevy-client/src/schemas.ts` to see the two curated schema exports.
2. Review `packages/core/src/tools/input-schemas.generated-contract.test.ts` for accepted and rejected RPE and set-type cases.
3. The MCP schemas intentionally retain their ergonomic coercion, defaults, ID validation, and routine-specific shape rather than extending the generated schemas.

## Correctness and invariants

- The MCP input schemas may diverge structurally from the generated client schemas, but their RPE and set-type vocabularies must accept and reject the same values.
- An upstream change to either generated enum vocabulary should fail the contract test instead of silently drifting.

## Testing and QA

- Added Vitest contract coverage for accepted and rejected RPE values and set types against the generated workout-set schema.

## Summary by Sourcery

Pin MCP input enum vocabularies to the generated client schemas so upstream changes fail contract tests instead of drifting silently.

Enhancements:
- Expose generated workout and routine set schemas through the curated client schemas entry point.
- Add contract coverage ensuring MCP workout-set RPE and set-type vocabularies remain aligned with the generated client schemas and routine-set RPE support remains intentionally absent.

Tests:
- Add Vitest contract tests for accepted and rejected RPE and set-type values against the generated schemas.

Chores:
- Record patch changesets for the affected packages.
