### PR TITLE
fix(core): guard mergeAbortSignals against missing AbortSignal.any #1062

### DIFF
--- a/.changeset/fuzzy-donkeys-guard.md
+++ b/.changeset/fuzzy-donkeys-guard.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Guard `mergeAbortSignals` with an `AbortSignal.any` capability check and a manual composition fallback so self-hosted Node runtimes older than 20.3 no longer fail every tool dispatch with `TypeError: AbortSignal.any is not a function`.

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -18,7 +18,7 @@ type ClientTestArgument =
 				| boolean
 				| null
 				| undefined;
-	  };
+		};
 type ClientMethodArguments = {
 	[K in keyof HevyClient]: ClientTestArgument[];
 };
@@ -200,7 +200,7 @@ describe("mergeAbortSignals", () => {
 	});
 
 	it("composes with the native AbortSignal.any when available", () => {
-		if (typeof AbortSignal.any !== "function") return;
+		if (!("any" in AbortSignal)) return;
 		const first = new AbortController();
 		const second = new AbortController();
 		const composed = mergeAbortSignals(first.signal, second.signal);

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -193,12 +193,14 @@ describe("mergeAbortSignals", () => {
 		} finally {
 			if (nativeDescriptor) {
 				Object.defineProperty(AbortSignal, "any", nativeDescriptor);
+			} else {
+				Reflect.deleteProperty(AbortSignal, "any");
 			}
 		}
 	});
 
 	it("composes with the native AbortSignal.any when available", () => {
-		if (!Reflect.has(AbortSignal, "any")) return;
+		if (typeof AbortSignal.any !== "function") return;
 		const first = new AbortController();
 		const second = new AbortController();
 		const composed = mergeAbortSignals(first.signal, second.signal);

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -18,7 +18,7 @@ type ClientTestArgument =
 				| boolean
 				| null
 				| undefined;
-		};
+	  };
 type ClientMethodArguments = {
 	[K in keyof HevyClient]: ClientTestArgument[];
 };

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -193,6 +193,8 @@ describe("mergeAbortSignals", () => {
 		} finally {
 			if (nativeDescriptor) {
 				Object.defineProperty(AbortSignal, "any", nativeDescriptor);
+			} else {
+				Reflect.deleteProperty(AbortSignal, "any");
 			}
 		}
 	});

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -4,6 +4,7 @@ import {
 	bindClientExecution,
 	createExecutionProjection,
 	HEVY_CLIENT_OPTION_INDEXES,
+	mergeAbortSignals,
 } from "./execution.js";
 
 type ClientTestArgument =
@@ -151,5 +152,58 @@ describe("bindClientExecution", () => {
 			commit_state: "not_sent",
 			safe_to_retry: false,
 		});
+	});
+});
+
+describe("mergeAbortSignals", () => {
+	it("returns undefined without signals and passes a single signal through", () => {
+		expect(mergeAbortSignals()).toBeUndefined();
+		const signal = new AbortController().signal;
+		expect(mergeAbortSignals(undefined, signal, undefined)).toBe(signal);
+	});
+
+	it("aborts the composed fallback signal when a source signal aborts", () => {
+		const nativeDescriptor = Object.getOwnPropertyDescriptor(
+			AbortSignal,
+			"any",
+		);
+		// Simulate runtimes without AbortSignal.any (Node < 20.3).
+		Object.defineProperty(AbortSignal, "any", {
+			value: undefined,
+			configurable: true,
+		});
+		try {
+			const first = new AbortController();
+			const second = new AbortController();
+			const reason = new Error("lifecycle closed");
+			const composed = mergeAbortSignals(first.signal, second.signal);
+
+			expect(composed).toBeDefined();
+			expect(composed?.aborted).toBe(false);
+
+			first.abort(reason);
+			expect(composed?.aborted).toBe(true);
+			expect(composed?.reason).toBe(reason);
+
+			const aborted = new AbortController();
+			aborted.abort();
+			expect(mergeAbortSignals(aborted.signal, second.signal)?.aborted).toBe(
+				true,
+			);
+		} finally {
+			if (nativeDescriptor) {
+				Object.defineProperty(AbortSignal, "any", nativeDescriptor);
+			}
+		}
+	});
+
+	it("composes with the native AbortSignal.any when available", () => {
+		if (!Reflect.has(AbortSignal, "any")) return;
+		const first = new AbortController();
+		const second = new AbortController();
+		const composed = mergeAbortSignals(first.signal, second.signal);
+		expect(composed?.aborted).toBe(false);
+		second.abort();
+		expect(composed?.aborted).toBe(true);
 	});
 });

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -82,18 +82,25 @@ export function mergeAbortSignals(
 		if (!(error instanceof TypeError)) throw error;
 	}
 	const composed = new AbortController();
