### PR TITLE
feat: add Effect request primitives

### DIFF
--- a/packages/hevy-client/src/attempt.ts
+++ b/packages/hevy-client/src/attempt.ts
@@ -1,0 +1,72 @@
+import { Data, Effect } from "effect";
+
+import type {
+	HevyCommitState,
+	HevyOperationSafety,
+	HevyRequestPhase,
+} from "./execution.js";
+
+export interface AttemptFailureOptions {
+	readonly cause: unknown;
+	readonly method: string;
+	readonly endpoint: string;
+	readonly phase: HevyRequestPhase;
+	readonly operationSafety: HevyOperationSafety;
+	readonly commitState: HevyCommitState;
+	readonly responseConfirmed: boolean;
+	readonly deadline?: number;
+	readonly retryCount: number;
+}
+
+/** Typed internal channel for a dispatch or response-consumption failure. */
+export class AttemptFailure extends Data.TaggedError("AttemptFailure")<{
+	readonly cause: unknown;
+	readonly method: string;
+	readonly endpoint: string;
+	readonly phase: HevyRequestPhase;
+	readonly operationSafety: HevyOperationSafety;
+	readonly commitState: HevyCommitState;
+	readonly responseConfirmed: boolean;
+	readonly deadline?: number;
+	readonly retryCount: number;
+}> {}
+
+/**
+ * Adapt one asynchronous attempt to Effect while retaining the metadata
+ * needed by the transition policy if the adapter itself throws.
+ */
+export function attemptEffect<A>(
+	options: AttemptFailureOptions & {
+		readonly run: (signal: AbortSignal) => Promise<A>;
+	},
+): Effect.Effect<A, AttemptFailure> {
+	return Effect.tryPromise({
+		try: options.run,
+		catch: (cause) =>
+			new AttemptFailure({
+				cause,
+				method: options.method,
+				endpoint: options.endpoint,
+				phase: options.phase,
+				operationSafety: options.operationSafety,
+				commitState: options.commitState,
+				responseConfirmed: options.responseConfirmed,
+				deadline: options.deadline,
+				retryCount: options.retryCount,
+			}),
+	});
+}
+
+/** Make observer and resource finalizers idempotent at their Effect seam. */
+export function finalizeOnce(finalizer: () => void): () => void {
+	let finalized = false;
+	return () => {
+		if (finalized) return;
+		finalized = true;
+		try {
+			finalizer();
+		} catch {
+			// Resource finalization is best-effort and cannot replace settlement.
+		}
+	};
+}

