### PR TITLE
chore: wire entire-graph code graph into agent workflow

### DIFF
--- a/.entire/graph-agent.md
+++ b/.entire/graph-agent.md
@@ -1,0 +1,43 @@
+# entire-graph — instructions for coding agents (follow directly)
+
+You have a deterministic local code graph: `entire graph` (functions, classes, methods,
+types, routes + call/inheritance relations; no network). These instructions are FOR YOU, the
+agent reading this file. Use the graph to narrow exploration without trading away correctness.
+
+## The workflow (mandatory for locate/fix/change tasks)
+
+Your FIRST action on any task that requires finding code must be ONE search:
+
+    entire graph search --repo . --profile full --query "<the task or bug in one sentence>"
+
+Then open the top hit's file with your file-read tool (pass a line range around the reported
+line), inspect enough surrounding behavior to justify the change, and make the smallest complete
+edit. Treat graph output as evidence, not an oracle.
+
+## Hard rules
+
+1. SEARCH FIRST — never grep/find/cat to locate code before you have searched.
+2. READ focused source around the result. Widen the check when aliases, generated code, dynamic
+   dispatch, or related implementations could matter.
+3. Use graph follow-ups only when they answer a real question. For impact or callers, prefer:
+       entire graph impact --repo . --symbol X
+4. Make the smallest complete edit and check sibling sites or contracts when the task implies them.
+5. VERIFY before stopping. Run the most focused relevant test, build, or reproduction available.
+   If execution is unavailable, perform a bounded source-level verification and state the limit.
+6. Prefer precise queries and line ranges, but never trade resolution for fewer turns.
+7. Feature-detect before relying on semantic relations:
+       entire graph capabilities --json
+
+## When NOT to use the graph
+
+If the task already names the exact file and it is small, just read it — the graph saves tokens
+by eliminating exploration; when there is nothing to explore, skip it.
+
+## Reference
+
+    locate  ->  entire graph search --repo . --profile full --query "..."
+    impact  ->  entire graph impact --repo . --symbol X   (one shot: callers, callees, type consumers, data flow, co-change, siblings)
+    callers ->  entire graph neighbors --repo . --symbol X --relation CALLS --direction in
+    change  ->  entire graph diff --base A --head B --json
+    detect  ->  entire graph capabilities --json   (inventory-only languages have no relations)
+    stats   ->  entire graph stats --repo .        (human-facing token-savings report; not part of your workflow — do not run it unless asked)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,3 +236,10 @@ Before reporting completion, confirm that the diff is focused, tests and
 checks for the changed paths passed (or their limitations are explicit),
 generated output is synchronized, the release requirement is satisfied, and
 `git status --short --branch` shows only intended files on the feature branch.
+
+<!-- entire-graph:begin -->
+This repo has the entire-graph code graph installed. Before exploring code with
+grep/find/whole-file reads, read .entire/graph-agent.md — resolution-first guidance
+for using graph retrieval, focused source inspection, and verification.
+@.entire/graph-agent.md
+<!-- entire-graph:end -->


### PR DESCRIPTION
> *This was generated by AI during triage.* (tooling change, not triage)

Installs **entire-graph** (local, no-egress code-graph search) as the agent-first exploration layer for this repo.

## Primary changes
- `AGENTS.md`: search-first instruction pointing agents at the graph before grep/find/whole-file reads
- `.entire/graph-agent.md` (new): operating guide — `entire graph search/impact` workflow, hard rules, verification
- Binary lives in `~/go/bin/entire-graph` / `entire` CLI + `graph` plugin (registered via `entire plugin install`); no repo runtime dependency
- Cache is external (`~/.cache/entire-graph`, ~1MB), not committed

## Reviewer walkthrough

- Read `AGENTS.md` for the pointer, then `.entire/graph-agent.md` for the graph workflow.
- For locate, fix, and change tasks, run the natural-language graph search first, inspect focused source around the result, and use impact or neighbors only for concrete questions.
- Make the smallest complete edit and run focused verification.

## Correctness and invariants

- The graph CLI and cache remain external to the repository; this change adds no runtime dependency or network egress.
- Graph output is evidence rather than an oracle; focused source inspection and verification remain required.

## Testing and QA
- `entire-graph search --query \"HTTP 409 conflict message for create body measurement that already exists\"` → top hit was `getStatusErrorMessage` (error-policy.ts), exactly the #1072 fix site, + related sites + covering tests
- `impact --symbol getStatusErrorMessage` → 5 callers, 2 co-change files (error-handler.test.ts co-changes 5x)
- Index: 508 files, 6,040 symbols, 16,069 relations, 0 parse failures
- `check:changeset` passes (repo-only change, no changeset)

**Out of scope**
- Installing the `entire` CLI login (auth flow is manual, Christoph doing it)
- Claude Code status-line badge (we don't run Claude Code)

## Summary by Sourcery

Guide coding agents to use the local entire-graph index for focused code exploration before making and verifying changes.

New Features:
- Add agent guidance for using the local entire-graph code graph as the first step when exploring unfamiliar code.

Enhancements:
- Integrate entire-graph search, impact analysis, and verification practices into the repository's coding-agent instructions.

Documentation:
- Document the entire-graph workflow, usage rules, and cases where graph exploration can be skipped.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Integrate entire-graph code retrieval system into agent workflow by adding deterministic graph search instructions and documentation.

Main changes:
- Created `.entire/graph-agent.md` with mandatory search-first workflow and hard rules for code location and verification
- Added reference documentation for entire-graph CLI commands (search, impact, neighbors, diff, capabilities, stats)
- Appended entire-graph disclosure and guidance link to `AGENTS.md` to direct agents to graph-based exploration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using the project’s code graph tools during development.
  - Documented recommended workflows for locating relevant code, reviewing impacts, checking callers, inspecting changes, and verifying available capabilities.
  - Clarified when conventional code search and exploration methods should be used instead.
  - Updated contributor instructions to reference the new code-navigation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->