### PR TITLE
fix(core): preserve operation domain errors instead of converting them to unhandled defects #1131

### DIFF
--- a/.changeset/preserve-operation-domain-errors.md
+++ b/.changeset/preserve-operation-domain-errors.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+fix(core): preserve operation domain errors in failure channel instead of converting them to unhandled defects. Domain errors from `@hevy-mcp/operations` (`WorkoutPrivacyError`, `WorkoutPayloadError`, `PaginationMismatchError`, `EmptyMeasurementUpdateError`, `TrainingSummaryValidationError`, `TrainingSummaryDataError`) are now included in `CoreToolError` and recognized by `isCoreToolError`, allowing tool error handlers to surface typed domain messages. In `runBoundedExecution`, unexpected defects are logged and re-thrown with their message rather than generic failure text.

--- a/packages/core/src/effect-errors.ts
+++ b/packages/core/src/effect-errors.ts
@@ -6,6 +6,14 @@ import {
 	RateLimitError,
 	ValidationError,
 } from "@hevy-mcp/hevy-client";
+import {
+	EmptyMeasurementUpdateError,
+	PaginationMismatchError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
+} from "@hevy-mcp/operations";
 
 /** Errors raised by core before an operation reaches the Hevy client. */
 export class ToolInputValidationError extends Schema.TaggedError<ToolInputValidationError>()(
@@ -37,7 +45,21 @@ export {
 	NotFoundError,
 	RateLimitError,
 	ValidationError,
+	EmptyMeasurementUpdateError,
+	PaginationMismatchError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
 };
+
+export type OperationDomainError =
+	| EmptyMeasurementUpdateError
+	| PaginationMismatchError
+	| TrainingSummaryDataError
+	| TrainingSummaryValidationError
+	| WorkoutPayloadError
+	| WorkoutPrivacyError;
 
 /** The complete recoverable error vocabulary exposed by core tool handlers. */
 export type CoreToolError =
@@ -48,4 +70,5 @@ export type CoreToolError =
 	| NetworkError
 	| NotFoundError
 	| RateLimitError
-	| ValidationError;
+	| ValidationError
+	| OperationDomainError;

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
 import type { HevyClient, HevyRequestOptions } from "@hevy-mcp/hevy-client";
 import {
 	bindClientExecution,
 	createExecutionProjection,
 	HEVY_CLIENT_OPTION_INDEXES,
 	mergeAbortSignals,
+	runBoundedExecution,
 } from "./execution.js";
 
 type ClientTestArgument =
@@ -246,5 +248,34 @@ describe("mergeAbortSignals", () => {
 		expect(composed?.aborted).toBe(false);
 		second.abort();
 		expect(composed?.aborted).toBe(true);
+	});
+});
+
+describe("runBoundedExecution", () => {
+	it("returns value on success", async () => {
+		const result = await runBoundedExecution(Effect.succeed("hello"), {
+			timeoutMs: 1000,
+		});
+		expect(result).toBe("hello");
+	});
+
+	it("re-throws typed failures directly", async () => {
+		const error = new Error("typed failure");
+		await expect(
+			runBoundedExecution(Effect.fail(error), { timeoutMs: 1000 }),
+		).rejects.toThrow("typed failure");
+	});
+
+	it("extracts and throws unexpected defects instead of a generic message", async () => {
+		const defect = new Error("internal defect details");
+		await expect(
+			runBoundedExecution(Effect.die(defect), { timeoutMs: 1000 }),
+		).rejects.toThrow("internal defect details");
+	});
+
+	it("converts non-Error defects to Error with string representation", async () => {
+		await expect(
+			runBoundedExecution(Effect.die("string defect"), { timeoutMs: 1000 }),
+		).rejects.toThrow("string defect");
 	});
 });

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -278,4 +278,38 @@ describe("runBoundedExecution", () => {
 			runBoundedExecution(Effect.die("string defect"), { timeoutMs: 1000 }),
 		).rejects.toThrow("string defect");
 	});