--- a/packages/hevy-client/src/backoff.test.ts
+++ b/packages/hevy-client/src/backoff.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
+
+import {
+	customPromiseSleep,
+	effectClockSleep,
+	retryBackoff,
+} from "./backoff.js";
+
+describe("Effect retry backoff primitives", () => {
+	it("uses the provided Effect TestClock for the default wait", async () => {
+		const controller = new AbortController();
+		const program = Effect.gen(function* () {
+			const fiber = yield* effectClockSleep(1_000, controller.signal).pipe(
+				Effect.forkChild,
+			);
+			yield* TestClock.adjust("1 second");
+			yield* Fiber.join(fiber);
+			return true;
+		});
+
+		await expect(
+			Effect.runPromise(Effect.provide(program, TestClock.layer())),
+		).resolves.toBe(true);
+	});
+
+	it("captures synchronous custom sleep throws as typed backoff failures", async () => {
+		const controller = new AbortController();
+		const result = await Effect.runPromiseExit(
+			retryBackoff({
+				delayMs: 1,
+				signal: controller.signal,
+				sleep: () => {
+					throw new Error("sleep failed");
+				},
+				cause: undefined,
+				method: "GET",
+				endpoint: "/v1/workouts",
+				phase: "backoff",
+				operationSafety: "read",
+			}),
+		);
+
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("keeps a non-cooperative custom sleep interruptible", async () => {
+		const controller = new AbortController();
+		const fiber = await Effect.runPromise(
+			customPromiseSleep(
+				60_000,
+				controller.signal,
+				() => new Promise(() => {}),
+			).pipe(Effect.forkChild),
+		);
+		await Effect.runPromise(Fiber.interrupt(fiber));
+		expect(fiber).toBeDefined();
+	});
+});

--- a/packages/hevy-client/src/backoff.ts
+++ b/packages/hevy-client/src/backoff.ts
@@ -1,0 +1,153 @@
+import { Data, Duration, Effect } from "effect";
+
+import type { HevyOperationSafety } from "./execution.js";
+
+export interface BackoffFailureOptions {
+	readonly cause: unknown;
+	readonly method: string;
+	readonly endpoint: string;
+	readonly phase: "backoff";
+	readonly operationSafety: HevyOperationSafety;
+	readonly deadline?: number;
+}
+
+/** Internal typed failure used while adapting a retry wait. */
+export class BackoffFailure extends Data.TaggedError("BackoffFailure")<{
+	readonly cause: unknown;
+	readonly method: string;
+	readonly endpoint: string;
+	readonly phase: "backoff";
+	readonly operationSafety: HevyOperationSafety;
+	readonly deadline?: number;
+}> {}
+
+function interruptionEffect(
+	signal: AbortSignal,
+): Effect.Effect<never, unknown> {
+	return Effect.callback<never, unknown>((resume, interruptionSignal) => {
+		const cleanup = () => {
+			signal.removeEventListener("abort", fail);
+			interruptionSignal.removeEventListener("abort", cleanup);
+		};
+		const fail = () =>
+			resume(
+				Effect.fail(
+					signal.reason ?? new DOMException("Operation canceled", "AbortError"),
+				),
+			);
+		if (signal.aborted) {
+			fail();
+			return;
+		}
+		signal.addEventListener("abort", fail, { once: true });
+		interruptionSignal.addEventListener("abort", cleanup, { once: true });
+		return Effect.sync(cleanup);
+	}).pipe(Effect.interruptible);
+}
+
+/**
+ * Wait using the Effect Clock while still observing the operation signal.
+ * This is deliberately separate from the Promise adapter so TestClock can
+ * control the actual production retry wait.
+ */
+export function effectClockSleep(
+	delayMs: number,
+	signal: AbortSignal,
+): Effect.Effect<void, unknown> {
+	if (signal.aborted) {
+		return Effect.fail(
+			signal.reason ?? new DOMException("Operation canceled", "AbortError"),
+		);
+	}
+	const sleep = Effect.sleep(Duration.millis(Math.max(0, delayMs)));
+	return Effect.raceFirst(sleep, interruptionEffect(signal)).pipe(
+		Effect.asVoid,
+	);
+}
+
+/**
+ * Adapt the established Promise sleep hook to an interruptible Effect.
+ * Synchronous throws are captured by tryPromise just like rejections.
+ */
+export function customPromiseSleep(
+	delayMs: number,
+	signal: AbortSignal,
+	sleep: (milliseconds: number, signal?: AbortSignal) => Promise<void>,
+): Effect.Effect<void, unknown> {
+	return Effect.tryPromise({
+		try: (interruptionSignal) => {
+			if (signal.aborted) {
+				return Promise.reject(
+					signal.reason ?? new DOMException("Operation canceled", "AbortError"),
+				);
+			}
+			return new Promise<void>((resolve, reject) => {
+				let settled = false;
+				const cleanup = () => {
+					signal.removeEventListener("abort", onOperationAbort);
+					interruptionSignal.removeEventListener("abort", onInterruptionAbort);
+				};
+				const settleReject = (cause: unknown) => {
+					if (settled) return;
+					settled = true;
+					cleanup();
+					reject(cause);
+				};
+				const onOperationAbort = () =>
+					settleReject(
+						signal.reason ??
+							new DOMException("Operation canceled", "AbortError"),
+					);
+				const onInterruptionAbort = () =>
+					settleReject(new DOMException("Effect interrupted", "AbortError"));
+				signal.addEventListener("abort", onOperationAbort, { once: true });
+				interruptionSignal.addEventListener("abort", onInterruptionAbort, {
+					once: true,
+				});
+				if (signal.aborted) {
+					onOperationAbort();
+					return;
+				}
+				try {
+					Promise.resolve(sleep(delayMs, signal)).then(() => {
+						if (settled) return;
+						settled = true;
+						cleanup();
+						resolve();
+					}, settleReject);
+				} catch (cause) {
+					settleReject(cause);
+				}
+			});
+		},
+		catch: (cause) => cause,
+	});
+}
+
+export function retryBackoff(
+	options: BackoffFailureOptions & {
+		readonly delayMs: number;
+		readonly sleep?: (
+			milliseconds: number,
+			signal?: AbortSignal,
+		) => Promise<void>;
+		readonly signal: AbortSignal;
+	},
+): Effect.Effect<void, BackoffFailure> {
+	const wait = options.sleep
+		? customPromiseSleep(options.delayMs, options.signal, options.sleep)
+		: effectClockSleep(options.delayMs, options.signal);
+	return wait.pipe(
+		Effect.mapError(
+			(cause) =>
+				new BackoffFailure({
+					cause,
+					method: options.method,
+					endpoint: options.endpoint,
+					phase: "backoff",
+					operationSafety: options.operationSafety,
+					deadline: options.deadline,
+				}),
+		),
+	);
+}

--- a/packages/hevy-client/src/execution.ts
+++ b/packages/hevy-client/src/execution.ts
@@ -116,6 +116,7 @@ export function createExecutionSignal(
 ): HevyExecutionSignal {
 	const controller = new AbortController();
 	let deadlineTriggered = false;
+	let cleaned = false;
 	const abortFromCaller = () => {
 		if (!controller.signal.aborted) controller.abort(control.signal?.reason);
 	};
@@ -140,6 +141,8 @@ export function createExecutionSignal(
 			if (!controller.signal.aborted) controller.abort(reason);
 		},
 		cleanup: () => {
+			if (cleaned) return;
+			cleaned = true;
 			if (timer !== undefined) clearTimeout(timer);
 			control.signal?.removeEventListener("abort", abortFromCaller);
 		},

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -608,13 +608,13 @@ type RequestAttemptOutcome<TData> =
 	| {
 			readonly ok: true;
 			readonly result: ResponseConfig<TData>;
-	  }
+		}
 	| {
 			readonly ok: false;
 			readonly cause: unknown;
 			readonly phase: HevyRequestPhase;
 			readonly responseConfirmed: boolean;
-	  };
+		};
 
 /** Execute one dispatch/response attempt and retain its safe phase state. */
 async function executeRequestAttempt<TData>(
@@ -1333,7 +1333,9 @@ export function createNativeClient(
 						}),
 						Effect.ensuring(Effect.sync(finishWait)),
 					);
