### PR TITLE
feat(worker): cache, retry, and log Hevy API key validation

### DIFF
--- a/.changeset/curly-plums-jog.md
+++ b/.changeset/curly-plums-jog.md
@@ -1,0 +1,5 @@
+---
+"@hevy-mcp/worker": patch
+---
+
+Retry transient Hevy API key validation failures (e.g. HTTP 429), log the upstream status/code when validation still fails, and cache successful validations for 15 minutes so a brief Hevy outage no longer turns into a 502 for a key that was just confirmed valid.

--- a/.changeset/curly-plums-jog.md
+++ b/.changeset/curly-plums-jog.md
@@ -2,4 +2,4 @@
 "@hevy-mcp/worker": patch
 ---
 
-Retry transient Hevy API key validation failures (e.g. HTTP 429), log the upstream status/code when validation still fails, and cache successful validations for 15 minutes so a brief Hevy outage no longer turns into a 502 for a key that was just confirmed valid.
+Retry transient Hevy API key validation failures (e.g. HTTP 503 or 408; HTTP 429 is intentionally not retried, to avoid spending calls against the rate limit that caused the outage), log the upstream status/code when validation still fails, and cache successful validations for 15 minutes so a brief Hevy outage no longer turns into a 502 for a key that was just confirmed valid.

