### PR TITLE
refactor: complete Effect retry interpreter

### DIFF
--- a/.changeset/steady-effect-interpreter.md
+++ b/.changeset/steady-effect-interpreter.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Complete the request-local Effect retry interpreter while preserving client and adapter behavior.

--- a/packages/hevy-client/src/execution.ts
+++ b/packages/hevy-client/src/execution.ts
@@ -127,12 +127,14 @@ export function createExecutionSignal(
 	if (control.deadline !== undefined) {
 		const delay = Math.max(0, control.deadline - Date.now());
 		timer = setTimeout(() => {
+			// Preserve a caller cancellation already observed at this
+			// checkpoint. Otherwise a later deadline callback could
+			// reclassify the request after cancellation won the race.
+			if (controller.signal.aborted) return;
 			deadlineTriggered = true;
-			if (!controller.signal.aborted) {
-				controller.abort(
-					new DOMException("Operation deadline exceeded", "TimeoutError"),
-				);
-			}
+			controller.abort(
+				new DOMException("Operation deadline exceeded", "TimeoutError"),
+			);
 		}, delay);
 	}
 	return {

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Duration, Effect, Schedule } from "effect";
+import { Cause, Duration, Effect, Option, Schedule } from "effect";
 import type * as Pull from "effect/Pull";
 
 const objectSchema = z.object({}).passthrough();
@@ -224,6 +224,7 @@ function withTimeout<T>(
 	timeoutMs: number,
 	onTimeout: () => void,
 	signal?: AbortSignal,
+	onAbortOperation = onTimeout,
 ): Promise<T> {
 	const promise = new Promise<T>((resolve, reject) => {
 		let settled = false;
@@ -232,6 +233,7 @@ function withTimeout<T>(
 			settled = true;
 			if (timer !== undefined) clearTimeout(timer);
 			signal?.removeEventListener("abort", onAbort);
+			onAbortOperation();
 			reject(
 				signal?.reason ?? new DOMException("Operation canceled", "AbortError"),
 			);
@@ -348,22 +350,6 @@ function runRequestObservation<T>(
 	}
 }
 
-function startRequestObservationEffect<E>(
-	scope: HevyRequestObservationScope | undefined,
-	operation: Effect.Effect<void, E>,
-): Effect.Effect<void, unknown> {
-	if (!scope?.run) return operation;
-	const run = (trackedOperation: () => Promise<void>) =>
-		scope.run?.(trackedOperation) ?? Promise.resolve();
-	// Observation scopes are Promise-based by contract. Start the scope with a
-	// settled no-op, then keep the actual wait in the surrounding Effect so
-	// there is no nested Effect runtime crossing.
-	return Effect.tryPromise({
-		try: () => run(() => Promise.resolve()),
-		catch: (cause) => cause,
-	}).pipe(Effect.asVoid, Effect.andThen(operation));
-}
-
 function emitRetryWait(
 	observer: HevyClientOptions["onRetryWait"],
 	observation: HevyRetryWait,
@@ -426,14 +412,25 @@ function buildUrl(baseUrl: string, config: RequestConfig<unknown>): URL {
 	return url;
 }
 
-async function parseResponseData(response: Response): Promise<unknown> {
+async function parseResponseData(
+	response: Response,
+	onFailure?: () => void,
+): Promise<unknown> {
 	if ([204, 205, 304].includes(response.status) || !response.body) return {};
-	const text = await response.text();
-	if (!text) return {};
 	try {
-		return JSON.parse(text) as unknown;
-	} catch {
-		return text;
+		const text = await response.text();
+		if (!text) return {};
+		try {
+			return JSON.parse(text) as unknown;
+		} catch {
+			return text;
+		}
+	} catch (error) {
+		// A stream can be acquired before cancellation, deadline expiry, or
+		// interruption reaches the attempt. Explicitly release it, while
+		// preserving the original classified failure.
+		onFailure?.();
+		throw error;
 	}
 }
 
@@ -601,6 +598,8 @@ interface RequestAttemptExecutionOptions {
 	retryCount: number;
 	observationScope: HevyRequestObservationScope | undefined;
 	onRequestComplete: HevyClientOptions["onRequestComplete"];
+	onAttemptComplete?: (observation: HevyRequestObservation) => void;
+	onEffectInterruption?: () => void;
 	onPhaseChange?: (phase: HevyRequestPhase) => void;
 }
 
@@ -627,8 +626,10 @@ async function executeRequestAttempt<TData>(
 		options.onPhaseChange?.(nextPhase);
 	};
 	const attemptController = new AbortController();
-	const abortAttempt = () =>
+	const abortAttempt = () => {
 		attemptController.abort(options.executionSignal.reason);
+		options.onEffectInterruption?.();
+	};
 	const removeAbortAttempt = finalizeOnce(() =>
 		options.executionSignal.removeEventListener("abort", abortAttempt),
 	);
@@ -678,14 +679,15 @@ async function executeRequestAttempt<TData>(
 				);
 				setPhase("response-headers");
 				setPhase("response-content");
+				const cancelBody = finalizeOnce(() => {
+					void response.body?.cancel().catch(() => {});
+				});
 				const data = await withTimeout(
-					parseResponseData(response),
+					parseResponseData(response, cancelBody),
 					remainingDeadlineMs(options.attemptDeadline),
-					() =>
-						attemptController.abort(
-							new DOMException("Operation timed out", "TimeoutError"),
-						),
+					cancelBody,
 					attemptController.signal,
+					cancelBody,
 				);
 				if (!response.ok) {
 					throw new HevyHttpError(
@@ -717,8 +719,12 @@ async function executeRequestAttempt<TData>(
 					commitState: "confirmed",
 					safeToRetry: false,
 				};
-				finishRequestObservation(options.observationScope, observation);
-				emitRequestObservation(options.onRequestComplete, observation);
+				if (options.onAttemptComplete) {
+					options.onAttemptComplete(observation);
+				} else {
+					finishRequestObservation(options.observationScope, observation);
+					emitRequestObservation(options.onRequestComplete, observation);
+				}
 				return {
 					data: data as TData,
 					status: response.status,
@@ -752,8 +758,11 @@ interface AttemptFailureTransitionOptions {
 	maxGetRetries: number;
 	/** True only while executing the one allowed fresh-budget deadline retry. */
 	deadlineRetryActive?: boolean;
+	/** Explicit caller deadlines are authoritative and cannot be retried. */
+	allowDeadlineRetry: boolean;
 	startedAt: number;
 	observationScope: HevyRequestObservationScope | undefined;
+	onAttemptComplete: (observation: HevyRequestObservation) => void;
 	clientOptions: HevyClientOptions;
 }
 
@@ -799,7 +808,8 @@ function canRetryAttempt(
 	const deadlineRetry =
 		options.safety === "read" &&
 		options.retryCount === 0 &&
-		options.maxGetRetries > 0;
+		options.maxGetRetries > 0 &&
+		options.allowDeadlineRetry;
 	if (
 		failure.deadlineExceeded ||
 		error.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE
@@ -1011,14 +1021,28 @@ function transitionAfterAttemptFailureEffect(
 		retryExhausted,
 		expectedReason,
 	);
-	finishRequestObservation(options.observationScope, observation);
-	emitRequestObservation(options.clientOptions.onRequestComplete, observation);
+	options.onAttemptComplete(observation);
 	if (expectedReason || !safeToRetry || retryExhausted) {
 		emitTerminalFailureLog(options, error);
 		return Effect.succeed({
 			retry: false,
 			error,
 			retryCount: options.retryCount,
+		});
+	}
+	// A client-derived attempt deadline has a single fresh-budget read retry.
+	// It is intentionally not a scheduled retry: do not consume a schedule
+	// step, emit a backoff log, or open a retry-wait scope for this transition.
+	if (
+		error.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE &&
+		options.safety === "read" &&
+		options.retryCount === 0 &&
+		options.allowDeadlineRetry
+	) {
+		return Effect.succeed({
+			retry: true,
+			error,
+			retryCount: options.retryCount + 1,
 		});
 	}
 	return createRetryTransitionEffect(options, error, retryDelayStep);
@@ -1057,288 +1081,319 @@ export function createNativeClient(
 			normalized.hevyTimeoutMs,
 			timeoutMs,
 		);
-		const operationStartedAt = Date.now();
-		let deadline =
-			normalized.hevyDeadline ??
-			operationStartedAt + operationTimeoutMs * (maxGetRetries + 1);
-		const operationDeadline =
-			normalized.hevyDeadline ?? deadline + operationTimeoutMs;
-		let executionSignal = createExecutionSignal({
-			signal: normalized.signal,
-			deadline,
-		});
-		let retryCount = 0;
-		let deadlineRetryActive = false;
-
-		const requestEffect = Effect.gen(function* () {
-			// Schedule steps are stateful. Construct this one inside each
-			// logical request so sequential and concurrent requests never share
-			// retry indexes or delay state.
-			const scheduleStep = yield* Schedule.toStep(
-				createRetrySchedule(
-					maxGetRetries,
-					DEFAULT_RETRY_POLICY,
-					boundedRandomInt,
-				),
-			);
-			const retryDelayStep: RetryDelayStep = (now, input) =>
-				scheduleStep(now, input);
-			while (true) {
-				const attemptDeadline = Math.min(
-					deadline,
-					Date.now() + operationTimeoutMs,
+		const requestEffect = Effect.suspend(() => {
+			const operationStartedAt = Date.now();
+			let deadline =
+				normalized.hevyDeadline ??
+				operationStartedAt + operationTimeoutMs * (maxGetRetries + 1);
+			const operationDeadline =
+				normalized.hevyDeadline ?? deadline + operationTimeoutMs;
+			let executionSignal = createExecutionSignal({
+				signal: normalized.signal,
+				deadline,
+			});
+			let retryCount = 0;
+			let deadlineRetryActive = false;
+			let currentPhase: HevyRequestPhase = "before-dispatch";
+			return Effect.gen(function* () {
+				// Schedule steps are stateful. Construct this one inside each
+				// logical request so sequential and concurrent requests never share
+				// retry indexes or delay state.
+				const scheduleStep = yield* Schedule.toStep(
+					createRetrySchedule(
+						maxGetRetries,
+						DEFAULT_RETRY_POLICY,
+						boundedRandomInt,
+					),
 				);
-				const remaining = remainingDeadlineMs(attemptDeadline);
-				if (executionSignal.signal.aborted || remaining <= 0) {
-					const deadlineExceeded = remaining <= 0;
-					const error = createExecutionError({
+				const retryDelayStep: RetryDelayStep = (now, input) =>
+					scheduleStep(now, input);
+				while (true) {
+					currentPhase = "before-dispatch";
+					const attemptDeadline = Math.min(
+						deadline,
+						Date.now() + operationTimeoutMs,
+					);
+					const remaining = remainingDeadlineMs(attemptDeadline);
+					if (executionSignal.signal.aborted || remaining <= 0) {
+						const deadlineExceeded = remaining <= 0;
+						const error = createExecutionError({
+							method,
+							endpoint,
+							safety,
+							phase: "before-dispatch",
+							deadlineExceeded,
+							canceled: !deadlineExceeded,
+							callerCanceled:
+								!deadlineExceeded && executionSignal.signal.aborted,
+						});
+						emitRequestObservation(options.onRequestComplete, {
+							method,
+							endpoint,
+							status: 0,
+							durationMs: 0,
+							retryCount,
+							outcome: error.outcome ?? "cancelled",
+							phase: error.phase,
+							operationSafety: safety,
+							commitState: error.commitState,
+							safeToRetry: false,
+							error: {
+								code: error.code,
+								category: "NetworkError",
+							},
+						});
+						return yield* Effect.fail(error);
+					}
+					const startedAt = Date.now();
+					currentPhase = "before-dispatch";
+					const observationScope = emitRequestStart(options.onRequestStart, {
 						method,
 						endpoint,
-						safety,
-						phase: "before-dispatch",
-						deadlineExceeded,
-						canceled: !deadlineExceeded,
-						callerCanceled: !deadlineExceeded && executionSignal.signal.aborted,
-					});
-					emitRequestObservation(options.onRequestComplete, {
-						method,
-						endpoint,
-						status: 0,
-						durationMs: 0,
 						retryCount,
-						outcome: error.outcome ?? "cancelled",
-						phase: error.phase,
-						operationSafety: safety,
-						commitState: error.commitState,
-						safeToRetry: false,
-						error: {
-							code: error.code,
-							category: "NetworkError",
-						},
 					});
-					return yield* Effect.fail(error);
-				}
-				const startedAt = Date.now();
-				const observationScope = emitRequestStart(options.onRequestStart, {
-					method,
-					endpoint,
-					retryCount,
-				});
-				let attemptPhase: HevyRequestPhase = "before-dispatch";
-				let attemptCompleted = false;
-				let attemptReturned = false;
-				const completeAttempt = (observation: HevyRequestObservation) => {
-					if (attemptCompleted) return;
-					attemptCompleted = true;
-					emitRequestObservation(options.onRequestComplete, observation);
-				};
-				const attemptClientOptions: HevyClientOptions = {
-					...options,
-					onRequestComplete: completeAttempt,
-				};
-				const attemptEffectProgram = attemptEffect({
-					method,
-					endpoint,
-					phase: "dispatch",
-					operationSafety: safety,
-					commitState: "not_sent",
-					responseConfirmed: false,
-					deadline: attemptDeadline,
-					retryCount,
-					cause: undefined,
-					run: (interruptionSignal) => {
-						const abortOnInterruption = () => {
-							const reason = interruptionSignal.reason;
-							executionSignal.abort(
-								reason instanceof Error || reason instanceof DOMException
-									? reason
-									: undefined,
+					let attemptPhase: HevyRequestPhase = "before-dispatch";
+					let attemptCompleted = false;
+					let attemptReturned = false;
+					const completeAttempt = (observation: HevyRequestObservation) => {
+						if (attemptCompleted) return;
+						attemptCompleted = true;
+						finishRequestObservation(observationScope, observation);
+						emitRequestObservation(options.onRequestComplete, observation);
+					};
+					const attemptEffectProgram = attemptEffect({
+						method,
+						endpoint,
+						phase: "dispatch",
+						operationSafety: safety,
+						commitState: "not_sent",
+						responseConfirmed: false,
+						deadline: attemptDeadline,
+						retryCount,
+						cause: undefined,
+						run: (interruptionSignal) => {
+							const abortOnInterruption = () => {
+								const reason = interruptionSignal.reason;
+								executionSignal.abort(
+									reason instanceof Error || reason instanceof DOMException
+										? reason
+										: undefined,
+								);
+							};
+							const removeInterruption = finalizeOnce(() =>
+								interruptionSignal.removeEventListener(
+									"abort",
+									abortOnInterruption,
+								),
 							);
-						};
-						const removeInterruption = finalizeOnce(() =>
-							interruptionSignal.removeEventListener(
+							interruptionSignal.addEventListener(
 								"abort",
 								abortOnInterruption,
-							),
-						);
-						interruptionSignal.addEventListener("abort", abortOnInterruption, {
-							once: true,
-						});
-						return executeRequestAttempt<TData>({
-							apiKey,
-							fetchImplementation,
-							normalized,
-							url,
-							method,
-							endpoint,
-							safety,
-							attemptDeadline,
-							executionSignal: executionSignal.signal,
-							startedAt,
-							retryCount,
-							observationScope,
-							onRequestComplete: completeAttempt,
-							onPhaseChange: (phase) => {
-								attemptPhase = phase;
-							},
-						}).finally(() => {
-							attemptReturned = true;
-							removeInterruption();
-						});
-					},
-				});
-				const attempt = yield* attemptEffectProgram.pipe(
-					Effect.catchTag("AttemptFailure", (failure) =>
-						Effect.succeed({
-							ok: false as const,
-							cause: failure.cause,
-							phase: failure.phase,
-							responseConfirmed: failure.responseConfirmed,
-						}),
-					),
-					Effect.ensuring(
-						Effect.sync(() => {
-							if (attemptReturned || attemptCompleted) return;
-							const failure = classifyExecutionFailure(
-								undefined,
-								executionSignal.signal,
-								attemptDeadline,
-								executionSignal.deadlineTriggered() ||
-									isDeadlineExceeded(attemptDeadline),
+								{
+									once: true,
+								},
 							);
-							const error = createExecutionError({
+							return executeRequestAttempt<TData>({
+								apiKey,
+								fetchImplementation,
+								normalized,
+								url,
 								method,
 								endpoint,
 								safety,
-								phase: attemptPhase,
-								deadlineExceeded: failure.deadlineExceeded,
-								canceled: failure.canceled,
-								callerCanceled: failure.callerCanceled,
-								responseConfirmed: false,
+								attemptDeadline,
+								executionSignal: executionSignal.signal,
+								startedAt,
+								retryCount,
+								observationScope,
+								onRequestComplete: options.onRequestComplete,
+								onAttemptComplete: completeAttempt,
+								onEffectInterruption: removeInterruption,
+								onPhaseChange: (phase) => {
+									attemptPhase = phase;
+									currentPhase = phase;
+								},
+							}).finally(() => {
+								attemptReturned = true;
+								removeInterruption();
 							});
-							const observation: HevyRequestObservation = {
+						},
+					});
+					const attempt = yield* attemptEffectProgram.pipe(
+						Effect.catchTag("AttemptFailure", (failure) =>
+							Effect.succeed({
+								ok: false as const,
+								cause: failure.cause,
+								phase: failure.phase,
+								responseConfirmed: failure.responseConfirmed,
+							}),
+						),
+						Effect.ensuring(
+							Effect.sync(() => {
+								if (attemptReturned || attemptCompleted) return;
+								const failure = classifyExecutionFailure(
+									undefined,
+									executionSignal.signal,
+									attemptDeadline,
+									executionSignal.deadlineTriggered() ||
+										isDeadlineExceeded(attemptDeadline),
+								);
+								const error = createExecutionError({
+									method,
+									endpoint,
+									safety,
+									phase: attemptPhase,
+									deadlineExceeded: failure.deadlineExceeded,
+									canceled: failure.canceled,
+									callerCanceled: failure.callerCanceled,
+									responseConfirmed: false,
+								});
+								const observation: HevyRequestObservation = {
+									method,
+									endpoint,
+									status: 0,
+									durationMs: Date.now() - startedAt,
+									retryCount,
+									outcome: error.outcome ?? "cancelled",
+									phase: error.phase,
+									operationSafety: safety,
+									commitState: error.commitState,
+									safeToRetry: false,
+									error: {
+										code: error.code,
+										category: "NetworkError",
+									},
+								};
+								completeAttempt(observation);
+							}),
+						),
+					);
+					if (attempt.ok) return attempt.result;
+					{
+						const { cause, phase, responseConfirmed } = attempt;
+						const transition = yield* transitionAfterAttemptFailureEffect(
+							{
+								cause,
 								method,
 								endpoint,
-								status: 0,
-								durationMs: Date.now() - startedAt,
+								page,
+								safety,
+								phase,
+								responseConfirmed,
+								executionSignal,
+								deadline,
+								attemptDeadline,
 								retryCount,
-								outcome: error.outcome ?? "cancelled",
-								phase: error.phase,
-								operationSafety: safety,
-								commitState: error.commitState,
-								safeToRetry: false,
-								error: {
-									code: error.code,
-									category: "NetworkError",
-								},
-							};
-							finishRequestObservation(observationScope, observation);
-							completeAttempt(observation);
-						}),
-					),
-				);
-				if (attempt.ok) return attempt.result;
-				{
-					const { cause, phase, responseConfirmed } = attempt;
-					const transition = yield* transitionAfterAttemptFailureEffect(
-						{
-							cause,
+								maxGetRetries,
+								deadlineRetryActive,
+								allowDeadlineRetry: normalized.hevyDeadline === undefined,
+								startedAt,
+								observationScope,
+								onAttemptComplete: completeAttempt,
+								clientOptions: options,
+							},
+							retryDelayStep,
+						);
+						if (!transition.retry) return yield* Effect.fail(transition.error);
+						retryCount = transition.retryCount;
+						if (transition.error.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE) {
+							// Skip the deadline retry when the caller supplied an
+							// explicit deadline — it is authoritative and no retry
+							// may extend beyond it. In that case operationDeadline
+							// equals deadline, leaving no fresh attempt budget.
+							if (operationDeadline <= deadline)
+								return yield* Effect.fail(transition.error);
+							executionSignal.cleanup();
+							deadline = Math.min(
+								Date.now() + operationTimeoutMs,
+								operationDeadline,
+							);
+							executionSignal = createExecutionSignal({
+								signal: normalized.signal,
+								deadline,
+							});
+							deadlineRetryActive = true;
+							continue;
+						}
+						const delayMs = transition.delayMs ?? 0;
+						const remaining = remainingDeadlineMs(deadline);
+						const finishWait = finalizeOnce(() =>
+							finishRetryWait(transition.retryWaitScope),
+						);
+						currentPhase = "backoff";
+						const wait = retryBackoff({
+							delayMs: Math.min(delayMs, Math.max(0, remaining)),
+							signal: executionSignal.signal,
+							sleep: options.sleep,
 							method,
 							endpoint,
-							page,
-							safety,
-							phase,
-							responseConfirmed,
-							executionSignal,
+							phase: "backoff",
+							operationSafety: safety,
 							deadline,
-							attemptDeadline,
-							retryCount,
-							maxGetRetries,
-							deadlineRetryActive,
-							startedAt,
-							observationScope,
-							clientOptions: attemptClientOptions,
-						},
-						retryDelayStep,
-					);
-					if (!transition.retry) return yield* Effect.fail(transition.error);
-					retryCount = transition.retryCount;
-					if (transition.error.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE) {
-						// Skip the deadline retry when the caller supplied an
-						// explicit deadline — it is authoritative and no retry
-						// may extend beyond it. In that case operationDeadline
-						// equals deadline, leaving no fresh attempt budget.
-						if (operationDeadline <= deadline)
-							return yield* Effect.fail(transition.error);
-						executionSignal.cleanup();
-						deadline = Math.min(
-							Date.now() + operationTimeoutMs,
-							operationDeadline,
+							cause: transition.error,
+						}).pipe(
+							Effect.mapError((failure: BackoffFailure) => {
+								const waitDeadlineExceeded =
+									executionSignal.deadlineTriggered() ||
+									isDeadlineExceeded(deadline);
+								const waitErrorResponse = createExecutionError({
+									method,
+									endpoint,
+									safety,
+									phase: "backoff",
+									deadlineExceeded: waitDeadlineExceeded,
+									canceled: !waitDeadlineExceeded,
+									callerCanceled:
+										!waitDeadlineExceeded && executionSignal.signal.aborted,
+									cause: failure.cause,
+								});
+								emitRequestObservation(options.onRequestComplete, {
+									method,
+									endpoint,
+									status: 0,
+									durationMs: Date.now() - startedAt,
+									retryCount,
+									outcome: waitErrorResponse.outcome ?? "cancelled",
+									phase: waitErrorResponse.phase,
+									operationSafety: safety,
+									commitState: waitErrorResponse.commitState,
+									safeToRetry: false,
+									error: {
+										code: waitErrorResponse.code,
+										category: "NetworkError",
+									},
+								});
+								return waitErrorResponse;
+							}),
+							Effect.ensuring(Effect.sync(finishWait)),
 						);
-						executionSignal = createExecutionSignal({
-							signal: normalized.signal,
-							deadline,
-						});
-						deadlineRetryActive = true;
-						continue;
+						yield* wait;
 					}
-					const delayMs = transition.delayMs ?? 0;
-					const remaining = remainingDeadlineMs(deadline);
-					const finishWait = finalizeOnce(() =>
-						finishRetryWait(transition.retryWaitScope),
-					);
-					const wait = retryBackoff({
-						delayMs: Math.min(delayMs, Math.max(0, remaining)),
-						signal: executionSignal.signal,
-						sleep: options.sleep,
-						method,
-						endpoint,
-						phase: "backoff",
-						operationSafety: safety,
-						deadline,
-						cause: transition.error,
-					}).pipe(
-						Effect.mapError((failure: BackoffFailure) => {
-							const waitDeadlineExceeded =
-								executionSignal.deadlineTriggered() ||
-								isDeadlineExceeded(deadline);
-							const waitErrorResponse = createExecutionError({
-								method,
-								endpoint,
-								safety,
-								phase: "backoff",
-								deadlineExceeded: waitDeadlineExceeded,
-								canceled: !waitDeadlineExceeded,
-								callerCanceled:
-									!waitDeadlineExceeded && executionSignal.signal.aborted,
-								cause: failure.cause,
-							});
-							emitRequestObservation(options.onRequestComplete, {
-								method,
-								endpoint,
-								status: 0,
-								durationMs: Date.now() - startedAt,
-								retryCount,
-								outcome: waitErrorResponse.outcome ?? "cancelled",
-								phase: waitErrorResponse.phase,
-								operationSafety: safety,
-								commitState: waitErrorResponse.commitState,
-								safeToRetry: false,
-								error: {
-									code: waitErrorResponse.code,
-									category: "NetworkError",
-								},
-							});
-							return waitErrorResponse;
-						}),
-						Effect.ensuring(Effect.sync(finishWait)),
-					);
-					yield* startRequestObservationEffect(observationScope, wait).pipe(
-						Effect.ensuring(Effect.sync(finishWait)),
-					);
 				}
-			}
-		}).pipe(Effect.ensuring(Effect.sync(() => executionSignal.cleanup())));
+			}).pipe(
+				Effect.catchCause((cause) => {
+					const failure = Cause.findErrorOption(cause);
+					if (Option.isSome(failure)) return Effect.fail(failure.value);
+					return Effect.fail(
+						createExecutionError({
+							method,
+							endpoint,
+							safety,
+							phase: currentPhase,
+							deadlineExceeded:
+								executionSignal.deadlineTriggered() ||
+								isDeadlineExceeded(deadline),
+							canceled: executionSignal.signal.aborted,
+							callerCanceled: executionSignal.signal.aborted,
+							// Never expose an Effect Cause or an internal
+							// interruption value through the Promise API.
+							cause: undefined,
+						}),
+					);
+				}),
+				Effect.ensuring(Effect.sync(() => executionSignal.cleanup())),
+			);
+		});
 		return requestEffect;
 	};
 

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -343,7 +343,10 @@ function runRequestObservation<T>(
 		return operation();
 	};
 	try {
-		return scope.run(trackedOperation);
+		return Promise.resolve(scope.run(trackedOperation)).catch((error) => {
+			if (started) throw error;
+			return operation();
+		});
 	} catch (error) {
 		if (started) throw error;
 		return operation();
@@ -680,7 +683,9 @@ async function executeRequestAttempt<TData>(
 				setPhase("response-headers");
 				setPhase("response-content");
 				const cancelBody = finalizeOnce(() => {
-					void response.body?.cancel().catch(() => {});
+					const body = response.body;
+					if (!body || body.locked) return;
+					void body.cancel().catch(() => {});
 				});
 				const data = await withTimeout(
 					parseResponseData(response, cancelBody),
@@ -1374,6 +1379,7 @@ export function createNativeClient(
 				Effect.catchCause((cause) => {
 					const failure = Cause.findErrorOption(cause);
 					if (Option.isSome(failure)) return Effect.fail(failure.value);
+					const interrupted = Cause.hasInterrupts(cause);
 					return Effect.fail(
 						createExecutionError({
 							method,
@@ -1381,10 +1387,11 @@ export function createNativeClient(
 							safety,
 							phase: currentPhase,
 							deadlineExceeded:
-								executionSignal.deadlineTriggered() ||
-								isDeadlineExceeded(deadline),
-							canceled: executionSignal.signal.aborted,
-							callerCanceled: executionSignal.signal.aborted,
+								!interrupted &&
+								(executionSignal.deadlineTriggered() ||
+									isDeadlineExceeded(deadline)),
+							canceled: interrupted || executionSignal.signal.aborted,
+							callerCanceled: interrupted || executionSignal.signal.aborted,
 							// Never expose an Effect Cause or an internal
 							// interruption value through the Promise API.
 							cause: undefined,

--- a/packages/hevy-client/src/hevy-client.test.ts
+++ b/packages/hevy-client/src/hevy-client.test.ts
@@ -258,6 +258,9 @@ describe("@hevy-mcp/hevy-client", () => {
 	});
 
 	it("retries a read once with a fresh deadline budget after a deadline", async () => {
+		const outcomes: string[] = [];
+		const onLog = vi.fn();
+		let waitCount = 0;
 		const fetchMock = vi
 			.fn()
 			.mockImplementationOnce(() => new Promise<Response>(() => {}))
@@ -267,12 +270,25 @@ describe("@hevy-mcp/hevy-client", () => {
 			fetch: fetchMock,
 			timeoutMs: 10,
 			maxGetRetries: 1,
+			onLog,
+			onRequestComplete: ({ outcome }) => outcomes.push(outcome),
+			onRetryWait: () => {
+				waitCount += 1;
+				return { finish: vi.fn() };
+			},
 		});
 
 		await expect(client.getWorkout("workout-1")).resolves.toEqual({
 			recovered: true,
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(outcomes).toEqual(["deadline_exceeded", "success"]);
+		expect(waitCount).toBe(0);
+		expect(
+			onLog.mock.calls.some(
+				([event]) => event.data.message === "Retrying Hevy API request",
+			),
+		).toBe(false);
 	});
 
 	it("returns the deadline error when the bounded read retry also times out", async () => {
@@ -329,11 +345,23 @@ describe("@hevy-mcp/hevy-client", () => {
 
 	it("does not extend a caller-supplied deadline with a deadline retry", async () => {
 		const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+		const onLog = vi.fn();
+		const sleeps: number[] = [];
+		let waitsOpened = 0;
 		const client = createHevyClient({
 			apiKey: "secret-key",
 			fetch: fetchMock,
 			timeoutMs: 10,
 			maxGetRetries: 1,
+			onLog,
+			sleep: (milliseconds) => {
+				sleeps.push(milliseconds);
+				return Promise.resolve();
+			},
+			onRetryWait: () => {
+				waitsOpened += 1;
+				return { finish: vi.fn() };
+			},
 		});
 		const deadline = Date.now() + 10;
 
@@ -344,6 +372,15 @@ describe("@hevy-mcp/hevy-client", () => {
 			outcome: "deadline_exceeded",
 		});
 		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(onLog).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					message: "Retrying Hevy API request",
+				}),
+			}),
+		);
+		expect(sleeps).toEqual([]);
+		expect(waitsOpened).toBe(0);
 	});
 
 	it("does not misclassify a non-deadline retry failure as deadline exceeded", async () => {
@@ -532,7 +569,7 @@ describe("@hevy-mcp/hevy-client", () => {
 		expect(outcomes).toEqual(["retryable_failure", "success"]);
 		expect(waits[0]).toBeGreaterThanOrEqual(300);
 		expect(waits[0]).toBeLessThan(550);
-		expect(scopedRuns).toEqual([0, 0, 1]);
+		expect(scopedRuns).toEqual([0, 1]);
 	});
 
 	it("does not rerun a request when an observation scope throws after starting", async () => {

--- a/packages/hevy-client/src/request-effect.test.ts
+++ b/packages/hevy-client/src/request-effect.test.ts
@@ -29,4 +29,30 @@ describe("internal production request Effect seam", () => {
 		await Effect.runPromise(Effect.provide(program, TestClock.layer()));
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
+
+	it("projects an interrupted request Effect to a public client error", async () => {
+		const fetchMock = vi.fn(
+			() =>
+				new Promise<Response>(() => {
+					// The request is interrupted by its owning Effect fiber.
+				}),
+		);
+		const client = createNativeClient("test-key", "https://api.hevyapp.com", {
+			fetch: fetchMock,
+			maxGetRetries: 0,
+		});
+
+		const exit = await Effect.runPromise(
+			Effect.gen(function* () {
+				const fiber = yield* client
+					.requestEffect({ method: "GET", url: "/v1/user/info" })
+					.pipe(Effect.forkChild);
+				yield* Effect.yieldNow;
+				yield* Fiber.interrupt(fiber);
+				return yield* Fiber.await(fiber);
+			}),
+		);
+
+		expect(exit._tag).toBe("Failure");
+	});
 });

--- a/packages/hevy-client/src/request-effect.test.ts
+++ b/packages/hevy-client/src/request-effect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { Effect, Fiber } from "effect";
+import { Cause, Effect, Fiber } from "effect";
 import { TestClock } from "effect/testing";
 
 import { createNativeClient } from "./hevy-client-kubb.js";
@@ -54,5 +54,87 @@ describe("internal production request Effect seam", () => {
 		);
 
 		expect(exit._tag).toBe("Failure");
+		if (exit._tag !== "Failure") return;
+		const error = Cause.findErrorOption(exit.cause);
+		if (error._tag === "Some") {
+			expect(error.value).toMatchObject({
+				code: "HEVY_REQUEST_ABORTED",
+				outcome: "cancelled",
+			});
+		} else {
+			expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+		}
+	});
+
+	it("projects interruption during Effect-clock backoff as cancellation", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("{}", { status: 503 }));
+		const client = createNativeClient("test-key", "https://api.hevyapp.com", {
+			fetch: fetchMock,
+			maxGetRetries: 1,
+		});
+
+		const exit = await Effect.runPromise(
+			Effect.provide(
+				Effect.gen(function* () {
+					const fiber = yield* client
+						.requestEffect({ method: "GET", url: "/v1/user/info" })
+						.pipe(Effect.forkChild);
+					yield* Effect.yieldNow;
+					expect(fetchMock).toHaveBeenCalledOnce();
+					yield* Fiber.interrupt(fiber);
+					return yield* Fiber.await(fiber);
+				}),
+				TestClock.layer(),
+			),
+		);
+
+		expect(exit._tag).toBe("Failure");
+		if (exit._tag !== "Failure") return;
+		const error = Cause.findErrorOption(exit.cause);
+		if (error._tag === "Some") {
+			expect(error.value).toMatchObject({
+				code: "HEVY_REQUEST_ABORTED",
+				outcome: "cancelled",
+			});
+		} else {
+			expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+		}
+	});
+
+	it("does not cancel a response body after text() has locked the stream", async () => {
+		let cancelled = false;
+		const body = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("{}"));
+				controller.close();
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const originalCancel = body.cancel.bind(body);
+		body.cancel = async (...args) => {
+			cancelled = true;
+			return originalCancel(...args);
+		};
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(body, {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const client = createNativeClient("test-key", "https://api.hevyapp.com", {
+			fetch: fetchMock,
+			maxGetRetries: 0,
+		});
+
+		await expect(
+			Effect.runPromise(
+				client.requestEffect({ method: "GET", url: "/v1/user/info" }),
+			),
+		).resolves.toMatchObject({ status: 200 });
+		expect(cancelled).toBe(false);
 	});
 });

--- a/tests/integration/worker-http.integration.test.ts
+++ b/tests/integration/worker-http.integration.test.ts
@@ -751,6 +751,19 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 		expect(invalid.status).toBe(401);
 		expect(invalid.headers.get("www-authenticate")).toBe("Bearer");
 		expect(unavailable.status).toBe(502);
+		const unavailableBody = await unavailable.json();
+		expect(unavailableBody).toEqual({
+			error: {
+				message: "Unable to validate the Hevy API key",
+				outcome: "terminal_failure",
+				phase: "response-content",
+				operation_safety: "read",
+				commit_state: "not_sent",
+				safe_to_retry: false,
+				code: "HEVY_RETRY_EXHAUSTED",
+				status: 503,
+			},
+		});
 		// A 401 is never retried; a 503 is transient and retried twice (three
 		// attempts total) before the validation client gives up.
 		expect(hevyRequests.map((request) => request.apiKey)).toEqual([
@@ -759,6 +772,9 @@ describe.sequential("Wrangler-backed Worker HTTP integration", () => {
 			UPSTREAM_FAILURE_API_KEY,
 			UPSTREAM_FAILURE_API_KEY,
 		]);
+		expect(JSON.stringify(unavailableBody)).not.toMatch(
+			/data|headers|responseError|cause|stack|Effect|secret/i,
+		);
 	});
 
 	it("returns MCP errors for unacceptable, unsupported, and invalid JSON requests", async () => {


### PR DESCRIPTION
## Primary changes
Completes the Effect retry interpreter on top of request-local retry state and Effect request primitives.

This is stack PR 4/4 (top). Base is `feat/effect-request-primitives`. Do not merge into `main` until the rest of the stack lands.

## Reviewer walkthrough
- `packages/hevy-client/src/hevy-client-kubb.ts` completes the request-local Effect retry loop, including per-request retry schedules, deadline handling, interruption projection, response-body cleanup, and request/retry observations.
- `packages/hevy-client/src/execution.ts` preserves caller cancellation when it races with the deadline callback.
- Client and Worker integration tests cover fresh-budget deadline retries, caller-supplied deadline enforcement, observation scopes, interrupted request Effects, and sanitized error responses.

## Correctness and invariants
- Retry state and schedule steps are created per logical request, so sequential and concurrent requests do not share retry indexes or delay state.
- A client-derived deadline may receive one fresh-budget read retry without consuming a scheduled retry step; caller-supplied deadlines remain authoritative.
- Caller cancellation and Effect interruption are not reclassified as deadline failures, and interrupted or cancelled response bodies are released.
- Public Promise-facing failures remain classified client errors without leaking internal Effect causes.

## Stack
1. #1104 `feat/effect-pure-operations` → `main`
2. `test/isolate-client-retry-schedule` → #1104
3. `feat/effect-request-primitives` → isolate-client-retry-schedule
4. **This PR** `feat/effect-retry-interpreter` → request primitives

## Testing and QA
- `mise exec -- pnpm run test:unit`
- Pre-push `repository:pre-push` passed on push

## Summary by Sourcery

Complete the request-local Effect retry interpreter while preserving cancellation semantics, deadline behavior, request observations, response cleanup, and sanitized adapter errors.

Bug Fixes:
- Preserve caller cancellation and Effect interruption as cancellation rather than reclassifying them as deadline failures.
- Release response bodies when parsing is interrupted, cancelled, or times out.
- Prevent public Promise-facing errors from exposing internal Effect causes or implementation details.

Enhancements:
- Complete the request-local Effect retry interpreter with isolated retry schedules, deadline-aware retry budgets, attempt observations, and correct retry-wait behavior.
- Support a single fresh-budget read retry for client-derived deadlines while keeping caller-supplied deadlines authoritative.
- Improve request observation scope handling so attempts and retry transitions are reported consistently.

Tests:
- Expand client tests for deadline retry budgets, caller deadlines, retry observations, and observation scopes.
- Add Effect tests for interruption during requests and backoff, plus response-body cleanup behavior.
- Strengthen Worker integration coverage for sanitized upstream failure responses.

Chores:
- Publish patch releases for the client, operations, core, CLI, and worker packages.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Complete Effect retry interpreter implementation with proper deadline handling, response cleanup, and observation scope management for request attempts.

Main changes:
- Refactored deadline callback logic to check abort status first and restructured timeout error creation in execution signal
- Added response body cancellation handling and `onFailure` callback to `parseResponseData` with improved error propagation
- Moved request Effect into suspended closure with inline attempt logic, direct observation callbacks, and deadline retry state management

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->