### PR TITLE
test: isolate client retry schedule #1105

### DIFF
--- a/.changeset/isolate-retry-schedule-state.md
+++ b/.changeset/isolate-retry-schedule-state.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Isolate Effect retry schedule state so concurrent and sequential requests keep independent retry indexes.

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -1066,19 +1066,6 @@ function createNativeClient(
 ): KubbClient {
 	const fetchImplementation = options.fetch ?? globalThis.fetch;
 	const maxGetRetries = normalizeMaxGetRetries(options.maxGetRetries);
-	const scheduleStep = Effect.runSync(
-		Schedule.toStep(
-			createRetrySchedule(
-				maxGetRetries,
-				DEFAULT_RETRY_POLICY,
-				boundedRandomInt,
-			),
-		),
-	);
-	const retryDelayStep = (
-		now: number,
-		input: Pick<HevyHttpError, "status" | "headers">,
-	) => Effect.runPromise(scheduleStep(now, input));
 	const timeoutMs = normalizePositiveInteger(
 		options.timeoutMs,
 		DEFAULT_API_TIMEOUT_MS,
@@ -1112,6 +1099,22 @@ function createNativeClient(
 			operationStartedAt + operationTimeoutMs * (maxGetRetries + 1);
 		const operationDeadline =
 			normalized.hevyDeadline ?? deadline + operationTimeoutMs;
+		// Schedule steps are stateful. Construct this one inside each logical
+		// request so sequential and concurrent requests never share retry
+		// indexes or delay state.
+		const scheduleStep = Effect.runSync(
+			Schedule.toStep(
+				createRetrySchedule(
+					maxGetRetries,
+					DEFAULT_RETRY_POLICY,
+					boundedRandomInt,
+				),
+			),
+		);
+		const retryDelayStep = (
+			now: number,
+			input: Pick<HevyHttpError, "status" | "headers">,
+		) => Effect.runPromise(scheduleStep(now, input));
 		let executionSignal = createExecutionSignal({
 			signal: normalized.signal,
 			deadline,

--- a/packages/hevy-client/src/request-local-retry-state.test.ts
+++ b/packages/hevy-client/src/request-local-retry-state.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createHevyClient } from "./hevy-client.js";
+import {
+	HEVY_REQUEST_ABORTED_ERROR_CODE,
+	HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+} from "./hevy-http-error.js";
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { readonly [key: string]: JsonValue };
+
+function requestUrl(input: RequestInfo | URL): string {
+	if (input instanceof URL) return input.href;
+	if (input instanceof Request) return input.url;
+	return input;
+}
+
+function response(data: JsonObject, status = 200): Response {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("request-local retry state", () => {
+	it("resets retry indexes for sequential logical requests", async () => {
+		const starts: number[] = [];
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(response({}, 503))
+			.mockResolvedValueOnce(response({ request: 1 }))
+			.mockResolvedValueOnce(response({}, 503))
+			.mockResolvedValueOnce(response({ request: 2 }));
+		const client = createHevyClient({
+			apiKey: "test-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			sleep: async () => {},
+			onRequestStart: ({ retryCount }) => {
+				starts.push(retryCount);
+			},
+		});
+
+		await expect(client.getUserInfo()).resolves.toEqual({ request: 1 });
+		await expect(client.getUserInfo()).resolves.toEqual({ request: 2 });
+
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+		expect(starts).toEqual([0, 1, 0, 1]);
+	});
+
+	it("keeps retry indexes and budgets isolated for concurrent requests", async () => {
+		const starts: Array<{ endpoint: string; retryCount: number }> = [];
+		const attemptsByEndpoint = new Map<string, number>();
+		const fetchMock = vi.fn((input: RequestInfo | URL) => {
+			const endpoint = new URL(requestUrl(input)).pathname;
+			const attempt = (attemptsByEndpoint.get(endpoint) ?? 0) + 1;
+			attemptsByEndpoint.set(endpoint, attempt);
+			return Promise.resolve(
+				attempt === 1 ? response({}, 503) : response({ endpoint }),
+			);
+		});
+		const client = createHevyClient({
+			apiKey: "test-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			sleep: async () => {},
+			onRequestStart: ({ endpoint, retryCount }) => {
+				starts.push({ endpoint, retryCount });
+			},
+		});
+
+		const [workouts, routines] = await Promise.all([
+			client.getWorkouts(),
+			client.getRoutines(),
+		]);
+
+		expect(workouts).toEqual({ endpoint: "/v1/workouts" });
+		expect(routines).toEqual({ endpoint: "/v1/routines" });
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+		expect(
+			starts.map(({ retryCount }) => retryCount).sort((a, b) => a - b),
+		).toEqual([0, 0, 1, 1]);
+	});
+
+	it.each([
+		["fractional values floor to zero", 0.9, 1],
+		["negative values use the default", -1, 4],
+	])("normalizes retry option: %s", async (_label, maxGetRetries, calls) => {
+		const fetchMock = vi.fn().mockResolvedValue(response({}, 503));
+		const client = createHevyClient({
+			apiKey: "test-key",
+			fetch: fetchMock,
+			maxGetRetries,
+			sleep: async () => {},
+		});
+
+		await expect(client.getUserInfo()).rejects.toMatchObject({
+			code: HEVY_RETRY_EXHAUSTED_ERROR_CODE,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(calls);
+	});
+
+	it("does not let cancellation of one request cancel a concurrent request", async () => {
+		const controller = new AbortController();
+		let cancelledStarted!: () => void;
+		const cancelledRequestStarted = new Promise<void>((resolve) => {
+			cancelledStarted = resolve;
+		});
+		const fetchMock = vi.fn(
+			(input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+				const endpoint = new URL(requestUrl(input)).pathname;
+				if (endpoint === "/v1/workouts/cancelled-id") {
+					cancelledStarted();
+					return new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener(
+							"abort",
+							() => reject(init.signal?.reason),
+							{ once: true },
+						);
+					});
+				}
+				return Promise.resolve(response({ recovered: true }));
+			},
+		);
+		const client = createHevyClient({
+			apiKey: "test-key",
+			fetch: fetchMock,
+			maxGetRetries: 1,
+			onRequestStart: () => ({ finish: vi.fn() }),
+		});
+
+		const cancelled = client.getWorkout("cancelled-id", {
+			signal: controller.signal,
+		});
+		await cancelledRequestStarted;
+		const successful = client.getUserInfo();
+		controller.abort(new DOMException("cancelled", "AbortError"));
+
+		await expect(cancelled).rejects.toMatchObject({
+			code: HEVY_REQUEST_ABORTED_ERROR_CODE,
+		});
+		await expect(successful).resolves.toEqual({ recovered: true });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Primary changes
Isolates Hevy client retry schedule state per request so concurrent calls do not share retry timers or attempt counters.

## Reviewer walkthrough
- Moves retry schedule construction into each logical client request in `packages/hevy-client/src/hevy-client-kubb.ts`.
- Adds coverage in `packages/hevy-client/src/request-local-retry-state.test.ts` for sequential and concurrent retry-state isolation, retry-option normalization, and independent cancellation.

## Correctness and invariants
- Each logical request owns its retry schedule, retry indexes, and cancellation state; sequential and concurrent calls cannot leak retry state.
- Existing retry behavior remains bounded by `maxGetRetries`, with invalid negative and fractional values normalized as covered by tests.

## Testing and QA
- `mise exec -- pnpm run test:unit`
- Pre-push `repository:pre-push` passed on push

This is stack PR 2/4. Base is `feat/effect-pure-operations` (#1104). Do not merge into `main` until the stack below it lands.

## Stack
1. #1104 `feat/effect-pure-operations` → `main` (Effect foundation)
2. **This PR** `test/isolate-client-retry-schedule` → `feat/effect-pure-operations`
3. `feat/effect-request-primitives` → this branch
4. `feat/effect-retry-interpreter` → request primitives

## Summary by Sourcery

Make client retries request-local so independent requests remain isolated and predictable.

Bug Fixes:
- Isolate retry schedule state per logical request so sequential and concurrent client calls no longer share retry indexes, budgets, timers, or cancellation state.

Enhancements:
- Normalize retry configuration consistently for fractional and negative values while preserving bounded retry behavior.

Tests:
- Add coverage for sequential and concurrent retry isolation, retry-option normalization, and independent request cancellation.

Chores:
- Publish patch releases for the affected Hevy MCP and CLI packages.

Refs #1105
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Isolate the retry schedule state in `createNativeClient` to ensure each request has an independent retry index.

Main changes:
- Moved `scheduleStep` and `retryDelayStep` initialization inside the request execution block
- Added `request-local-retry-state.test.ts` to verify isolation for sequential and concurrent requests
- Updated changesets to include patch versions for affected @hevy-mcp packages and hevy-cli

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

Refs #1105