--- a/.changeset/oxfmt-063-core-mapped-types.md
+++ b/.changeset/oxfmt-063-core-mapped-types.md
@@ -1,0 +1,7 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Apply oxfmt 0.63.0 formatting to core mapped-type declarations in `execution.ts`, `tools/input-schemas.ts`, and `tools/tool-runtime.ts`. Formatting only — no functional change. `hevy-mcp` and `@chrisdoc/hevy-cli` get a patch bump solely because the release cascade re-releases core's consumers.

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -27,7 +27,9 @@ export interface StructuredExecutionProjection {
 /** Backward-compatible name for the structured error projection. */
 export type StructuredExecutionError = StructuredExecutionProjection;
 type MutableExecutionProjection = {
-	-readonly [K in keyof StructuredExecutionProjection]?: StructuredExecutionProjection[K];
+	-readonly [
+		K in keyof StructuredExecutionProjection
+	]?: StructuredExecutionProjection[K];
 } & Pick<
 	StructuredExecutionProjection,
 	"outcome" | "phase" | "operation_safety" | "commit_state" | "safe_to_retry"

--- a/packages/core/src/tools/input-schemas.ts
+++ b/packages/core/src/tools/input-schemas.ts
@@ -108,9 +108,11 @@ export const workoutExerciseFields = {
 	notes: z.string().optional().nullable(),
 	sets: z.array(workoutSetSchema),
 } as const satisfies {
-	[K in keyof NonNullable<
-		NonNullable<PostWorkoutsRequestBody["workout"]>["exercises"]
-	>[number]]: z.ZodTypeAny;
+	[
+		K in keyof NonNullable<
+			NonNullable<PostWorkoutsRequestBody["workout"]>["exercises"]
+		>[number]
+	]: z.ZodTypeAny;
 };
 
 const workoutExerciseSchema = z.strictObject(workoutExerciseFields);
@@ -192,9 +194,11 @@ export const routineExerciseFields = {
 	notes: z.string().optional(),
 	sets: z.array(routineSetSchema),
 } as const satisfies {
-	[K in keyof NonNullable<
-		NonNullable<PostRoutinesRequestBody["routine"]>["exercises"]
-	>[number]]: z.ZodTypeAny;
+	[
+		K in keyof NonNullable<
+			NonNullable<PostRoutinesRequestBody["routine"]>["exercises"]
+		>[number]
+	]: z.ZodTypeAny;
 };
 
 const routineExerciseSchema = z.strictObject(routineExerciseFields);

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -267,7 +267,9 @@ export function createToolRuntime({
 				observer,
 				execution: (() => {
 					const nested: {
-						-readonly [K in keyof ToolExecutionContext]?: ToolExecutionContext[K];
+						-readonly [
+							K in keyof ToolExecutionContext
+						]?: ToolExecutionContext[K];
 					} = {};
 					if (nextExecution) Object.assign(nested, nextExecution);
 					nested.signal = mergeAbortSignals(

--- a/packages/worker/src/validation-cache.test.ts
+++ b/packages/worker/src/validation-cache.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HevyHttpError, type HevyClient } from "@hevy-mcp/hevy-client";
+import {
+	cacheValidation,
+	hasCachedValidation,
+	MEMORY_CACHE_MAX_ENTRIES,
+	resetMemoryValidationCacheForTests,
+	validateHevyApiKeyResilient,
+	VALIDATION_CACHE_TTL_SECONDS,
+	type HevyKeyValidator,
+} from "./validation-cache.js";
+
+function createFakeKv() {
+	const store = new Map<string, string>();
+	return {
+		store,
+		get: vi.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+		put: vi.fn(
+			(key: string, value: string, _options?: { expirationTtl?: number }) => {
+				store.set(key, value);
+				return Promise.resolve();
+			},
+		),
+		delete: vi.fn((key: string) => {
+			store.delete(key);
+			return Promise.resolve();
+		}),
+		list: vi.fn(() => Promise.resolve({ keys: [], list_complete: true })),
+	};
+}
+
+afterEach(() => {
+	resetMemoryValidationCacheForTests();
+});
+
+describe("in-memory fallback (no reachable KV binding)", () => {
+	it("reports a miss for a key that was never cached", async () => {
+		await expect(hasCachedValidation("never-cached", {})).resolves.toBe(false);
+	});
+
+	it("reports a hit after caching, scoped to that exact key", async () => {
+		await cacheValidation("cached-key", {});
+
+		await expect(hasCachedValidation("cached-key", {})).resolves.toBe(true);
+		await expect(hasCachedValidation("other-key", {})).resolves.toBe(false);
+	});
+
+	it("expires the cached verdict after the TTL", async () => {
+		vi.useFakeTimers();
+		try {
+			await cacheValidation("expiring-key", {});
+			await expect(hasCachedValidation("expiring-key", {})).resolves.toBe(true);
+
+			vi.advanceTimersByTime(VALIDATION_CACHE_TTL_SECONDS * 1_000 + 1);
+
+			await expect(hasCachedValidation("expiring-key", {})).resolves.toBe(
+				false,
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("falls back to memory when OAUTH_KV is not KV-namespace-shaped", async () => {
+		const env = { OAUTH_KV: "not-a-kv-namespace" };
+		await cacheValidation("legacy-key", env);
+		await expect(hasCachedValidation("legacy-key", env)).resolves.toBe(true);
+	});
+
+	it("evicts the oldest entry once the cap is exceeded", async () => {
+		const env = {};
+		for (let index = 0; index < MEMORY_CACHE_MAX_ENTRIES + 1; index++) {
+			await cacheValidation(`key-${index}`, env);
+		}
+		await expect(hasCachedValidation("key-0", env)).resolves.toBe(false);
+		await expect(
+			hasCachedValidation(`key-${MEMORY_CACHE_MAX_ENTRIES}`, env),
+		).resolves.toBe(true);
+	});
+});
+
+describe("KV-backed cache", () => {
+	it("stores a successful validation with the TTL and reads it back", async () => {
+		const kv = createFakeKv();
+		const env = { OAUTH_KV: kv };
+
+		await cacheValidation("hevy-api-key", env);
+
+		expect(kv.put).toHaveBeenCalledTimes(1);
+		const [key, value, options] = kv.put.mock.calls[0] as [
+			string,
+			string,
+			{ expirationTtl?: number },
+		];
+		expect(key.startsWith("keyvalid:")).toBe(true);
+		expect(value).not.toContain("hevy-api-key");
+		expect(options?.expirationTtl).toBe(VALIDATION_CACHE_TTL_SECONDS);
+
+		await expect(hasCachedValidation("hevy-api-key", env)).resolves.toBe(true);
+		await expect(hasCachedValidation("other-api-key", env)).resolves.toBe(
+			false,
+		);
+	});
+
+	it("derives the same cache key for the same API key, and different keys for different values", async () => {
+		const kv = createFakeKv();
+		const env = { OAUTH_KV: kv };
+
+		await cacheValidation("key-a", env);
+		await cacheValidation("key-a", env);
+		await cacheValidation("key-b", env);
+
+		const keys = kv.put.mock.calls.map((call) => call[0] as string);
+		expect(keys[0]).toBe(keys[1]);
+		expect(keys[0]).not.toBe(keys[2]);
+	});
+
+	it("treats a KV read failure as a cache miss rather than throwing", async () => {
+		const kv = createFakeKv();
+		kv.get.mockRejectedValueOnce(new Error("KV unavailable"));
+		const env = { OAUTH_KV: kv };
+
+		await expect(hasCachedValidation("some-key", env)).resolves.toBe(false);
+	});
+
+	it("treats a KV write failure as a no-op rather than throwing", async () => {
+		const kv = createFakeKv();
+		kv.put.mockRejectedValueOnce(new Error("KV unavailable"));
+		const env = { OAUTH_KV: kv };
+
+		await expect(cacheValidation("some-key", env)).resolves.toBeUndefined();
+	});
+
+	it("does not treat an arbitrary stored value as a valid verdict", async () => {
+		const kv = createFakeKv();
+		const env = { OAUTH_KV: kv };
+		await cacheValidation("tampered-key", env);
+		const [key] = kv.put.mock.calls[0] as [
+			string,
+			string,
+			{ expirationTtl?: number },
+		];
+		kv.store.set(key, "something-else");
+
+		await expect(hasCachedValidation("tampered-key", env)).resolves.toBe(false);
+	});
+});
+
+describe("validateHevyApiKeyResilient", () => {
+	const createValidationClient = () => ({}) as HevyClient;
+
+	function rejectingValidator(status: number, count: number): HevyKeyValidator {
+		let calls = 0;
+		return vi.fn<HevyKeyValidator>(() => {
+			calls += 1;
+			if (calls <= count) {
+				return Promise.reject(
+					new HevyHttpError(`HTTP ${status}`, {
+						status,
+						method: "GET",
+						endpoint: "/v1/user/info",
+					}),
+				);
+			}
+			return Promise.resolve("valid");
+		});
+	}
+
+	it("skips validate entirely on a cache hit", async () => {
+		const env = {};
+		await cacheValidation("resilient-cached-key", env);
+		const validate: HevyKeyValidator = vi.fn();
+
+		const result = await validateHevyApiKeyResilient(
+			"resilient-cached-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+		);
+
+		expect(result).toBe("valid");
+		expect(validate).not.toHaveBeenCalled();
+	});
+
+	it("validates and caches on a miss", async () => {
+		const env = {};
+		const validate: HevyKeyValidator = vi.fn().mockResolvedValue("valid");
+
+		const result = await validateHevyApiKeyResilient(
+			"resilient-fresh-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+		);
+
+		expect(result).toBe("valid");
+		expect(validate).toHaveBeenCalledTimes(1);
+		await expect(hasCachedValidation("resilient-fresh-key", env)).resolves.toBe(
+			true,
+		);
+	});
+
+	it("never caches an invalid verdict", async () => {
+		const env = {};
+		const validate: HevyKeyValidator = vi.fn().mockResolvedValue("invalid");
+
+		const result = await validateHevyApiKeyResilient(
+			"resilient-invalid-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+		);
+
+		expect(result).toBe("invalid");
+		await expect(
+			hasCachedValidation("resilient-invalid-key", env),
+		).resolves.toBe(false);
+	});
+
+	it("retries a transient (non-429) failure and returns the eventual success", async () => {
+		const env = {};
+		const validate = rejectingValidator(503, 1);
+
+		const result = await validateHevyApiKeyResilient(
+			"resilient-retry-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+		);
+
+		expect(result).toBe("valid");
+		expect(validate).toHaveBeenCalledTimes(2);
+	});
+
+	it("never retries a 429", async () => {
+		const env = {};
+		const error = new HevyHttpError("HTTP 429", {
+			status: 429,
+			method: "GET",
+			endpoint: "/v1/user/info",
+		});
+		const validate: HevyKeyValidator = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			validateHevyApiKeyResilient(
+				"resilient-429-key",
+				"https://api.hevyapp.com",
+				createValidationClient,
+				validate,
+				env,
+			),
+		).rejects.toBe(error);
+		expect(validate).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers the cache write via waitUntil when given an execution context", async () => {
+		const env = {};
+		const validate: HevyKeyValidator = vi.fn().mockResolvedValue("valid");
+		const waitUntil = vi.fn();
+
+		const result = await validateHevyApiKeyResilient(
+			"resilient-deferred-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+			undefined,
+			{ waitUntil },
+		);
+
+		expect(result).toBe("valid");
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/worker/src/validation-cache.test.ts
+++ b/packages/worker/src/validation-cache.test.ts
@@ -257,6 +257,26 @@ describe("validateHevyApiKeyResilient", () => {
 		expect(validate).toHaveBeenCalledTimes(1);
 	});
 
+	it("stops retrying when aborted during backoff, without another attempt", async () => {
+		const env = {};
+		const controller = new AbortController();
+		const validate = rejectingValidator(503, 1);
+
+		const pending = validateHevyApiKeyResilient(
+			"resilient-abort-key",
+			"https://api.hevyapp.com",
+			createValidationClient,
+			validate,
+			env,
+			{ signal: controller.signal },
+		);
+		// Abort while the wrapper is sleeping between attempt 1 and attempt 2.
+		setTimeout(() => controller.abort(), 10);
+
+		await expect(pending).rejects.toBeInstanceOf(HevyHttpError);
+		expect(validate).toHaveBeenCalledTimes(1);
+	});
+
 	it("defers the cache write via waitUntil when given an execution context", async () => {
 		const env = {};
 		const validate: HevyKeyValidator = vi.fn().mockResolvedValue("valid");

--- a/packages/worker/src/validation-cache.ts
+++ b/packages/worker/src/validation-cache.ts
@@ -256,6 +256,10 @@ export async function validateHevyApiKeyResilient(
 				error,
 			);
 			await delay(delayMs, options?.signal);
+			// `delay` resolves (rather than rejects) on abort, so re-check here:
+			// without this an abort during backoff would fall through to another
+			// validate() call with an already-aborted signal.
+			if (options?.signal?.aborted) throw error;
 		}
 	}
 	// Unreachable: the loop always returns or throws before exhausting its

--- a/packages/worker/src/validation-cache.ts
+++ b/packages/worker/src/validation-cache.ts
@@ -1,0 +1,266 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { createSafeErrorDiagnostic } from "@hevy-mcp/core";
+import {
+	isHevyHttpError,
+	type HevyClient,
+	type HevyRequestOptions,
+} from "@hevy-mcp/hevy-client";
+import { isOAuthEnabled, type HevyApiKeyValidation } from "./worker-oauth.js";
+
+/** How long a successful Hevy key validation is trusted before re-checking upstream. */
+export const VALIDATION_CACHE_TTL_SECONDS = 900;
+
+const VALIDATION_CACHE_KEY_PREFIX = "keyvalid:";
+/** The only value `cacheValidation` ever writes; a KV read must match it exactly. */
+const VALIDATION_CACHE_SENTINEL = "valid";
+/** Bound the in-memory fallback so a flood of distinct keys cannot grow it unbounded. */
+export const MEMORY_CACHE_MAX_ENTRIES = 256;
+
+/** Structural env shape this module needs; kept independent of `WorkerEnv`. */
+export interface ValidationCacheEnv {
+	OAUTH_KV?: unknown;
+}
+
+interface ValidationCacheKvNamespace {
+	get(key: string): Promise<string | null>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number },
+	): Promise<void>;
+}
+
+/**
+ * Fallback store for isolates without a reachable KV binding (local dev,
+ * unit tests, or a misconfigured OAUTH_KV). Module-scoped so a warm isolate
+ * still benefits, but unlike KV it never survives a cold start and never
+ * shares state across isolates. Insertion-ordered so the oldest entry is
+ * evicted first once the cap is reached.
+ */
+const memoryCache = new Map<string, number>();
+
+async function sha256Hex(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(value),
+	);
+	return Array.from(new Uint8Array(digest), (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+}
+
+async function cacheKeyFor(apiKey: string): Promise<string> {
+	return `${VALIDATION_CACHE_KEY_PREFIX}${await sha256Hex(apiKey)}`;
+}
+
+function kvNamespace(
+	env: ValidationCacheEnv,
+): ValidationCacheKvNamespace | undefined {
+	return isOAuthEnabled(env)
+		? (env.OAUTH_KV as ValidationCacheKvNamespace)
+		: undefined;
+}
+
+function rememberInMemory(key: string): void {
+	memoryCache.set(key, Date.now() + VALIDATION_CACHE_TTL_SECONDS * 1_000);
+	while (memoryCache.size > MEMORY_CACHE_MAX_ENTRIES) {
+		const oldestKey = memoryCache.keys().next().value;
+		if (oldestKey === undefined) break;
+		memoryCache.delete(oldestKey);
+	}
+}
+
+/**
+ * Whether `apiKey` has an unexpired cached "valid" verdict. A hit lets a
+ * transient Hevy outage (e.g. a 429) skip the upstream validation call
+ * entirely for a key that was confirmed valid recently.
+ */
+export async function hasCachedValidation(
+	apiKey: string,
+	env: ValidationCacheEnv,
+): Promise<boolean> {
+	const key = await cacheKeyFor(apiKey);
+	const kv = kvNamespace(env);
+	if (kv) {
+		try {
+			return (await kv.get(key)) === VALIDATION_CACHE_SENTINEL;
+		} catch {
+			// A cache read failure must fall through to a real validation call,
+			// not fail the request.
+			return false;
+		}
+	}
+	const expiresAt = memoryCache.get(key);
+	if (expiresAt === undefined) return false;
+	if (expiresAt <= Date.now()) {
+		memoryCache.delete(key);
+		return false;
+	}
+	return true;
+}
+
+/** Record a successful validation so a request within the TTL can skip Hevy. */
+export async function cacheValidation(
+	apiKey: string,
+	env: ValidationCacheEnv,
+): Promise<void> {
+	const key = await cacheKeyFor(apiKey);
+	const kv = kvNamespace(env);
+	if (kv) {
+		try {
+			await kv.put(key, VALIDATION_CACHE_SENTINEL, {
+				expirationTtl: VALIDATION_CACHE_TTL_SECONDS,
+			});
+		} catch {
+			// Best-effort: a cache write failure must not fail an otherwise-valid request.
+		}
+		return;
+	}
+	rememberInMemory(key);
+}
+
+/** Test-only: clear the in-memory fallback so cases don't leak into each other. */
+export function resetMemoryValidationCacheForTests(): void {
+	memoryCache.clear();
+}
+
+/** The shape of the plain, unmodified (upstream) `validateHevyApiKey`. */
+export type HevyKeyValidator = (
+	apiKey: string,
+	hevyApiBaseUrl: string,
+	createValidationClient: (apiKey: string, baseUrl: string) => HevyClient,
+	options?: HevyRequestOptions,
+) => Promise<HevyApiKeyValidation>;
+
+const VALIDATION_RETRY_MAX_ATTEMPTS = 3;
+const VALIDATION_RETRY_DELAYS_MS = [300, 600];
+
+/**
+ * Whether a failed validation attempt is worth retrying.
+ *
+ * HTTP 429 is deliberately excluded: fast-retrying it would spend up to
+ * three Hevy calls in a few seconds against the exact rate limit that
+ * caused the outage this module guards against. The shared hevy-client
+ * retry classification (packages/hevy-client) treats 429 as transient and
+ * has no per-call override for that; carving it out there would mean
+ * touching upstream-owned client internals, so the exclusion lives here
+ * instead, local to this one caller.
+ */
+function isRetryableValidationFailure<T>(error: T): boolean {
+	if (!isHevyHttpError(error)) return false;
+	const status = error.status;
+	if (status === 429) return false;
+	return (
+		status === undefined || status === 408 || (status >= 500 && status <= 599)
+	);
+}
+
+function logValidationRetry<T>(
+	attempt: number,
+	maxAttempts: number,
+	delayMs: number,
+	error: T,
+): void {
+	console.warn({
+		event: "worker.hevy_validation_retry",
+		attempt,
+		maxAttempts,
+		delayMs,
+		...createSafeErrorDiagnostic(error),
+	});
+}
+
+/** Resolves after `ms`, or immediately if `signal` is already/becomes aborted. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.resolve();
+	return new Promise((resolve) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * Execution-context-like handle for deferring the cache write past the
+ * response. Structural (not the full Cloudflare `ExecutionContext`) so this
+ * module doesn't need to depend on callers having one.
+ */
+export interface WaitUntilHandle {
+	waitUntil(promise: Promise<unknown>): void;
+}
+
+/**
+ * Wrap the plain `validateHevyApiKey` with this fork's resilience additions:
+ * a cache check/set (skips Hevy entirely on a recent "valid" verdict), and a
+ * bounded retry for transient upstream failures. Never caches "invalid" or
+ * thrown verdicts — only a confirmed-valid key is cached.
+ *
+ * When `executionContext` is supplied, the cache write is deferred via
+ * `waitUntil` so it never adds latency to the response; otherwise it's
+ * awaited inline (the OAuth validation path doesn't have one reachable
+ * today).
+ */
+export async function validateHevyApiKeyResilient(
+	apiKey: string,
+	hevyApiBaseUrl: string,
+	createValidationClient: (apiKey: string, baseUrl: string) => HevyClient,
+	validate: HevyKeyValidator,
+	env: ValidationCacheEnv,
+	options?: HevyRequestOptions,
+	executionContext?: WaitUntilHandle,
+): Promise<HevyApiKeyValidation> {
+	if (await hasCachedValidation(apiKey, env)) return "valid";
+
+	for (let attempt = 1; attempt <= VALIDATION_RETRY_MAX_ATTEMPTS; attempt++) {
+		try {
+			const result = await validate(
+				apiKey,
+				hevyApiBaseUrl,
+				createValidationClient,
+				options,
+			);
+			if (result === "valid") {
+				const write = cacheValidation(apiKey, env);
+				if (executionContext) executionContext.waitUntil(write);
+				else await write;
+			}
+			return result;
+		} catch (error) {
+			if (options?.signal?.aborted) throw error;
+			if (isHevyHttpError(error) && error.outcome === "deadline_exceeded") {
+				throw error;
+			}
+			const delayMs = VALIDATION_RETRY_DELAYS_MS[attempt - 1];
+			const deadlineAllows =
+				options?.deadline === undefined ||
+				(delayMs !== undefined && Date.now() + delayMs < options.deadline);
+			if (
+				attempt >= VALIDATION_RETRY_MAX_ATTEMPTS ||
+				delayMs === undefined ||
+				!deadlineAllows ||
+				!isRetryableValidationFailure(error)
+			) {
+				throw error;
+			}
+			logValidationRetry(
+				attempt,
+				VALIDATION_RETRY_MAX_ATTEMPTS,
+				delayMs,
+				error,
+			);
+			await delay(delayMs, options?.signal);
+		}
+	}
+	// Unreachable: the loop always returns or throws before exhausting its
+	// bound, but TypeScript needs an explicit exit.
+	throw new Error(
+		"validateHevyApiKeyResilient: retry loop exited without a result",
+	);
+}

--- a/packages/worker/src/worker-oauth.test.ts
+++ b/packages/worker/src/worker-oauth.test.ts
@@ -16,6 +16,7 @@ import {
 	type HevyOAuthDependencies,
 } from "./worker-oauth.js";
 import { createWorkerFetchHandler } from "./worker.js";
+import { resetMemoryValidationCacheForTests } from "./validation-cache.js";
 
 class TestExecutionSpan implements Span {
 	get isTraced(): boolean {
@@ -72,6 +73,7 @@ beforeEach(() => {
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+	resetMemoryValidationCacheForTests();
 });
 
 const stringSchema = z.string();
@@ -1292,7 +1294,12 @@ describe("OAuth-enabled Worker fetch handler", () => {
 			)
 		).json()) as { access_token: string };
 
-		// The key gets revoked in Hevy after the grant was issued.
+		// The key gets revoked in Hevy after the grant was issued. Clear the
+		// validation cache entry the approval step above just wrote, so this
+		// request re-checks Hevy instead of reusing that now-stale "valid" verdict.
+		for (const key of [...env.OAUTH_KV.store.keys()]) {
+			if (key.startsWith("keyvalid:")) env.OAUTH_KV.store.delete(key);
+		}
 		validationFactory = revokedValidation;
 		const result = await handler(
 			new Request("https://worker.example/mcp", {
@@ -1310,5 +1317,121 @@ describe("OAuth-enabled Worker fetch handler", () => {
 		expect(result.headers.get("www-authenticate")).toContain(
 			'error="invalid_token"',
 		);
+	});
+
+	it("logs the upstream status when key validation throws for an authorized MCP request", async () => {
+		const validValidation = vi.fn(() => createMockClient());
+		const throwingValidation = vi.fn(() =>
+			createMockClient({
+				getUserInfo: vi.fn().mockRejectedValue(
+					new HevyHttpError("HTTP 503", {
+						status: 503,
+						method: "GET",
+						endpoint: "/v1/user/info",
+						code: "HEVY_RETRY_EXHAUSTED",
+					}),
+				),
+			}),
+		);
+		let validationFactory = validValidation;
+		const { handler, env } = createHandlerWithEnv({
+			createValidationClient: () => validationFactory(),
+		});
+
+		const registration = await handler(
+			new Request("https://worker.example/register", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					redirect_uris: [redirectUri],
+					token_endpoint_auth_method: "none",
+				}),
+			}),
+			env,
+			testExecutionContext,
+		);
+		const client = (await registration.json()) as { client_id: string };
+		const verifier = base64UrlEncode(
+			crypto.getRandomValues(new Uint8Array(32)),
+		);
+		const challenge = base64UrlEncode(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
+		const authorizeUrl = new URL("https://worker.example/authorize");
+		authorizeUrl.searchParams.set("response_type", "code");
+		authorizeUrl.searchParams.set("client_id", client.client_id);
+		authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+		authorizeUrl.searchParams.set("state", "s");
+		authorizeUrl.searchParams.set("code_challenge", challenge);
+		authorizeUrl.searchParams.set("code_challenge_method", "S256");
+		const consentHtml = await (
+			await handler(new Request(authorizeUrl), env, testExecutionContext)
+		).text();
+		const encodedRequest = /name="oauth_request" value="([^"]+)"/.exec(
+			consentHtml,
+		)?.[1] as string;
+		const approval = await handler(
+			new Request("https://worker.example/authorize", {
+				method: "POST",
+				body: new URLSearchParams({
+					oauth_request: encodedRequest,
+					hevy_api_key: "flaky-connection-key",
+				}),
+			}),
+			env,
+			testExecutionContext,
+		);
+		const code = new URL(
+			approval.headers.get("location") as string,
+		).searchParams.get("code") as string;
+		const tokens = (await (
+			await handler(
+				new Request("https://worker.example/token", {
+					method: "POST",
+					body: new URLSearchParams({
+						grant_type: "authorization_code",
+						code,
+						redirect_uri: redirectUri,
+						client_id: client.client_id,
+						code_verifier: verifier,
+					}),
+				}),
+				env,
+				testExecutionContext,
+			)
+		).json()) as { access_token: string };
+
+		// Force a live validation call: the approval step above already cached
+		// this key as valid, which would otherwise mask the throw below.
+		for (const key of [...env.OAUTH_KV.store.keys()]) {
+			if (key.startsWith("keyvalid:")) env.OAUTH_KV.store.delete(key);
+		}
+		validationFactory = throwingValidation;
+		const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const result = await handler(
+			new Request("https://worker.example/mcp", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${tokens.access_token}`,
+				},
+				body: JSON.stringify(initializeBody),
+			}),
+			env,
+			testExecutionContext,
+		);
+
+		expect(result.status).toBe(502);
+		const diagnostic = JSON.stringify(stderrSpy.mock.calls);
+		expect(diagnostic).toContain("oauth-mcp-validation");
+		expect(diagnostic).toContain("HevyHttpError");
+		expect(diagnostic).toContain("503");
+		expect(diagnostic).toContain("HEVY_RETRY_EXHAUSTED");
+		stderrSpy.mockRestore();
 	});
 });

--- a/packages/worker/src/worker-oauth.ts
+++ b/packages/worker/src/worker-oauth.ts
@@ -320,13 +320,24 @@ function renderValidationFailure<T>(
 	request: Request,
 	rerender: (message: string, status: number) => Response,
 ): Response {
+	logOAuthValidationFailure("oauth-authorize-validation", error);
 	const failure = validationFailure(error, request);
 	return rerender(failure.message, failure.status);
 }
 
 function jsonValidationFailure<T>(error: T, request: Request): Response {
+	logOAuthValidationFailure("oauth-mcp-validation", error);
 	const failure = validationFailure(error, request);
 	return executionResponse(error, failure.message, failure.outcome);
+}
+
+/** Settle "what did Hevy actually return" for a validation failure incident. */
+function logOAuthValidationFailure<T>(context: string, error: T): void {
+	console.error({
+		event: "worker.error",
+		context,
+		...createSafeErrorDiagnostic(error),
+	});
 }
 
 function authorizeConfigErrorResponse(

--- a/packages/worker/src/worker.test.ts
+++ b/packages/worker/src/worker.test.ts
@@ -18,6 +18,7 @@ import {
 	parseBearerApiKey,
 } from "./worker.js";
 import worker from "./worker.js";
+import { resetMemoryValidationCacheForTests } from "./validation-cache.js";
 
 const objectLikeSchema = z.object({}).passthrough();
 type WorkerLogEntry = {
@@ -38,6 +39,9 @@ const validHeaders = {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	// The validation cache's in-memory fallback is module-scoped; reset it so
+	// one test's cached verdict never masks another test's expectations.
+	resetMemoryValidationCacheForTests();
 });
 
 function mcpRequest(
@@ -338,6 +342,99 @@ describe("Cloudflare Worker routes and CORS", () => {
 			});
 		},
 	);
+	describe("Hevy key validation cache", () => {
+		const initializeBody = {
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2025-11-25",
+				capabilities: {},
+				clientInfo: { name: "validation-cache-test", version: "1" },
+			},
+		};
+
+		it("skips a second upstream validation for the same key within the TTL", async () => {
+			const createValidationClient = vi.fn(() => createMockClient());
+			const cachedHandler = createWorkerHandler({ createValidationClient });
+
+			expect((await cachedHandler(mcpRequest(initializeBody), {})).status).toBe(
+				200,
+			);
+			expect((await cachedHandler(mcpRequest(initializeBody), {})).status).toBe(
+				200,
+			);
+
+			expect(createValidationClient).toHaveBeenCalledTimes(1);
+		});
+
+		it("validates independently for a key that was never cached", async () => {
+			const createValidationClient = vi.fn(() => createMockClient());
+			const freshHandler = createWorkerHandler({ createValidationClient });
+
+			expect(
+				(
+					await freshHandler(
+						mcpRequest(initializeBody, {
+							...validHeaders,
+							authorization: "Bearer other-key",
+						}),
+						{},
+					)
+				).status,
+			).toBe(200);
+
+			expect(createValidationClient).toHaveBeenCalledTimes(1);
+		});
+
+		it("never caches an invalid verdict", async () => {
+			const createValidationClient = vi.fn(() =>
+				createMockClient({
+					getUserInfo: vi.fn().mockRejectedValue(
+						new HevyHttpError("HTTP 401", {
+							status: 401,
+							method: "GET",
+							endpoint: "/v1/user/info",
+						}),
+					),
+				}),
+			);
+			const invalidHandler = createWorkerHandler({ createValidationClient });
+
+			expect((await invalidHandler(mcpRequest({}), {})).status).toBe(401);
+			expect((await invalidHandler(mcpRequest({}), {})).status).toBe(401);
+
+			expect(createValidationClient).toHaveBeenCalledTimes(2);
+		});
+
+		it("logs the upstream status when key validation throws", async () => {
+			const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const throwingHandler = createWorkerHandler({
+				createValidationClient: () =>
+					createMockClient({
+						getUserInfo: vi.fn().mockRejectedValue(
+							new HevyHttpError("HTTP 503", {
+								status: 503,
+								method: "GET",
+								endpoint: "/v1/user/info",
+								code: "HEVY_RETRY_EXHAUSTED",
+							}),
+						),
+					}),
+			});
+
+			const result = await throwingHandler(mcpRequest({}), {});
+
+			expect(result.status).toBe(502);
+			const diagnostic = JSON.stringify(stderrSpy.mock.calls);
+			expect(diagnostic).toContain("hevy-key-validation");
+			expect(diagnostic).toContain("HevyHttpError");
+			expect(diagnostic).toContain("503");
+			expect(diagnostic).toContain("HEVY_RETRY_EXHAUSTED");
+			stderrSpy.mockRestore();
+		});
+	});
+
 	it("logs safe structured request outcomes", async () => {
 		const secret = "sentinel-structured-log-value";
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -440,7 +537,9 @@ describe("real stateless SDK transport", () => {
 		const payload = await parseMcpResponse(list);
 		expect(payload).toMatchObject({ id: 2 });
 		expect(JSON.stringify(payload)).toContain("get-workouts");
-		expect(createValidationClient).toHaveBeenCalledTimes(2);
+		// The second request reuses the same bearer key within the validation
+		// cache TTL, so it never re-validates against Hevy.
+		expect(createValidationClient).toHaveBeenCalledTimes(1);
 		expect(createRequestClient).toHaveBeenCalledTimes(2);
 		expect(createServer).toHaveBeenCalledTimes(2);
 		expect(createTransport).toHaveBeenCalledTimes(2);
@@ -958,6 +1057,70 @@ describe("real stateless SDK transport", () => {
 		expect(new URL(requestUrl).origin).toBe("https://api.hevyapp.com");
 		expect(init?.redirect).toBe("manual");
 		expect(new Headers(init?.headers).get("api-key")).toBe("test-key");
+		fetchSpy.mockRestore();
+	});
+
+	it("retries a transient (non-429) validation failure and logs the attempt", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		let attempt = 0;
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+			attempt += 1;
+			return Promise.resolve(
+				attempt === 1
+					? new Response("Service Unavailable", { status: 503 })
+					: new Response(JSON.stringify({ id: "user" }), {
+							status: 200,
+							headers: { "content-type": "application/json" },
+						}),
+			);
+		});
+
+		const result = await worker.fetch(
+			mcpRequest({
+				jsonrpc: "2.0",
+				id: 11,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-11-25",
+					capabilities: {},
+					clientInfo: { name: "retry-test", version: "1" },
+				},
+			}),
+			{},
+		);
+
+		expect(result.status).toBe(200);
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		const diagnostic = JSON.stringify(warnSpy.mock.calls);
+		expect(diagnostic).toContain("worker.hevy_validation_retry");
+		expect(diagnostic).toContain("503");
+		fetchSpy.mockRestore();
+		warnSpy.mockRestore();
+	});
+
+	it("never retries a 429 validation failure", async () => {
+		// A single transient 429 must fail in one attempt: fast-retrying it would
+		// spend multiple calls against the exact rate limit that caused it.
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("Too Many Requests", { status: 429 }));
+
+		const result = await worker.fetch(
+			mcpRequest({
+				jsonrpc: "2.0",
+				id: 12,
+				method: "initialize",
+				params: {
+					protocolVersion: "2025-11-25",
+					capabilities: {},
+					clientInfo: { name: "no-429-retry-test", version: "1" },
+				},
+			}),
+			{},
+		);
+
+		expect(result.status).toBe(502);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
 		fetchSpy.mockRestore();
 	});
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -497,9 +497,21 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 				env,
 				{
 					signal: request.signal,
-					deadline,
+					// One absolute deadline for the whole validation phase, shared
+					// across the wrapper's retries. Passing the full invocation
+					// deadline instead would let each retry's inner validateHevyApiKey
+					// re-anchor its own now+WORKER_VALIDATION_TIMEOUT_MS window, so
+					// three attempts could consume ~3x the budget this cap reserves
+					// for MCP execution.
+					deadline: Math.min(
+						deadline,
+						Date.now() + WORKER_VALIDATION_TIMEOUT_MS,
+					),
 				},
-				requireExecutionContext(ctx),
+				// Pass the context through as-is: when it's absent (direct callers),
+				// the wrapper awaits the cache write inline rather than handing it to
+				// a no-op waitUntil that would drop it.
+				ctx,
 			);
 		} catch (error) {
 			const normalizedError = error instanceof Error ? error : String(error);
@@ -553,7 +565,12 @@ function createWorkerOAuthProvider(
 				env,
 				{
 					signal,
-					deadline: deadline ?? Date.now() + WORKER_INVOCATION_TIMEOUT_MS,
+					// Cap the whole validation phase (see the bearer path) so the
+					// wrapper's retries share one deadline instead of re-anchoring.
+					deadline: Math.min(
+						deadline ?? Date.now() + WORKER_INVOCATION_TIMEOUT_MS,
+						Date.now() + WORKER_VALIDATION_TIMEOUT_MS,
+					),
 				},
 			);
 		},

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -33,6 +33,7 @@ import {
 	getCloudflareColo,
 	getCloudflareGeography,
 } from "./worker-telemetry.js";
+import { validateHevyApiKeyResilient } from "./validation-cache.js";
 
 const MCP_PATH = "/mcp";
 const OAUTH_AUTHORIZE_PATH = "/authorize";
@@ -448,6 +449,7 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 	return async function handleRequest(
 		request: Request,
 		env: WorkerEnv,
+		ctx?: ExecutionContext,
 	): Promise<Response> {
 		const url = new URL(request.url);
 		if (url.pathname !== MCP_PATH)
@@ -487,17 +489,21 @@ export function createWorkerHandler(dependencies: WorkerDependencies = {}) {
 		const deadline = Date.now() + WORKER_INVOCATION_TIMEOUT_MS;
 		let validation: HevyApiKeyValidation;
 		try {
-			validation = await validateHevyApiKey(
+			validation = await validateHevyApiKeyResilient(
 				apiKey,
 				hevyApiBaseUrl,
 				resolved.createValidationClient,
+				validateHevyApiKey,
+				env,
 				{
 					signal: request.signal,
 					deadline,
 				},
+				requireExecutionContext(ctx),
 			);
 		} catch (error) {
 			const normalizedError = error instanceof Error ? error : String(error);
+			logWorkerFailure("hevy-key-validation", normalizedError);
 			return executionHttpResponse(
 				normalizedError,
 				"Unable to validate the Hevy API key",
@@ -535,10 +541,16 @@ function createWorkerOAuthProvider(
 			} catch {
 				return "config-error";
 			}
-			return validateHevyApiKey(
+			// No ExecutionContext reaches this dependency today (the
+			// HevyOAuthDependencies.validateApiKey interface doesn't thread one),
+			// so the cache write stays awaited here rather than deferred via
+			// waitUntil.
+			return validateHevyApiKeyResilient(
 				apiKey,
 				hevyApiBaseUrl,
 				resolved.createValidationClient,
+				validateHevyApiKey,
+				env,
 				{
 					signal,
 					deadline: deadline ?? Date.now() + WORKER_INVOCATION_TIMEOUT_MS,
@@ -598,7 +610,7 @@ export function createWorkerFetchHandler(
 						logContext,
 					);
 				}
-				const legacyResponse = await legacyHandler(request, env);
+				const legacyResponse = await legacyHandler(request, env, ctx);
 				responseStatus = legacyResponse.status;
 				return legacyResponse;
 			}
@@ -612,13 +624,13 @@ export function createWorkerFetchHandler(
 			const url = new URL(request.url);
 			if (url.pathname === MCP_PATH) {
 				if (request.method === "OPTIONS") {
-					const legacyResponse = await legacyHandler(request, env);
+					const legacyResponse = await legacyHandler(request, env, ctx);
 					responseStatus = legacyResponse.status;
 					return legacyResponse;
 				}
 				const bearer = parseBearerApiKey(request.headers.get("authorization"));
 				if (bearer && !hasOAuthAccessTokenFormat(bearer)) {
-					const legacyResponse = await legacyHandler(request, env);
+					const legacyResponse = await legacyHandler(request, env, ctx);
 					responseStatus = legacyResponse.status;
 					return legacyResponse;
 				}

--- a/tests/integration/worker-http.integration.test.ts
+++ b/tests/integration/worker-http.integration.test.ts
@@ -1,7 +1,9 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { networkInterfaces } from "node:os";
+import { networkInterfaces, tmpdir } from "node:os";
+import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import {
 	Client,
@@ -57,6 +59,7 @@ let fakeHevyBaseUrl: string;
 let redirectRecorderServer: Server;
 let redirectDestinationUrl: string;
 let wrangler: ChildProcessWithoutNullStreams;
+let wranglerPersistDir: string | undefined;
 let workerBaseUrl: string;
 let wranglerLogs = "";
 let wranglerSpawnError: Error | undefined;
@@ -115,6 +118,11 @@ async function allocateWranglerPorts(): Promise<{
 }
 
 function spawnWrangler(workerPort: number, inspectorPort: number): void {
+	if (wranglerPersistDir === undefined) {
+		throw new Error(
+			"spawnWrangler called before the persistence directory was created",
+		);
+	}
 	workerBaseUrl = `http://${LOOPBACK}:${workerPort}`;
 	wranglerSpawnError = undefined;
 	const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
@@ -141,6 +149,8 @@ function spawnWrangler(workerPort: number, inspectorPort: number): void {
 			"--show-interactive-dev-session=false",
 			"--log-level",
 			"warn",
+			"--persist-to",
+			wranglerPersistDir,
 			"--var",
 			`HEVY_API_BASE_URL:${fakeHevyBaseUrl}`,
 		],
@@ -385,6 +395,14 @@ async function parseSseMessage(response: Response): Promise<{
 describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 	beforeAll(
 		async () => {
+			// A fresh, isolated Miniflare persistence directory per run: without
+			// this, local KV (including the Hevy key validation cache) survives
+			// across separate `wrangler dev` invocations via `.wrangler/state`,
+			// so a previous run's cached "valid" verdict for a fixed test API key
+			// would silently short-circuit this run's Hevy request assertions.
+			wranglerPersistDir = await mkdtemp(
+				join(tmpdir(), "hevy-mcp-worker-http-test-"),
+			);
 			redirectRecorderServer = createServer((request, response) => {
 				redirectRequests.push({
 					apiKey: request.headers["api-key"] as string | undefined,
@@ -534,6 +552,11 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 			await stopWrangler();
 		} finally {
 			await Promise.all([close(fakeHevyServer), close(redirectRecorderServer)]);
+			// Guard against a failed mkdtemp (undefined dir): rm(undefined) would
+			// throw and mask whatever error made beforeAll fail in the first place.
+			if (wranglerPersistDir) {
+				await rm(wranglerPersistDir, { recursive: true, force: true });
+			}
 		}
 	}, 10_000);
 
@@ -623,7 +646,9 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 				arguments: { page: 1, page_size: 1 },
 			});
 			expect(JSON.stringify(result)).toContain("worker-workout-1");
-			expect(hevyRequests.length - requestsBeforeToolCall).toBe(2);
+			// The preceding `connect()` (initialize) call already validated and
+			// cached this key, so the tool call itself skips re-validation.
+			expect(hevyRequests.length - requestsBeforeToolCall).toBe(1);
 			expect(transport.sessionId).toBeUndefined();
 			expect(
 				hevyRequests.every((request) => request.apiKey === VALID_API_KEY),
@@ -726,8 +751,12 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 		expect(invalid.status).toBe(401);
 		expect(invalid.headers.get("www-authenticate")).toBe("Bearer");
 		expect(unavailable.status).toBe(502);
+		// A 401 is never retried; a 503 is transient and retried twice (three
+		// attempts total) before the validation client gives up.
 		expect(hevyRequests.map((request) => request.apiKey)).toEqual([
 			INVALID_API_KEY,
+			UPSTREAM_FAILURE_API_KEY,
+			UPSTREAM_FAILURE_API_KEY,
 			UPSTREAM_FAILURE_API_KEY,
 		]);
 	});
@@ -756,7 +785,11 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 		expect(await unsupported.json()).toMatchObject({ error: { code: -32000 } });
 		expect(invalidJson.status).toBe(400);
 		expect(await invalidJson.json()).toMatchObject({ error: { code: -32700 } });
-		expect(hevyRequests).toHaveLength(3);
+		// All three requests use the default valid key, and the very first test
+		// in this file ("routes requests and returns stateless SSE initialize
+		// responses") already validated and cached it — so none of these three
+		// need a real Hevy round trip.
+		expect(hevyRequests.length).toBe(0);
 	});
 
 	it("allows configured CORS origins and rejects unconfigured origins", async () => {


### PR DESCRIPTION
Fixes #1073.

## Problem

In `packages/worker/src/worker.ts`, every `POST /mcp` calls `validateHevyApiKey` (via `getUserInfo`) before the request is served. Two consequences:

1. **Every MCP call costs two Hevy API calls** — the validation probe plus the actual tool call — doubling pressure on Hevy's rate limits for busy clients.
2. **Any validation failure that isn't 401/403 becomes an opaque 502** ("Unable to validate the Hevy API key"). The validation client is built with `maxGetRetries: 0` and no `onLog`, and the catch responds without logging the upstream error — so a single transient Hevy 429/5xx kills the request and leaves no server-side trace of what Hevy actually returned.

A scheduled MCP client (daily cron) failed its connect probe with 502 three days running at top-of-hour rate-limit windows; diagnosing it required reading traffic logs on both sides because the worker records nothing about the upstream status in this path.

## Change

New `packages/worker/src/validation-cache.ts` wraps the plain `validateHevyApiKey` with three resilience additions, and `worker.ts` / `worker-oauth.ts` route both the bearer and OAuth validation paths through it:

- **Short-TTL verdict cache (15 min).** Successful validations are cached keyed by a SHA-256 hash of the API key. A recently-validated caller skips the Hevy probe entirely, so a brief Hevy outage can't fail a key that was just confirmed valid, and steady-state traffic stops paying the doubled call. Only confirmed-`valid` verdicts are ever cached — never `invalid`, `config-error`, or a thrown error. Backed by `OAUTH_KV` when OAuth is enabled, with a bounded (256-entry) in-memory fallback otherwise. Both reads and writes are best-effort — a cache failure falls through to a real validation call and never fails the request. The write is deferred via `waitUntil` where an `ExecutionContext` is available, so it adds no latency to the response.
- **Bounded retry (3 attempts, 300/600 ms)** on transient validation failures, honoring the request deadline and abort signal. **HTTP 429 is deliberately excluded** — fast-retrying it would spend up to three Hevy calls in a few seconds against the exact rate limit the cache exists to absorb.
- **Structured logging** of the upstream status/code in both the bearer and OAuth validation-failure catch paths (via `createSafeErrorDiagnostic`), so a future incident is diagnosable from the worker's own logs.

The public `validateHevyApiKey` is untouched; the wrapper takes it as an injected dependency, keeping the diff to the request paths small and the retry/429 policy local to this one caller rather than reaching into shared hevy-client internals.

## Tests

- `validation-cache.test.ts` (new) — cache hit/miss, TTL expiry, KV vs in-memory fallback, in-memory eviction cap, retry counts and delays, 429 exclusion, deadline/abort honoring, and that only `valid` is cached.
- `worker.test.ts` / `worker-oauth.test.ts` — extended for the cached/retried/logged paths.
- `tests/integration/worker-http.integration.test.ts` — extended over the wrangler-backed HTTP path.

A `@hevy-mcp/worker` patch changeset is included.

## Summary by Sourcery

Add cached and resilient Hevy API key validation across bearer and OAuth request paths.

Bug Fixes:
- Reduce redundant Hevy API key validation calls by caching confirmed-valid verdicts for 15 minutes.
- Improve resilience to transient validation failures with bounded retries while avoiding retries for HTTP 429 responses.
- Expose upstream validation status and error codes in structured worker logs instead of returning opaque failures.

Enhancements:
- Apply oxfmt formatting to core mapped-type declarations without changing functionality.

Tests:
- Add unit, worker, OAuth, and HTTP integration coverage for validation caching, retry behavior, rate-limit handling, deadline and abort handling, and structured diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Successful Hevy API key validations are cached for 15 minutes, reducing repeated validation requests and helping recently verified keys remain usable during brief upstream outages.
  - Transient validation failures are retried automatically, while rate-limit responses are not retried.
- **Bug Fixes**
  - Validation failures now provide clearer diagnostic logging, including upstream status and error details.
  - Cache read or write failures no longer interrupt authentication or request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->