### PR TITLE
fix(gitstream): drop zod dependency from findDiffLocation plugin #1086

### DIFF
--- a/.cm/plugins/filters/findDiffLocation/index.js
+++ b/.cm/plugins/filters/findDiffLocation/index.js
@@ -1,9 +1,5 @@
-const { z } = require("zod");
-
-const stringSchema = z.string();
-
 function isString(value) {
-	return stringSchema.safeParse(value).success;
+	return Object.prototype.toString.call(value) === "[object String]";
 }
 
 /**


### PR DESCRIPTION
## Primary changes

Replace the zod string validation with a dependency-free check (`Object.prototype.toString`). Zero runtime deps, verified behaviorally (finds the correct added line in a diff).

## Reviewer walkthrough

The filter is loaded from gitStream's own `code/repo` checkout, where `node_modules` never exists — so `require('zod')` can never resolve. Removing that import and schema construction keeps the filter loadable in that checkout.

## Correctness and invariants

gitStream resolves filters from the **base tree**, so this must merge to main before any PR's gitStream check can pass. This PR's own gitStream check will fail until it is merged.

## Testing and QA

The change is limited to one file and validated locally (`node` load + diff test), plus all other lanes (build, test, zizmor, audit) pass.


## Summary by Sourcery

Make the findDiffLocation filter loadable without external runtime dependencies.

Bug Fixes:
- Remove the runtime zod dependency from the findDiffLocation filter so gitStream can load it from the repository checkout.

Enhancements:
- Replace schema-based string validation with a dependency-free equivalent.

Resolves #1086
Refs #1085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string detection for more reliable diff location filtering.
  * Removed unnecessary validation dependency usage without changing existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->