-					yield* startRequestObservationEffect(observationScope, wait);
+					yield* startRequestObservationEffect(observationScope, wait).pipe(
+						Effect.ensuring(Effect.sync(finishWait)),
+					);
 				}
 			}
 		}).pipe(Effect.ensuring(Effect.sync(() => executionSignal.cleanup())));

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Duration, Effect, Schedule } from "effect";
+import type * as Pull from "effect/Pull";
 
 const objectSchema = z.object({}).passthrough();
 const numberSchema = z.number();
@@ -78,6 +79,8 @@ import {
 } from "./execution.js";
 import { DEFAULT_RETRY_POLICY } from "./retry-policy.js";
 import { createRetrySchedule } from "./retry-schedule.js";
+import { BackoffFailure, retryBackoff } from "./backoff.js";
+import { attemptEffect, finalizeOnce } from "./attempt.js";
 export interface HevyClientLogEvent {
 	readonly level: "debug" | "warning" | "error";
 	readonly logger: "hevy-api";
@@ -98,6 +101,10 @@ type KubbClient = {
 	<TData, _TError = unknown, TVariables = unknown>(
 		config: RequestConfig<TVariables> & InternalRequestControl,
 	): Promise<ResponseConfig<TData>>;
+	/** Internal seam for deterministic Effect runtime tests. */
+	requestEffect: <TData, TVariables = unknown>(
+		config: RequestConfig<TVariables> & InternalRequestControl,
+	) => Effect.Effect<ResponseConfig<TData>, unknown>;
 	getConfig: () => Partial<RequestConfig<unknown>>;
 	setConfig: (config: RequestConfig) => Partial<RequestConfig<unknown>>;
 };
@@ -210,44 +217,6 @@ function normalizeMaxGetRetries(value: number | undefined) {
 	return value === undefined || !Number.isFinite(value) || value < 0
 		? MAX_GET_RETRIES
 		: Math.floor(value);
-}
-
-function defaultSleep(
-	milliseconds: number,
-	signal?: AbortSignal,
-): Promise<void> {
-	if (signal?.aborted) {
-		return Promise.reject(
-			signal.reason ?? new DOMException("Operation canceled", "AbortError"),
-		);
-	}
-	return new Promise((resolve, reject) => {
-		let settled = false;
-		let timer: ReturnType<typeof setTimeout> | undefined;
-		const cleanup = () => {
-			if (timer !== undefined) clearTimeout(timer);
-			signal?.removeEventListener("abort", onAbort);
-		};
-		const resolveSleep = () => {
-			if (settled) return;
-			settled = true;
-			cleanup();
-			resolve();
-		};
-		const rejectSleep = <T>(reason: T) => {
-			if (settled) return;
-			settled = true;
-			cleanup();
-			reject(reason);
-		};
-		const onAbort = () =>
-			rejectSleep(
-				signal?.reason ?? new DOMException("Operation canceled", "AbortError"),
-			);
-		timer = setTimeout(resolveSleep, Math.max(0, milliseconds));
-		signal?.addEventListener("abort", onAbort, { once: true });
-		if (signal?.aborted) onAbort();
-	});
 }
 
 function withTimeout<T>(
@@ -379,6 +348,22 @@ function runRequestObservation<T>(
 	}
 }
 
+function startRequestObservationEffect<E>(
+	scope: HevyRequestObservationScope | undefined,
+	operation: Effect.Effect<void, E>,
+): Effect.Effect<void, unknown> {
+	if (!scope?.run) return operation;
+	const run = (trackedOperation: () => Promise<void>) =>
+		scope.run?.(trackedOperation) ?? Promise.resolve();
+	// Observation scopes are Promise-based by contract. Start the scope with a
+	// settled no-op, then keep the actual wait in the surrounding Effect so
+	// there is no nested Effect runtime crossing.
+	return Effect.tryPromise({
+		try: () => run(() => Promise.resolve()),
+		catch: (cause) => cause,
+	}).pipe(Effect.asVoid, Effect.andThen(operation));
+}
+
 function emitRetryWait(
 	observer: HevyClientOptions["onRetryWait"],
 	observation: HevyRetryWait,
@@ -462,41 +447,10 @@ function isRetryable(error: HevyHttpError): boolean {
 	return isTransientRetryFailure(error.status, error.code);
 }
 
-async function waitForRetry(
-	delayMs: number,
-	signal: AbortSignal,
-	sleep: (milliseconds: number, signal?: AbortSignal) => Promise<void>,
-): Promise<void> {
-	if (signal.aborted) {
-		throw signal.reason ?? new DOMException("Operation canceled", "AbortError");
-	}
-	await new Promise<void>((resolve, reject) => {
-		let settled = false;
-		const onAbort = () => {
-			if (settled) return;
-			settled = true;
-			signal.removeEventListener("abort", onAbort);
-			reject(
-				signal.reason ?? new DOMException("Operation canceled", "AbortError"),
-			);
-		};
-		signal.addEventListener("abort", onAbort, { once: true });
-		void sleep(delayMs, signal).then(
-			() => {
-				if (settled) return;
-				settled = true;
-				signal.removeEventListener("abort", onAbort);
-				resolve();
-			},
-			(error) => {
-				if (settled) return;
-				settled = true;
-				signal.removeEventListener("abort", onAbort);
-				reject(error);
-			},
-		);
-	});
-}
+type RetryDelayStep = (
+	now: number,
+	input: Pick<HevyHttpError, "status" | "headers">,
+) => Pull.Pull<[number, Duration.Duration], never, number, never>;
 
 interface ExecutionErrorOptions {
 	method: string;
@@ -647,6 +601,7 @@ interface RequestAttemptExecutionOptions {
 	retryCount: number;
 	observationScope: HevyRequestObservationScope | undefined;
 	onRequestComplete: HevyClientOptions["onRequestComplete"];
+	onPhaseChange?: (phase: HevyRequestPhase) => void;
 }
 
 type RequestAttemptOutcome<TData> =
@@ -667,9 +622,16 @@ async function executeRequestAttempt<TData>(
 ): Promise<RequestAttemptOutcome<TData>> {
 	let phase: HevyRequestPhase = "before-dispatch";
 	let responseConfirmed = false;
+	const setPhase = (nextPhase: HevyRequestPhase) => {
+		phase = nextPhase;
+		options.onPhaseChange?.(nextPhase);
+	};
 	const attemptController = new AbortController();
 	const abortAttempt = () =>
 		attemptController.abort(options.executionSignal.reason);
+	const removeAbortAttempt = finalizeOnce(() =>
+		options.executionSignal.removeEventListener("abort", abortAttempt),
+	);
 	options.executionSignal.addEventListener("abort", abortAttempt, {
 		once: true,
 	});
@@ -701,10 +663,10 @@ async function executeRequestAttempt<TData>(
 						fetchImplementation(options.url, requestInit),
 					);
 				} catch (error) {
-					phase = "before-dispatch";
+					setPhase("before-dispatch");
 					throw error;
 				}
-				phase = "dispatch";
+				setPhase("dispatch");
 				const response = await withTimeout(
 					fetchPromise,
 					remainingDeadlineMs(options.attemptDeadline),
@@ -714,8 +676,8 @@ async function executeRequestAttempt<TData>(
 						),
 					attemptController.signal,
 				);
-				phase = "response-headers";
-				phase = "response-content";
+				setPhase("response-headers");
+				setPhase("response-content");
 				const data = await withTimeout(
 					parseResponseData(response),
 					remainingDeadlineMs(options.attemptDeadline),
@@ -769,7 +731,7 @@ async function executeRequestAttempt<TData>(
 	} catch (cause) {
 		return { ok: false, cause, phase, responseConfirmed };
 	} finally {
-		options.executionSignal.removeEventListener("abort", abortAttempt);
+		removeAbortAttempt();
 	}
 }
 
@@ -964,52 +926,55 @@ function emitTerminalFailureLog(
 	});
 }
 
-async function createRetryTransition(
+function createRetryTransitionEffect(
 	options: AttemptFailureTransitionOptions,
 	error: HevyHttpError,
-	retryDelayStep: (
-		now: number,
-		input: Pick<HevyHttpError, "status" | "headers">,
-	) => Promise<[number, Duration.Duration]>,
-): Promise<AttemptFailureTransition> {
+	retryDelayStep: RetryDelayStep,
+): Effect.Effect<AttemptFailureTransition, never> {
 	const retryCount = options.retryCount + 1;
-	const [, delay] = await retryDelayStep(Date.now(), error);
-	const delayMs = Duration.toMillis(delay);
-	emitClientLog(options.clientOptions.onLog, {
-		level: error.status === 429 ? "warning" : "debug",
-		logger: "hevy-api",
-		data: {
-			message: "Retrying Hevy API request",
-			status: error.status ?? null,
-			attempt: retryCount + 1,
-			maxAttempts: options.maxGetRetries + 1,
-			delayMs,
-			method: options.method,
-			endpoint: options.endpoint,
-		},
+	return Effect.matchCauseEffect(retryDelayStep(Date.now(), error), {
+		onFailure: () =>
+			Effect.succeed({
+				retry: false,
+				error,
+				retryCount: options.retryCount,
+			}),
+		onSuccess: ([, delay]) =>
+			Effect.sync(() => {
+				const delayMs = Duration.toMillis(delay);
+				emitClientLog(options.clientOptions.onLog, {
+					level: error.status === 429 ? "warning" : "debug",
+					logger: "hevy-api",
+					data: {
+						message: "Retrying Hevy API request",
+						status: error.status ?? null,
+						attempt: retryCount + 1,
+						maxAttempts: options.maxGetRetries + 1,
+						delayMs,
+						method: options.method,
+						endpoint: options.endpoint,
+					},
+				});
+				return {
+					retry: true,
+					error,
+					retryCount,
+					delayMs,
+					retryWaitScope: emitRetryWait(options.clientOptions.onRetryWait, {
+						method: options.method,
+						endpoint: options.endpoint,
+						retryCount,
+						delayMs,
+					}),
+				};
+			}),
 	});
-	return {
-		retry: true,
-		error,
-		retryCount,
-		delayMs,
-		retryWaitScope: emitRetryWait(options.clientOptions.onRetryWait, {
-			method: options.method,
-			endpoint: options.endpoint,
-			retryCount,
-			delayMs,
-		}),
-	};
 }
 
-/** Classify an attempt failure, emit its observation, and choose retry/backoff. */
-async function transitionAfterAttemptFailure(
+function transitionAfterAttemptFailureEffect(
 	options: AttemptFailureTransitionOptions,
-	retryDelayStep: (
-		now: number,
-		input: Pick<HevyHttpError, "status" | "headers">,
-	) => Promise<[number, Duration.Duration]>,
-): Promise<AttemptFailureTransition> {
+	retryDelayStep: RetryDelayStep,
+): Effect.Effect<AttemptFailureTransition, never> {
 	const failure = classifyExecutionFailure(
 		options.cause,
 		options.executionSignal.signal,
@@ -1050,16 +1015,16 @@ async function transitionAfterAttemptFailure(
 	emitRequestObservation(options.clientOptions.onRequestComplete, observation);
 	if (expectedReason || !safeToRetry || retryExhausted) {
 		emitTerminalFailureLog(options, error);
-		return {
+		return Effect.succeed({
 			retry: false,
 			error,
 			retryCount: options.retryCount,
-		};
+		});
 	}
-	return createRetryTransition(options, error, retryDelayStep);
+	return createRetryTransitionEffect(options, error, retryDelayStep);
 }
 
-function createNativeClient(
+export function createNativeClient(
 	apiKey: string,
 	baseUrl: string,
 	options: HevyClientOptions,
@@ -1070,12 +1035,11 @@ function createNativeClient(
 		options.timeoutMs,
 		DEFAULT_API_TIMEOUT_MS,
 	);
-	const sleep = options.sleep ?? defaultSleep;
 	let clientConfig: Partial<RequestConfig<unknown>> = { baseURL: baseUrl };
 
-	const client = (async <TData, _TError = unknown, TVariables = unknown>(
+	const createRequestEffect = <TData, TVariables = unknown>(
 		config: RequestConfig<TVariables> & InternalRequestControl,
-	): Promise<ResponseConfig<TData>> => {
+	): Effect.Effect<ResponseConfig<TData>, unknown> => {
 		const normalized = {
 			...clientConfig,
 			...config,
@@ -1099,22 +1063,6 @@ function createNativeClient(
 			operationStartedAt + operationTimeoutMs * (maxGetRetries + 1);
 		const operationDeadline =
 			normalized.hevyDeadline ?? deadline + operationTimeoutMs;
-		// Schedule steps are stateful. Construct this one inside each logical
-		// request so sequential and concurrent requests never share retry
-		// indexes or delay state.
-		const scheduleStep = Effect.runSync(
-			Schedule.toStep(
-				createRetrySchedule(
-					maxGetRetries,
-					DEFAULT_RETRY_POLICY,
-					boundedRandomInt,
-				),
-			),
-		);
-		const retryDelayStep = (
-			now: number,
-			input: Pick<HevyHttpError, "status" | "headers">,
-		) => Effect.runPromise(scheduleStep(now, input));
 		let executionSignal = createExecutionSignal({
 			signal: normalized.signal,
 			deadline,
@@ -1122,7 +1070,19 @@ function createNativeClient(
 		let retryCount = 0;
 		let deadlineRetryActive = false;
 
-		try {
+		const requestEffect = Effect.gen(function* () {
+			// Schedule steps are stateful. Construct this one inside each
+			// logical request so sequential and concurrent requests never share
+			// retry indexes or delay state.
+			const scheduleStep = yield* Schedule.toStep(
+				createRetrySchedule(
+					maxGetRetries,
+					DEFAULT_RETRY_POLICY,
+					boundedRandomInt,
+				),
+			);
+			const retryDelayStep: RetryDelayStep = (now, input) =>
+				scheduleStep(now, input);
 			while (true) {
 				const attemptDeadline = Math.min(
 					deadline,
@@ -1156,7 +1116,7 @@ function createNativeClient(
 							category: "NetworkError",
 						},
 					});
-					throw error;
+					return yield* Effect.fail(error);
 				}
 				const startedAt = Date.now();
 				const observationScope = emitRequestStart(options.onRequestStart, {
@@ -1164,25 +1124,123 @@ function createNativeClient(
 					endpoint,
 					retryCount,
 				});
-				const attempt = await executeRequestAttempt<TData>({
-					apiKey,
-					fetchImplementation,
-					normalized,
-					url,
+				let attemptPhase: HevyRequestPhase = "before-dispatch";
+				let attemptCompleted = false;
+				let attemptReturned = false;
+				const completeAttempt = (observation: HevyRequestObservation) => {
+					if (attemptCompleted) return;
+					attemptCompleted = true;
+					emitRequestObservation(options.onRequestComplete, observation);
+				};
+				const attemptClientOptions: HevyClientOptions = {
+					...options,
+					onRequestComplete: completeAttempt,
+				};
+				const attemptEffectProgram = attemptEffect({
 					method,
 					endpoint,
-					safety,
-					attemptDeadline,
-					executionSignal: executionSignal.signal,
-					startedAt,
+					phase: "dispatch",
+					operationSafety: safety,
+					commitState: "not_sent",
+					responseConfirmed: false,
+					deadline: attemptDeadline,
 					retryCount,
-					observationScope,
-					onRequestComplete: options.onRequestComplete,
+					cause: undefined,
+					run: (interruptionSignal) => {
+						const abortOnInterruption = () => {
+							const reason = interruptionSignal.reason;
+							executionSignal.abort(
+								reason instanceof Error || reason instanceof DOMException
+									? reason
+									: undefined,
+							);
+						};
+						const removeInterruption = finalizeOnce(() =>
+							interruptionSignal.removeEventListener(
+								"abort",
+								abortOnInterruption,
+							),
+						);
+						interruptionSignal.addEventListener("abort", abortOnInterruption, {
+							once: true,
+						});
+						return executeRequestAttempt<TData>({
+							apiKey,
+							fetchImplementation,
+							normalized,
+							url,
+							method,
+							endpoint,
+							safety,
+							attemptDeadline,
+							executionSignal: executionSignal.signal,
+							startedAt,
+							retryCount,
+							observationScope,
+							onRequestComplete: completeAttempt,
+							onPhaseChange: (phase) => {
+								attemptPhase = phase;
+							},
+						}).finally(() => {
+							attemptReturned = true;
+							removeInterruption();
+						});
+					},
 				});
+				const attempt = yield* attemptEffectProgram.pipe(
+					Effect.catchTag("AttemptFailure", (failure) =>
+						Effect.succeed({
+							ok: false as const,
+							cause: failure.cause,
+							phase: failure.phase,
+							responseConfirmed: failure.responseConfirmed,
+						}),
+					),
+					Effect.ensuring(
+						Effect.sync(() => {
+							if (attemptReturned || attemptCompleted) return;
+							const failure = classifyExecutionFailure(
+								undefined,
+								executionSignal.signal,
+								attemptDeadline,
+								executionSignal.deadlineTriggered() ||
+									isDeadlineExceeded(attemptDeadline),
+							);
+							const error = createExecutionError({
+								method,
+								endpoint,
+								safety,
+								phase: attemptPhase,
+								deadlineExceeded: failure.deadlineExceeded,
+								canceled: failure.canceled,
+								callerCanceled: failure.callerCanceled,
+								responseConfirmed: false,
+							});
+							const observation: HevyRequestObservation = {
+								method,
+								endpoint,
+								status: 0,
+								durationMs: Date.now() - startedAt,
+								retryCount,
+								outcome: error.outcome ?? "cancelled",
+								phase: error.phase,
+								operationSafety: safety,
+								commitState: error.commitState,
+								safeToRetry: false,
+								error: {
+									code: error.code,
+									category: "NetworkError",
+								},
+							};
+							finishRequestObservation(observationScope, observation);
+							completeAttempt(observation);
+						}),
+					),
+				);
 				if (attempt.ok) return attempt.result;
 				{
 					const { cause, phase, responseConfirmed } = attempt;
-					const transition = await transitionAfterAttemptFailure(
+					const transition = yield* transitionAfterAttemptFailureEffect(
 						{
 							cause,
 							method,
@@ -1199,18 +1257,19 @@ function createNativeClient(
 							deadlineRetryActive,
 							startedAt,
 							observationScope,
-							clientOptions: options,
+							clientOptions: attemptClientOptions,
 						},
 						retryDelayStep,
 					);
-					if (!transition.retry) throw transition.error;
+					if (!transition.retry) return yield* Effect.fail(transition.error);
 					retryCount = transition.retryCount;
 					if (transition.error.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE) {
 						// Skip the deadline retry when the caller supplied an
 						// explicit deadline — it is authoritative and no retry
 						// may extend beyond it. In that case operationDeadline
 						// equals deadline, leaving no fresh attempt budget.
-						if (operationDeadline <= deadline) throw transition.error;
+						if (operationDeadline <= deadline)
+							return yield* Effect.fail(transition.error);
 						executionSignal.cleanup();
 						deadline = Math.min(
 							Date.now() + operationTimeoutMs,
@@ -1225,55 +1284,67 @@ function createNativeClient(
 					}
 					const delayMs = transition.delayMs ?? 0;
 					const remaining = remainingDeadlineMs(deadline);
-					try {
-						await runRequestObservation(observationScope, () =>
-							waitForRetry(
-								Math.min(delayMs, Math.max(0, remaining)),
-								executionSignal.signal,
-								sleep,
-							),
-						);
-					} catch (waitError) {
-						const waitDeadlineExceeded =
-							executionSignal.deadlineTriggered() ||
-							isDeadlineExceeded(deadline);
-						const waitErrorResponse = createExecutionError({
-							method,
-							endpoint,
-							safety,
-							phase: "backoff",
-							deadlineExceeded: waitDeadlineExceeded,
-							canceled: !waitDeadlineExceeded,
-							callerCanceled:
-								!waitDeadlineExceeded && executionSignal.signal.aborted,
-							cause: waitError,
-						});
-						emitRequestObservation(options.onRequestComplete, {
-							method,
-							endpoint,
-							status: 0,
-							durationMs: Date.now() - startedAt,
-							retryCount,
-							outcome: waitErrorResponse.outcome ?? "cancelled",
-							phase: waitErrorResponse.phase,
-							operationSafety: safety,
-							commitState: waitErrorResponse.commitState,
-							safeToRetry: false,
-							error: {
-								code: waitErrorResponse.code,
-								category: "NetworkError",
-							},
-						});
-						throw waitErrorResponse;
-					} finally {
-						finishRetryWait(transition.retryWaitScope);
-					}
+					const finishWait = finalizeOnce(() =>
+						finishRetryWait(transition.retryWaitScope),
+					);
+					const wait = retryBackoff({
+						delayMs: Math.min(delayMs, Math.max(0, remaining)),
+						signal: executionSignal.signal,
+						sleep: options.sleep,
+						method,
+						endpoint,
+						phase: "backoff",
+						operationSafety: safety,
+						deadline,
+						cause: transition.error,
+					}).pipe(
+						Effect.mapError((failure: BackoffFailure) => {
+							const waitDeadlineExceeded =
+								executionSignal.deadlineTriggered() ||
+								isDeadlineExceeded(deadline);
+							const waitErrorResponse = createExecutionError({
+								method,
+								endpoint,
+								safety,
+								phase: "backoff",
+								deadlineExceeded: waitDeadlineExceeded,
+								canceled: !waitDeadlineExceeded,
+								callerCanceled:
+									!waitDeadlineExceeded && executionSignal.signal.aborted,
+								cause: failure.cause,
+							});
+							emitRequestObservation(options.onRequestComplete, {
+								method,
+								endpoint,
+								status: 0,
+								durationMs: Date.now() - startedAt,
+								retryCount,
+								outcome: waitErrorResponse.outcome ?? "cancelled",
+								phase: waitErrorResponse.phase,
+								operationSafety: safety,
+								commitState: waitErrorResponse.commitState,
+								safeToRetry: false,
+								error: {
+									code: waitErrorResponse.code,
+									category: "NetworkError",
+								},
+							});
+							return waitErrorResponse;
+						}),
+						Effect.ensuring(Effect.sync(finishWait)),
+					);
+					yield* startRequestObservationEffect(observationScope, wait);
 				}
 			}
-		} finally {
-			executionSignal.cleanup();
-		}
-	}) as KubbClient;
+		}).pipe(Effect.ensuring(Effect.sync(() => executionSignal.cleanup())));
+		return requestEffect;
+	};
+
+	const client = (<TData, _TError = unknown, TVariables = unknown>(
+		config: RequestConfig<TVariables> & InternalRequestControl,
+	): Promise<ResponseConfig<TData>> =>
+		Effect.runPromise(createRequestEffect(config))) as KubbClient;
+	client.requestEffect = createRequestEffect;
 
 	client.getConfig = () => ({ ...clientConfig });
 	client.setConfig = (config: RequestConfig) => {

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -608,13 +608,13 @@ type RequestAttemptOutcome<TData> =
 	| {
 			readonly ok: true;
 			readonly result: ResponseConfig<TData>;
-		}
+	  }
 	| {
 			readonly ok: false;
 			readonly cause: unknown;
 			readonly phase: HevyRequestPhase;
 			readonly responseConfirmed: boolean;
-		};
+	  };
 
 /** Execute one dispatch/response attempt and retain its safe phase state. */
 async function executeRequestAttempt<TData>(

--- a/packages/hevy-client/src/primitives.ts
+++ b/packages/hevy-client/src/primitives.ts
@@ -1,0 +1,14 @@
+/** Internal Effect request primitives, intentionally absent from package exports. */
+export {
+	AttemptFailure,
+	attemptEffect,
+	finalizeOnce,
+	type AttemptFailureOptions,
+} from "./attempt.js";
+export {
+	BackoffFailure,
+	customPromiseSleep,
+	effectClockSleep,
+	retryBackoff,
+	type BackoffFailureOptions,
+} from "./backoff.js";

--- a/packages/hevy-client/src/request-effect.test.ts
+++ b/packages/hevy-client/src/request-effect.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { Effect, Fiber } from "effect";
+import { TestClock } from "effect/testing";
+
+import { createNativeClient } from "./hevy-client-kubb.js";
+
+describe("internal production request Effect seam", () => {
+	it("routes default client backoff through TestClock", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("{}", { status: 503 }))
+			.mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+		const client = createNativeClient("test-key", "https://api.hevyapp.com", {
+			fetch: fetchMock,
+			maxGetRetries: 1,
+		});
+
+		const program = Effect.gen(function* () {
+			const fiber = yield* client
+				.requestEffect({ method: "GET", url: "/v1/user/info" })
+				.pipe(Effect.forkChild);
+			yield* Effect.yieldNow;
+			expect(fetchMock).toHaveBeenCalledOnce();
+			yield* TestClock.adjust("1 second");
+			const result = yield* Fiber.join(fiber);
+			expect(result.data).toEqual({ ok: true });
+		});
+
+		await Effect.runPromise(Effect.provide(program, TestClock.layer()));
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Primary changes
Adds Effect request primitives (`attemptEffect`, retry backoff, and an internal `requestEffect` seam) used by the retry interpreter. Native request/retry execution now runs through one Effect runtime boundary while preserving the public Promise client API.

This is stack PR 3/4. Base is `test/isolate-client-retry-schedule`. Do not merge into `main` until the stack below it lands.

## Stack
1. #1104 `feat/effect-pure-operations` → `main`
2. `test/isolate-client-retry-schedule` → #1104
3. **This PR** `feat/effect-request-primitives` → isolate-client-retry-schedule
4. `feat/effect-retry-interpreter` → this branch

## Reviewer walkthrough
- `attemptEffect` wraps asynchronous attempts with typed failure metadata, while `retryBackoff` adapts Effect Clock or the established Promise sleep hook with cancellation and interruption handling.
- `createNativeClient` constructs a request-local retry schedule and routes attempts, retry transitions, and waits through the Effect runtime.
- Execution-signal cleanup and request/retry observation finalizers are guarded so repeated cleanup is safe.

## Correctness and invariants
- Each logical request owns an independent retry schedule, so sequential and concurrent requests do not share retry indexes or delay state.
- The public Promise client remains compatible through `Effect.runPromise`, while the internal `requestEffect` seam supports deterministic `TestClock` execution.
- Attempt and backoff cancellation preserve request phase and failure metadata, and retry waits finalize their observation exactly once.

## Testing and QA
- `mise exec -- pnpm run test:unit`
- Pre-push `repository:pre-push` passed on push
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Migrate the request execution and retry logic to the Effect library to enable deterministic testing and better interruption control.

Main changes:
- Implemented `attemptEffect` and `retryBackoff` primitives for typed failure handling and sleep
- Exposed `requestEffect` on `KubbClient` to allow `TestClock` based asynchronous timing tests
- Replaced promise-based retry loops with an `Effect.gen` pipeline using `Schedule.toStep`

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

## Summary by Sourcery

Migrate native request and retry execution to Effect while maintaining the existing Promise client interface and improving deterministic timing and interruption control.

New Features:
- Add typed Effect primitives for asynchronous request attempts and retry backoff waits.
- Expose an internal request Effect seam while preserving the public Promise-based client API.
- Route native request execution and retry waits through a single Effect runtime boundary with per-request retry schedules.

Bug Fixes:
- Make execution-signal, attempt, and retry-wait cleanup idempotent to prevent duplicate finalization and observation callbacks.
- Preserve cancellation, interruption, phase, and failure metadata across request attempts and backoff waits.

Enhancements:
- Support deterministic retry timing through Effect TestClock and retain compatibility with the existing Promise sleep hook.

Tests:
- Add coverage for Effect-clock backoff, custom sleep failures, interruption of non-cooperative sleeps, and TestClock-controlled request retries.