+
+	it("treats Effect.die(undefined) as a present defect, not a missing one", async () => {
+		await expect(
+			runBoundedExecution(Effect.die(undefined), { timeoutMs: 1000 }),
+		).rejects.toThrow("Unknown defect");
+	});
+
+	it("falls back to Unknown defect for non-serializable defects", async () => {
+		await expect(
+			runBoundedExecution(Effect.die(Symbol("x")), { timeoutMs: 1000 }),
+		).rejects.toThrow("Unknown defect");
+		await expect(
+			runBoundedExecution(
+				Effect.die(() => "secret"),
+				{ timeoutMs: 1000 },
+			),
+		).rejects.toThrow("Unknown defect");
+	});
+
+	it("does not leak the raw defect message into logs", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await runBoundedExecution(
+				Effect.die(new Error("credential-bearing defect")),
+				{ timeoutMs: 1000 },
+			);
+		} catch {
+			// Expected throw; the assertion below is the real check.
+		}
+		const logged = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+		expect(logged).toContain("Unexpected execution defect");
+		expect(logged).not.toContain("credential-bearing defect");
+		errorSpy.mockRestore();
+	});
 });

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -12,6 +12,8 @@ import {
 	isString,
 	type RuntimeValue,
 } from "./utils/type-predicates.js";
+import { logCoreError } from "./utils/core-logger.js";
+import { createSafeErrorDiagnostic } from "./utils/error-policy.js";
 
 /** Per-request control supplied by MCP, HTTP, CLI, or a lifecycle owner. */
 export interface ToolExecutionContext extends HevyRequestOptions {
@@ -118,7 +120,7 @@ function defectMessage(defect: RuntimeValue): string {
 		return defect;
 	}
 	try {
-		return JSON.stringify(defect);
+		return JSON.stringify(defect) ?? "Unknown defect";
 	} catch {
 		return "Unknown defect";
 	}
@@ -157,12 +159,17 @@ export async function runBoundedExecution<A, E>(
 			"AbortError",
 		);
 	}
