### PR TITLE
feat: add Effect service layer

### DIFF
--- a/.changeset/typed-layers-compose.md
+++ b/.changeset/typed-layers-compose.md
@@ -1,6 +1,4 @@
 ---
-"@hevy-mcp/hevy-client": patch
-"@hevy-mcp/operations": patch
 "@hevy-mcp/core": patch
 "hevy-mcp": patch
 "@hevy-mcp/worker": patch

--- a/.changeset/typed-layers-compose.md
+++ b/.changeset/typed-layers-compose.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Add a typed Effect service layer for incremental dependency-injection adoption.

--- a/packages/core/src/effect-layer.ts
+++ b/packages/core/src/effect-layer.ts
@@ -31,7 +31,12 @@ export function createCoreServiceLayer({
 	catalog,
 	execution,
 	operations = createOperations(client),
-}: CoreServiceLayerOptions) {
+}: CoreServiceLayerOptions): Layer.Layer<
+	| HevyClientService
+	| HevyOperationsService
+	| ExerciseTemplateCatalogService
+	| ToolExecutionContextService
+> {
 	return Layer.mergeAll(
 		Layer.succeed(HevyClientService, client),
 		Layer.succeed(HevyOperationsService, operations),
@@ -40,6 +45,8 @@ export function createCoreServiceLayer({
 	);
 }
 
-export function createToolObserverLayer(observer: ToolObserver) {
+export function createToolObserverLayer(
+	observer: ToolObserver,
+): Layer.Layer<ToolObserverService> {
 	return Layer.succeed(ToolObserverService, observer);
 }

--- a/packages/core/src/effect-layer.ts
+++ b/packages/core/src/effect-layer.ts
@@ -1,0 +1,45 @@
+import { Layer } from "effect";
+import type { HevyClient } from "@hevy-mcp/hevy-client";
+import { createOperations, type HevyOperations } from "@hevy-mcp/operations";
+import {
+	ExerciseTemplateCatalogService,
+	HevyClientService,
+	HevyOperationsService,
+	ToolExecutionContextService,
+	ToolObserverService,
+} from "./effect-services.js";
+import type { ToolExecutionContext } from "./execution.js";
+import type { ToolObserver } from "./observation.js";
+import type { ExerciseTemplateCatalog } from "./utils/exercise-template-catalog.js";
+
+export interface CoreServiceLayerOptions {
+	readonly client: HevyClient;
+	readonly catalog: ExerciseTemplateCatalog;
+	readonly execution: ToolExecutionContext;
+	readonly operations?: HevyOperations;
+}
+
+/**
+ * Build the runtime-neutral dependency graph for an Effect program.
+ *
+ * This is deliberately additive: current MCP registration still uses
+ * ToolRuntime, while new code can request these services without constructing
+ * a parallel container or binding client argument positions through a Proxy.
+ */
+export function createCoreServiceLayer({
+	client,
+	catalog,
+	execution,
+	operations = createOperations(client),
+}: CoreServiceLayerOptions) {
+	return Layer.mergeAll(
+		Layer.succeed(HevyClientService, client),
+		Layer.succeed(HevyOperationsService, operations),
+		Layer.succeed(ExerciseTemplateCatalogService, catalog),
+		Layer.succeed(ToolExecutionContextService, execution),
+	);
+}
+
+export function createToolObserverLayer(observer: ToolObserver) {
+	return Layer.succeed(ToolObserverService, observer);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,3 +85,8 @@ export {
 	ToolExecutionContextService,
 	ToolObserverService,
 } from "./effect-services.js";
+export {
+	createCoreServiceLayer,
+	createToolObserverLayer,
+	type CoreServiceLayerOptions,
+} from "./effect-layer.js";


### PR DESCRIPTION
## Primary changes
- add a typed Layer for client, operations, catalog, and execution services
- add an observer Layer for optional instrumentation
- preserve ToolRuntime and existing Promise-based dispatch while establishing the DI seam


## Reviewer walkthrough
- `packages/core/src/effect-layer.ts` adds the core service-layer factory and the optional tool-observer layer.
- `packages/core/src/index.ts` exports both layer factories and `CoreServiceLayerOptions`.
- `.changeset/typed-layers-compose.md` records the release metadata for the Effect layer adoption.

## Correctness and invariants
- The core layer provides client, operations, catalog, and execution services; callers may override operations or use the client-derived default.
- Existing `ToolRuntime` and Promise-based dispatch remain unchanged, and observer instrumentation remains opt-in.

## Testing and QA
- focused core execution tests
- `pnpm run test:unit`
- package type checks
- formatter and lint checks

## Summary by Sourcery

Introduce composable typed Effect layers as an additive dependency-injection seam for core services.

New Features:
- Add typed Effect service-layer factories for core client, operations, catalog, execution, and optional observer services.

Enhancements:
- Enable incremental dependency-injection adoption while preserving the existing ToolRuntime and Promise-based dispatch APIs.

Chores:
- Add patch release metadata for the affected packages.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Create a typed Effect service layer enabling incremental dependency-injection adoption for core services.

Main changes:
- Introduced `createCoreServiceLayer()` function to build Effect Layer with HevyClient, operations, catalog, and execution context services
- Added `createToolObserverLayer()` factory for ToolObserver service composition
- Exported service layer utilities and options interface from core package

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->