+	const listeners: Array<{
+		signal: AbortSignal;
+		onAbort: () => void;
+	}> = [];
+	const abort = (signal: AbortSignal) => {
+		for (const listener of listeners) {
+			listener.signal.removeEventListener("abort", listener.onAbort);
+		}
+		listeners.length = 0;
+		composed.abort(signal.reason);
+	};
 	for (const signal of active) {
 		if (signal.aborted) {
-			composed.abort(signal.reason);
+			abort(signal);
 			break;
 		}
-		signal.addEventListener(
-			"abort",
-			() => {
-				composed.abort(signal.reason);
-			},
-			{ once: true },
-		);
+		const onAbort = () => abort(signal);
+		listeners.push({ signal, onAbort });
+		signal.addEventListener("abort", onAbort, { once: true });
 	}
 	return composed.signal;
 }

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -27,9 +27,7 @@ export interface StructuredExecutionProjection {
 /** Backward-compatible name for the structured error projection. */
 export type StructuredExecutionError = StructuredExecutionProjection;
 type MutableExecutionProjection = {
-	-readonly [
-		K in keyof StructuredExecutionProjection
-	]?: StructuredExecutionProjection[K];
+	-readonly [K in keyof StructuredExecutionProjection]?: StructuredExecutionProjection[K];
 } & Pick<
 	StructuredExecutionProjection,
 	"outcome" | "phase" | "operation_safety" | "commit_state" | "safe_to_retry"

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -73,8 +73,29 @@ export function mergeAbortSignals(
 	if (active.length === 1) return active[0];
 	// Node 24 and the supported Worker runtimes provide AbortSignal.any. The
 	// native composition owns listener cleanup when the derived signal settles,
-	// avoiding one retained lifecycle/request listener per invocation.
-	return AbortSignal.any(active);
+	// avoiding one retained lifecycle/request listener per invocation. Older
+	// self-hosted Node runtimes (< 20.3) lack it; the TypeError from the missing
+	// static falls through to manual composition instead of failing dispatch.
+	try {
+		return AbortSignal.any(active);
+	} catch (error) {
+		if (!(error instanceof TypeError)) throw error;
+	}
+	const composed = new AbortController();
+	for (const signal of active) {
+		if (signal.aborted) {
+			composed.abort(signal.reason);
+			break;
+		}
+		signal.addEventListener(
+			"abort",
+			() => {
+				composed.abort(signal.reason);
+			},
+			{ once: true },
+		);
+	}
+	return composed.signal;
 }
 
 type ClientMethod = keyof HevyClient;

--- a/packages/core/src/tools/input-schemas.ts
+++ b/packages/core/src/tools/input-schemas.ts
@@ -108,11 +108,9 @@ export const workoutExerciseFields = {
 	notes: z.string().optional().nullable(),
 	sets: z.array(workoutSetSchema),
 } as const satisfies {
-	[
-		K in keyof NonNullable<
-			NonNullable<PostWorkoutsRequestBody["workout"]>["exercises"]
-		>[number]
-	]: z.ZodTypeAny;
+	[K in keyof NonNullable<
+		NonNullable<PostWorkoutsRequestBody["workout"]>["exercises"]
+	>[number]]: z.ZodTypeAny;
 };
 
 const workoutExerciseSchema = z.strictObject(workoutExerciseFields);
@@ -194,11 +192,9 @@ export const routineExerciseFields = {
 	notes: z.string().optional(),
 	sets: z.array(routineSetSchema),
 } as const satisfies {
-	[
-		K in keyof NonNullable<
-			NonNullable<PostRoutinesRequestBody["routine"]>["exercises"]
-		>[number]
-	]: z.ZodTypeAny;
+	[K in keyof NonNullable<
+		NonNullable<PostRoutinesRequestBody["routine"]>["exercises"]
+	>[number]]: z.ZodTypeAny;
 };
 
 const routineExerciseSchema = z.strictObject(routineExerciseFields);

--- a/packages/core/src/tools/tool-runtime.test.ts
+++ b/packages/core/src/tools/tool-runtime.test.ts
@@ -228,4 +228,42 @@ describe("createToolRuntime observation scope", () => {
 			deadline: 222,
 		});
 	});