-	const defect = exit.cause.reasons.find(Cause.isDieReason)?.defect;
-	if (defect !== undefined) {
-		const message = defectMessage(defect);
-		Effect.runSync(Effect.logError(`Unexpected execution defect: ${message}`));
-		if (defect instanceof Error) {
-			throw defect;
+	const dieReason = exit.cause.reasons.find(Cause.isDieReason);
+	if (dieReason !== undefined) {
+		const message = defectMessage(dieReason.defect);
+		// Bounded diagnostic (category/status/frames only), never the raw defect
+		// message, matching the core logging policy for tool errors.
+		logCoreError(
+			"Unexpected execution defect",
+			createSafeErrorDiagnostic(dieReason.defect),
+		);
+		if (dieReason.defect instanceof Error) {
+			throw dieReason.defect;
 		}
 		throw new Error(message);
 	}

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -7,7 +7,11 @@ import type {
 	HevyRequestPhase,
 } from "@hevy-mcp/hevy-client";
 import { Cause, Clock, Effect, Exit } from "effect";
-import { isFunction } from "./utils/type-predicates.js";
+import {
+	isFunction,
+	isString,
+	type RuntimeValue,
+} from "./utils/type-predicates.js";
 
 /** Per-request control supplied by MCP, HTTP, CLI, or a lifecycle owner. */
 export interface ToolExecutionContext extends HevyRequestOptions {
@@ -106,6 +110,20 @@ export function mergeAbortSignals(
 	return composed.signal;
 }
 
+function defectMessage(defect: RuntimeValue): string {
+	if (defect instanceof Error) {
+		return defect.message;
+	}
+	if (isString(defect)) {
+		return defect;
+	}
+	try {
+		return JSON.stringify(defect);
+	} catch {
+		return "Unknown defect";
+	}
+}
+
 /**
  * Run one MCP operation with the request's remaining budget.
  *
@@ -138,6 +156,15 @@ export async function runBoundedExecution<A, E>(
 			"The request was canceled by the client.",
 			"AbortError",
 		);
+	}
+	const defect = exit.cause.reasons.find(Cause.isDieReason)?.defect;
+	if (defect !== undefined) {
+		const message = defectMessage(defect);
+		Effect.runSync(Effect.logError(`Unexpected execution defect: ${message}`));
+		if (defect instanceof Error) {
+			throw defect;
+		}
+		throw new Error(message);
 	}
 	throw new Error("The request failed unexpectedly.");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,14 +76,20 @@ export {
 export {
 	ApiError,
 	ClientNotInitializedError,
+	EmptyMeasurementUpdateError,
 	NetworkError,
 	NotFoundError,
 	OperationUnavailableError,
+	PaginationMismatchError,
 	RateLimitError,
 	ToolInputValidationError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
 	ValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
 } from "./effect-errors.js";
-export type { CoreToolError } from "./effect-errors.js";
+export type { CoreToolError, OperationDomainError } from "./effect-errors.js";
 export type { ToolEffectHandler } from "./tools/tool-runtime.js";
 export {
 	ExerciseTemplateCatalogService,

--- a/packages/core/src/tools/operation-helpers.test.ts
+++ b/packages/core/src/tools/operation-helpers.test.ts
@@ -1,6 +1,15 @@
 import { Cause, Context, Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
-import { ApiError, OperationUnavailableError } from "../effect-errors.js";
+import {
+	ApiError,
+	EmptyMeasurementUpdateError,
+	OperationUnavailableError,
+	PaginationMismatchError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
+} from "../effect-errors.js";
 import {
 	normalizeCoreCause,
 	operationEffect,
@@ -70,6 +79,45 @@ describe("operation error normalization", () => {
 		if (Exit.isFailure(exit)) {
 			expect(Cause.hasDies(exit.cause)).toBe(true);
 			expect(JSON.stringify(exit.cause)).toContain("never-render-this");
+		}
+	});
+
+	it("preserves operation domain errors in failure channel", async () => {
+		const domainErrors = [
+			new WorkoutPrivacyError({
+				message: "Workout is private and cannot be updated.",
+			}),
+			new WorkoutPayloadError({ message: "Invalid exercises payload." }),
+			new PaginationMismatchError({
+				requested: 10,
+				received: 5,
+				collection: "workouts",
+				message: "Pagination count mismatch.",
+			}),
+			new EmptyMeasurementUpdateError({
+				message: "Measurement update payload is empty.",
+			}),
+			new TrainingSummaryValidationError({
+				weeks: 0,
+				message: "Weeks must be positive.",
+			}),
+			new TrainingSummaryDataError({
+				collection: "workouts",
+				message: "Corrupted workout data in summary.",
+			}),
+		];
+
+		for (const error of domainErrors) {
+			const operation = {
+				effect: () => Effect.fail(error),
+			};
+
+			const result = await Effect.runPromise(
+				Effect.flip(operationEffect(Effect.succeed(operation))),
+			);
+
+			expect(result).toBe(error);
+			expect(result._tag).toBe(error._tag);
 		}
 	});
 });

--- a/packages/core/src/tools/operation-helpers.ts
+++ b/packages/core/src/tools/operation-helpers.ts
@@ -2,12 +2,18 @@ import { Cause, Context, Effect } from "effect";
 import {
 	ApiError,
 	ClientNotInitializedError,
+	EmptyMeasurementUpdateError,
 	NetworkError,
 	NotFoundError,
 	OperationUnavailableError,
+	PaginationMismatchError,
 	RateLimitError,
 	ToolInputValidationError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
 	ValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
 	type CoreToolError,
 } from "../effect-errors.js";
 import type { RuntimeValue } from "../utils/type-predicates.js";
@@ -42,7 +48,13 @@ function isCoreToolError(error: RuntimeValue): error is CoreToolError {
 		error instanceof NetworkError ||
 		error instanceof NotFoundError ||
 		error instanceof RateLimitError ||
-		error instanceof ValidationError
+		error instanceof ValidationError ||
+		error instanceof EmptyMeasurementUpdateError ||
+		error instanceof PaginationMismatchError ||
+		error instanceof TrainingSummaryDataError ||
+		error instanceof TrainingSummaryValidationError ||
+		error instanceof WorkoutPayloadError ||
+		error instanceof WorkoutPrivacyError
 	);
 }
 

--- a/packages/core/src/utils/error-policy.test.ts
+++ b/packages/core/src/utils/error-policy.test.ts
@@ -3,11 +3,22 @@ import { HevyHttpError } from "@hevy-mcp/hevy-client";
 
 import {
 	createSafeErrorDiagnostic,
+	determineErrorType,
+	ErrorType,
+	resolveErrorPolicy,
 	SAFE_ERROR_CATEGORIES,
 	SAFE_ERROR_CODES,
 	SAFE_HTTP_METHODS,
 	SAFE_STACK_SOURCES,
 } from "./error-policy.js";
+import {
+	EmptyMeasurementUpdateError,
+	PaginationMismatchError,
+	TrainingSummaryDataError,
+	TrainingSummaryValidationError,
+	WorkoutPayloadError,
+	WorkoutPrivacyError,
+} from "@hevy-mcp/operations";
 
 /** A category with no corresponding JS constructor (produced by fallthrough). */
 const LAST_RESORT_CATEGORY = "UnknownError" as const;
@@ -185,5 +196,48 @@ describe("createSafeErrorDiagnostic", () => {
 			commit_state: "unknown",
 			safe_to_retry: false,
 		});
+	});
+
+	it("classifies and resolves operation domain errors with their messages", () => {
+		const validationErrors = [
+			new WorkoutPrivacyError({
+				message: "Workout is private and cannot be updated.",
+			}),
+			new WorkoutPayloadError({ message: "Invalid exercises payload." }),
+			new EmptyMeasurementUpdateError({
+				message: "Measurement update payload is empty.",
+			}),
+			new TrainingSummaryValidationError({
+				weeks: 0,
+				message: "Weeks must be positive.",
+			}),
+		];
+
+		for (const err of validationErrors) {
+			expect(determineErrorType(err)).toBe(ErrorType.VALIDATION_ERROR);
+			const policy = resolveErrorPolicy(err, "fallback");
+			expect(policy.type).toBe(ErrorType.VALIDATION_ERROR);
+			expect(policy.message).toBe(err.message);
+		}
+
+		const apiErrors = [
+			new PaginationMismatchError({
+				requested: 10,
+				received: 5,
+				collection: "workouts",
+				message: "Pagination count mismatch.",
+			}),
+			new TrainingSummaryDataError({
+				collection: "workouts",
+				message: "Corrupted workout data in summary.",
+			}),
+		];
+
+		for (const err of apiErrors) {
+			expect(determineErrorType(err)).toBe(ErrorType.API_ERROR);
+			const policy = resolveErrorPolicy(err, "fallback");
+			expect(policy.type).toBe(ErrorType.API_ERROR);
+			expect(policy.message).toBe(err.message);
+		}
 	});
 });

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -118,7 +118,13 @@ type ErrorTag =
 	| "ValidationError"
 	| "ToolInputValidationError"
 	| "ClientNotInitializedError"
-	| "OperationUnavailableError";
+	| "OperationUnavailableError"
+	| "WorkoutPrivacyError"
+	| "WorkoutPayloadError"
+	| "PaginationMismatchError"
+	| "EmptyMeasurementUpdateError"
+	| "TrainingSummaryValidationError"
+	| "TrainingSummaryDataError";
 type TaggedValue = {
 	readonly _tag?: ErrorTag;
 	readonly path?: unknown;
@@ -395,6 +401,17 @@ export function determineErrorType(error: RuntimeValue): ErrorType {
 	if (tag === "ApiError") return ErrorType.API_ERROR;
 	if (tag === "NetworkError") return ErrorType.NETWORK_ERROR;
 	if (tag === "ToolInputValidationError") return ErrorType.VALIDATION_ERROR;
+	if (
+		tag === "WorkoutPrivacyError" ||
+		tag === "WorkoutPayloadError" ||
+		tag === "EmptyMeasurementUpdateError" ||
+		tag === "TrainingSummaryValidationError"
+	) {
+		return ErrorType.VALIDATION_ERROR;
+	}
+	if (tag === "PaginationMismatchError" || tag === "TrainingSummaryDataError") {
+		return ErrorType.API_ERROR;
+	}
 	if (isRetryExhausted(error)) return ErrorType.NETWORK_ERROR;
 	const status = extractErrorStatus(error);
 	if (status === 429) return ErrorType.RATE_LIMIT;
@@ -600,6 +617,18 @@ export function resolveErrorPolicy(
 			tag === "ClientNotInitializedError"
 				? "API client not initialized. Please provide HEVY_API_KEY."
 				: "The requested Hevy operation is unavailable.";
+	}
+	if (
+		tag === "WorkoutPrivacyError" ||
+		tag === "WorkoutPayloadError" ||
+		tag === "PaginationMismatchError" ||
+		tag === "EmptyMeasurementUpdateError" ||
+		tag === "TrainingSummaryValidationError" ||
+		tag === "TrainingSummaryDataError"
+	) {
+		if (error instanceof Error && error.message) {
+			message = error.message;
+		}
 	}
 	let isNotInitialized = false;
 	try {


### PR DESCRIPTION
## Primary changes

1. **Expand CoreToolError with Domain Errors**:
   - Re-exported domain errors from `@hevy-mcp/operations` (`WorkoutPrivacyError`, `WorkoutPayloadError`, `PaginationMismatchError`, `EmptyMeasurementUpdateError`, `TrainingSummaryValidationError`, `TrainingSummaryDataError`) through the `@hevy-mcp/core` public barrel.
   - Defined `OperationDomainError` union and included it in `CoreToolError`.

2. **Update Core Boundary Normalization (`packages/core/src/tools/operation-helpers.ts`)**:
   - Updated `isCoreToolError` to recognize the domain errors so that `normalizeCoreCause` keeps them typed in the fail channel instead of converting them into defects.

3. **Defect Extraction & Logging in Bounded Execution (`packages/core/src/execution.ts`)**:
   - In `runBoundedExecution`, extract the die reason explicitly, log a bounded safe diagnostic through the core logger instead of raw defect text, and re-throw the original `Error` or a safe fallback message rather than a generic "The request failed unexpectedly." error.

4. **Error Policy Mapping (`packages/core/src/utils/error-policy.ts`)**:
   - Added domain errors to `determineErrorType` (`VALIDATION_ERROR` for workout privacy/payload and measurement/training validation; `API_ERROR` for pagination mismatch and data errors) and ensured `resolveErrorPolicy` surfaces their explicit error messages to callers.

5. **Tests & Changeset**:
   - Added unit tests in `packages/core/src/tools/operation-helpers.test.ts` verifying all 6 domain errors are preserved in the failure channel.
   - Added unit tests in `packages/core/src/execution.test.ts` verifying defect propagation, undefined/non-serializable fallback messages, and that raw defect text is not logged.
   - Added unit tests in `packages/core/src/utils/error-policy.test.ts` verifying error policy resolution.
   - Added patch changeset for `@hevy-mcp/core` and consumers.

## Reviewer walkthrough

- `packages/core/src/effect-errors.ts` adds the six operation domain errors to the core error vocabulary.
- `packages/core/src/index.ts` exposes the operation domain errors and `OperationDomainError` through the public core barrel.
- `packages/core/src/tools/operation-helpers.ts` recognizes those errors so normalization preserves them as typed failures.
- `packages/core/src/execution.ts` logs bounded safe diagnostics for unexpected defects and re-throws their original or fallback messages, while `packages/core/src/utils/error-policy.ts` maps domain errors to caller-facing policies.

## Correctness and invariants

- Recognized operation domain errors remain in the Effect failure channel and retain their original messages.
- Unexpected defects remain distinct from recoverable domain failures, use bounded diagnostics without raw defect text, and retain the original error or a safe fallback message when re-thrown.
- Validation and API classifications continue to use the explicit domain error message presented to callers.

## Testing and QA

- Added regression coverage for all six domain errors in `operation-helpers.test.ts`.
- Added bounded-execution coverage for typed failures, defect propagation, undefined/non-serializable fallback messages, and raw-log redaction in `execution.test.ts`.
- Added error-policy classification and message-resolution coverage in `error-policy.test.ts`.
- Added the required patch changeset for `@hevy-mcp/core` and its consuming packages.

## Summary by Sourcery

Preserve operation domain errors through core execution while retaining safe handling and diagnostics for unexpected defects.

Bug Fixes:
- Preserve operation domain errors as typed core failures so callers receive their original messages instead of generic unhandled-defect responses.
- Re-throw unexpected execution defects with their actual messages while keeping sensitive details out of diagnostic logs.

Enhancements:
- Classify operation domain errors consistently as validation or API errors and surface their explicit messages through error policies.

Tests:
- Add regression coverage for domain-error preservation, defect message propagation, safe defect logging, and error-policy classification.

Chores:
- Add patch changeset entries for core and consuming packages.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Preserve typed operation domain errors in the failure channel instead of converting them to unhandled defects in core tool handlers.

Main changes:
- Import and export six operation domain errors from @hevy-mcp/operations through the @hevy-mcp/core public barrel; add OperationDomainError union type to CoreToolError
- Update isCoreToolError type guard and error-policy classification to recognize domain errors as VALIDATION_ERROR or API_ERROR
- Extract die reasons explicitly, log bounded safe diagnostics, and re-throw unexpected defects with their original or safe fallback message in runBoundedExecution instead of generic failure text

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using [Guidelines](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->

Resolves #1131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent handling and public availability for operation-related errors.
  * Validation and API errors now retain their original messages for clearer diagnostics.
  * Unexpected execution defects are safely reported with bounded diagnostic messages.

* **Bug Fixes**
  * Prevented raw defect details from being exposed in logs.
  * Ensured unknown or non-serializable defects resolve to a safe fallback message.
  * Preserved typed operation failures through execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->