+
+	it("cleans up fallback listeners across repeated execution scopes", () => {
+		const nativeDescriptor = Object.getOwnPropertyDescriptor(
+			AbortSignal,
+			"any",
+		);
+		Object.defineProperty(AbortSignal, "any", {
+			value: undefined,
+			configurable: true,
+		});
+		try {
+			const lifecycle = new AbortController();
+			const removeEventListener = vi.spyOn(
+				lifecycle.signal,
+				"removeEventListener",
+			);
+			const runtime = createToolRuntime({
+				client: null,
+				catalog,
+				lifecycleSignal: lifecycle.signal,
+			});
+
+			for (let index = 0; index < 3; index += 1) {
+				const request = new AbortController();
+				const scoped = runtime.forExecution({ signal: request.signal });
+				request.abort();
+				expect(scoped.execution?.signal?.aborted).toBe(true);
+			}
+
+			expect(removeEventListener).toHaveBeenCalledTimes(3);
+		} finally {
+			if (nativeDescriptor) {
+				Object.defineProperty(AbortSignal, "any", nativeDescriptor);
+			} else {
+				Reflect.deleteProperty(AbortSignal, "any");
+			}
+		}
+	});
 });

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -267,9 +267,7 @@ export function createToolRuntime({
 				observer,
 				execution: (() => {
 					const nested: {
-						-readonly [
-							K in keyof ToolExecutionContext
-						]?: ToolExecutionContext[K];
+						-readonly [K in keyof ToolExecutionContext]?: ToolExecutionContext[K];
 					} = {};
 					if (nextExecution) Object.assign(nested, nextExecution);
 					nested.signal = mergeAbortSignals(

--- a/scripts/check-generated-client.test.ts
+++ b/scripts/check-generated-client.test.ts
@@ -334,11 +334,17 @@ describe("generated client closure checks", () => {
 		}
 	});
 
-	it("regenerates the checked client without drift", async () => {
-		const result = await checkGeneratedClient();
+	it.skipIf(process.env.HEVY_UNIT_LANE === "1")(
+		"regenerates the checked client without drift",
+		async () => {
+			// Redundant with `check:generated` (npm run check), which runs the
+			// same full Kubb regeneration; skipped in the fast unit lane.
+			const result = await checkGeneratedClient();
 
-		expect(result.generatedFiles).toBeGreaterThan(0);
-	}, 60_000);
+			expect(result.generatedFiles).toBeGreaterThan(0);
+		},
+		60_000,
+	);
 
 	it("reports a missing named public export", async () => {
 		const fixture = await materializeFixture(

--- a/scripts/run-vitest-lane.mjs
+++ b/scripts/run-vitest-lane.mjs
@@ -19,6 +19,11 @@ if (!Object.hasOwn(selectors, lane)) {
 }
 
 const args = ["run", ...selectors[lane]];
+if (lane === "unit") {
+	// Lets slow, expensive tests that duplicate the `check` targets skip
+	// themselves in the fast unit lane (see check-generated-client.test.ts).
+	process.env.HEVY_UNIT_LANE = "1";
+}
 if (process.env.HEVY_TEST_REPORT_MODE === "ci") {
 	const nodeMajor = Number.parseInt(process.versions.node, 10);
 	if (lane === "unit") {


### PR DESCRIPTION
## Primary changes

Fixes the production issue seen as Sentry `HEVY-MCP-60` (`TypeError: AbortSignal.any is not a function`, 2 events on `hevy-mcp@6.1.4`).

`mergeAbortSignals` in `packages/core/src/execution.ts` calls `AbortSignal.any` unguarded when composing a lifecycle signal with a request signal. `AbortSignal.any` requires Node >= 20.3, so self-hosted users on older Node runtimes had every tool dispatch fail before any request was sent (`phase: before-dispatch`, `commit_state: not_sent`).

The change:

- Probes the native `AbortSignal.any` at dispatch time and falls through to a manual composition fallback (an `AbortController` with `once` abort listeners forwarding the original abort reason) when the runtime lacks it.
- Adds regression tests covering the fallback path (abort propagation, reason forwarding, pre-aborted sources) and the native path.

## Reviewer walkthrough

- `packages/core/src/execution.ts`: guard native abort-signal composition and provide the manual fallback for runtimes without `AbortSignal.any`.
- `packages/core/src/execution.test.ts`: cover fallback abort propagation, reason forwarding, pre-aborted sources, and native composition.
- `packages/core/src/tools/tool-runtime.ts` and `packages/core/src/tools/tool-runtime.test.ts`: compose scoped lifecycle/request signals and verify fallback listener cleanup across repeated execution scopes.
- `scripts/check-generated-client.test.ts` and `scripts/run-vitest-lane.mjs`: skip redundant generated-client regeneration in the fast unit lane while retaining it in the full `check` lane.
- `.changeset/fuzzy-donkeys-guard.md`: record the patch release and affected package cascade.

## Correctness and invariants

- Preserve existing behavior for zero or single active signals.
- Use native `AbortSignal.any` when available; otherwise compose active signals through an `AbortController`.
- Forward the original abort reason and handle sources that are already aborted.
- Keep the compatibility fix scoped to signal composition without changing request dispatch semantics.

## Notes on the related 429 issue (HEVY-MCP-55)

Investigation showed the 429 retry-budget problem is already fixed on `main`: both production adapters (`packages/node/src/runtime.ts`, `packages/worker/src/worker.ts`) no longer pass `maxGetRetries: 0` to the main request client, so the default `MAX_GET_RETRIES = 3` with `Retry-After`-aware backoff now applies. Only the startup API-key validation probes intentionally keep retries disabled. No change is needed in this PR for that issue.

## Testing and QA

- `npm run test:unit` — 849 tests passed (84 suites) on `ce4e257`; the latest `8f35c7e` head only skips the redundant generated-client regeneration test in this fast lane
- `npm run check:types` — passed
- `npm run check:changeset` — passed (patch bump for `@hevy-mcp/core` plus cascade: `hevy-mcp`, `@hevy-mcp/worker`, `@chrisdoc/hevy-cli`)
- Pre-commit hooks (oxlint type-aware, oxfmt, commitlint, unit lane) — passed

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>

## Summary by Sourcery

Guard abort-signal merging against unavailable native composition so older self-hosted Node runtimes can dispatch tools reliably.

Bug Fixes:
- Prevent tool dispatch failures on runtimes without native `AbortSignal.any` by providing compatible abort-signal composition.

Enhancements:
- Preserve abort reasons, pre-aborted sources, and listener cleanup across fallback signal composition.

CI:
- Skip the redundant generated-client regeneration test in the fast unit lane while retaining it in the full check workflow.

Tests:
- Add regression coverage for native and fallback abort-signal composition, including propagation, reason forwarding, pre-aborted signals, and listener cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling on Node.js runtimes older than 20.3 by providing a fallback when native signal composition is unavailable.
  - Ensured cancellation listeners are cleaned up correctly after repeated operations.
  - Preserved cancellation reasons when requests are aborted.

- **Tests**
  - Added coverage for single, multiple, and pre-aborted cancellation signals.
  - Added verification that fallback listeners are removed after each operation.
  - Improved test execution by avoiding redundant checks in the fast unit test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #1062
Refs #1017

