### PR TITLE
fix: harden effect type safety across request, execution, and catalog boundaries

### DIFF
--- a/.changeset/tidy-effects-harden.md
+++ b/.changeset/tidy-effects-harden.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Harden Effect type safety: narrow the request error channel to tagged errors, surface bounded-execution timeouts as typed deadline failures, validate template search pagination, and return template list results as an explicit struct.

--- a/.changeset/witty-catalogs-repeat.md
+++ b/.changeset/witty-catalogs-repeat.md
@@ -1,0 +1,8 @@
+---
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Preserve the fetched template page count through the exercise catalog cache instead of recomputing it from the cached item count.

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -11,6 +11,7 @@ import {
 import {
 	EmptyMeasurementUpdateError,
 	PaginationMismatchError,
+	TemplatesSearchValidationError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,
 	WorkoutPayloadError,
@@ -43,6 +44,7 @@ type TaggedClientError =
 type OperationDomainError =
 	| EmptyMeasurementUpdateError
 	| PaginationMismatchError
+	| TemplatesSearchValidationError
 	| TrainingSummaryDataError
 	| TrainingSummaryValidationError
 	| WorkoutPayloadError
@@ -67,6 +69,7 @@ function isOperationDomainError(
 		error instanceof EmptyMeasurementUpdateError ||
 		error instanceof TrainingSummaryDataError ||
 		error instanceof PaginationMismatchError ||
+		error instanceof TemplatesSearchValidationError ||
 		error instanceof TrainingSummaryValidationError ||
 		error instanceof WorkoutPayloadError ||
 		error instanceof WorkoutPrivacyError

--- a/packages/core/src/effect-errors.ts
+++ b/packages/core/src/effect-errors.ts
@@ -13,6 +13,7 @@ import {
 	TrainingSummaryValidationError,
 	WorkoutPayloadError,
 	WorkoutPrivacyError,
+	TemplatesSearchValidationError,
 } from "@hevy-mcp/operations";
 
 /** Errors raised by core before an operation reaches the Hevy client. */
@@ -47,6 +48,7 @@ export {
 	ValidationError,
 	EmptyMeasurementUpdateError,
 	PaginationMismatchError,
+	TemplatesSearchValidationError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,
 	WorkoutPayloadError,
@@ -56,6 +58,7 @@ export {
 export type OperationDomainError =
 	| EmptyMeasurementUpdateError
 	| PaginationMismatchError
+	| TemplatesSearchValidationError
 	| TrainingSummaryDataError
 	| TrainingSummaryValidationError
 	| WorkoutPayloadError

--- a/packages/core/src/execution.test.ts
+++ b/packages/core/src/execution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import type { HevyClient, HevyRequestOptions } from "@hevy-mcp/hevy-client";
 import {
 	bindClientExecution,
@@ -295,6 +295,18 @@ describe("runBoundedExecution", () => {
 				{ timeoutMs: 1000 },
 			),
 		).rejects.toThrow("Unknown defect");
+	});
+
+	it("surfaces bounded timeouts as typed TimeoutError failures", async () => {
+		const failure = await runBoundedExecution(Effect.never, {
+			timeoutMs: 10,
+		}).then(
+			() => {
+				throw new Error("expected the bounded execution to time out");
+			},
+			(error) => error,
+		);
+		expect(Cause.isTimeoutError(failure)).toBe(true);
 	});
 
 	it("does not leak the raw defect message into logs", async () => {

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -6,7 +6,7 @@ import type {
 	HevyRequestOptions,
 	HevyRequestPhase,
 } from "@hevy-mcp/hevy-client";
-import { Cause, Clock, Effect, Exit } from "effect";
+import { Cause, Clock, Effect, Exit, Option } from "effect";
 import {
 	isFunction,
 	isString,
@@ -151,8 +151,8 @@ export async function runBoundedExecution<A, E>(
 		signal: options.signal,
 	});
 	if (Exit.isSuccess(exit)) return exit.value;
-	const failure = exit.cause.reasons.find(Cause.isFailReason)?.error;
-	if (failure !== undefined) throw failure;
+	const failure = Cause.findErrorOption(exit.cause);
+	if (Option.isSome(failure)) throw failure.value;
 	if (Cause.hasInterruptsOnly(exit.cause)) {
 		throw new DOMException(
 			"The request was canceled by the client.",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export {
 	OperationUnavailableError,
 	PaginationMismatchError,
 	RateLimitError,
+	TemplatesSearchValidationError,
 	ToolInputValidationError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,

--- a/packages/core/src/resources/hevy.test.ts
+++ b/packages/core/src/resources/hevy.test.ts
@@ -16,6 +16,7 @@ import {
 	createOperations,
 	foldersListAllDescriptor,
 	type TemplatesListAllOperation,
+	type TemplatesListAllResult,
 	templatesListAllDescriptor,
 	userGetDescriptor,
 	workoutsCountDescriptor,
@@ -50,14 +51,15 @@ function createTestRuntime(
 			id: "templates.listAll",
 			safety: "read",
 		},
-		effect: () => Effect.succeed([]),
-		execute: () => Promise.resolve([]),
+		effect: () => Effect.succeed({ items: [], pageCount: 0 }),
+		execute: () => Promise.resolve({ items: [], pageCount: 0 }),
 	};
 	const cache: ExerciseTemplateCatalogCache = Effect.runSync(
 		Cache.make({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) => listAll.effect(),
+			lookup: (_key: string) =>
+				Effect.map(listAll.effect(), (result) => result.items),
 		}),
 	);
 	return createToolRuntime({
@@ -254,7 +256,9 @@ describe("registerHevyResources", () => {
 		];
 		const userGet = vi.fn(() => Effect.succeed(user));
 		const workoutCount = vi.fn(() => Effect.succeed(7));
-		const templateListAll = vi.fn(() => Effect.succeed(templates));
+		const templateListAll = vi.fn(() =>
+			Effect.succeed({ items: templates, pageCount: 1 }),
+		);
 		const folderListAll = vi.fn(() => Effect.succeed(folders));
 		const operations: HevyOperations = {
 			...baseOperations,
@@ -298,7 +302,8 @@ describe("registerHevyResources", () => {
 			>({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) => templateListAll(),
+				lookup: (_key: string) =>
+					Effect.map(templateListAll(), (result) => result.items),
 			}),
 		);
 		const catalog = createExerciseTemplateCatalog(operations, cache);
@@ -446,11 +451,11 @@ describe("registerHevyResources", () => {
 	it("shares completed and controlled in-flight catalog values", async () => {
 		const { registerResource, server, tool } = createMockServer();
 		const hevyClient = createMockHevyClient();
-		const pendingLookups: Array<(value: ExerciseTemplate[]) => void> = [];
+		const pendingLookups: Array<(value: TemplatesListAllResult) => void> = [];
 		const listAll = vi
 			.fn<TemplatesListAllOperation["effect"]>()
 			.mockImplementation(() =>
-				Effect.callback<ExerciseTemplate[]>((resume) => {
+				Effect.callback<TemplatesListAllResult>((resume) => {
 					pendingLookups.push((value) => resume(Effect.succeed(value)));
 				}),
 			);
@@ -462,7 +467,7 @@ describe("registerHevyResources", () => {
 						safety: "read" as const,
 					},
 					effect: listAll,
-					execute: () => Promise.resolve([]),
+					execute: () => Promise.resolve({ items: [], pageCount: 0 }),
 				},
 			},
 		};
@@ -470,7 +475,8 @@ describe("registerHevyResources", () => {
 			Cache.make({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) => listAll(),
+				lookup: (_key: string) =>
+					Effect.map(listAll(), (result) => result.items),
 			}),
 		);
 		const catalog = createExerciseTemplateCatalog(operations, cache);
@@ -496,7 +502,7 @@ describe("registerHevyResources", () => {
 
 		await vi.waitFor(() => expect(listAll).toHaveBeenCalledOnce());
 		for (const resolveCatalog of pendingLookups) {
-			resolveCatalog([benchTemplate]);
+			resolveCatalog({ items: [benchTemplate], pageCount: 1 });
 		}
 
 		const [resourceResult, searchResult] = await Promise.all([

--- a/packages/core/src/resources/hevy.test.ts
+++ b/packages/core/src/resources/hevy.test.ts
@@ -58,8 +58,7 @@ function createTestRuntime(
 		Cache.make({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) =>
-				Effect.map(listAll.effect(), (result) => result.items),
+			lookup: (_key: string) => listAll.effect(),
 		}),
 	);
 	return createToolRuntime({
@@ -297,13 +296,12 @@ describe("registerHevyResources", () => {
 		const cache: ExerciseTemplateCatalogCache = Effect.runSync(
 			Cache.make<
 				string,
-				ExerciseTemplate[],
+				TemplatesListAllResult,
 				Effect.Error<ReturnType<TemplatesListAllOperation["effect"]>>
 			>({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) =>
-					Effect.map(templateListAll(), (result) => result.items),
+				lookup: (_key: string) => templateListAll(),
 			}),
 		);
 		const catalog = createExerciseTemplateCatalog(operations, cache);
@@ -475,8 +473,7 @@ describe("registerHevyResources", () => {
 			Cache.make({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) =>
-					Effect.map(listAll(), (result) => result.items),
+				lookup: (_key: string) => listAll(),
 			}),
 		);
 		const catalog = createExerciseTemplateCatalog(operations, cache);

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -2,8 +2,10 @@ import { McpServer } from "@modelcontextprotocol/server";
 import type { HevyClient, HevyClientLogEvent } from "@hevy-mcp/hevy-client";
 import { Cache, Effect, Exit, Layer, Schema, Scope } from "effect";
 import { createOperations } from "@hevy-mcp/operations";
-import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
-import type { TemplatesListAllOperation } from "@hevy-mcp/operations";
+import type {
+	TemplatesListAllOperation,
+	TemplatesListAllResult,
+} from "@hevy-mcp/operations";
 import { registerWorkoutPrompts } from "./prompts/workouts.js";
 import { registerHevyResources } from "./resources/hevy.js";
 import {
@@ -103,13 +105,12 @@ export const createHevyMcpServerEffect = Effect.fn("core.createHevyMcpServer")(
 			: shutdown.signal;
 		const cache = yield* Cache.make<
 			string,
-			ExerciseTemplate[],
+			TemplatesListAllResult,
 			Effect.Error<ReturnType<TemplatesListAllOperation["effect"]>>
 		>({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) =>
-				Effect.map(templateListAll.effect(), (result) => result.items),
+			lookup: (_key: string) => templateListAll.effect(),
 		});
 		const catalog = createExerciseTemplateCatalog(
 			operations,

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -108,7 +108,8 @@ export const createHevyMcpServerEffect = Effect.fn("core.createHevyMcpServer")(
 		>({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) => templateListAll.effect(),
+			lookup: (_key: string) =>
+				Effect.map(templateListAll.effect(), (result) => result.items),
 		});
 		const catalog = createExerciseTemplateCatalog(
 			operations,

--- a/packages/core/src/tools/cross-package.test.ts
+++ b/packages/core/src/tools/cross-package.test.ts
@@ -241,7 +241,7 @@ describe("cross-package core invariants", () => {
 				...layerOperations.workouts,
 				get: {
 					...layerOperations.workouts.get,
-					effect: vi.fn(() => Effect.fail(new Error("wrong source"))),
+					effect: vi.fn(() => Effect.die(new Error("wrong source"))),
 				},
 			},
 		};
@@ -330,7 +330,7 @@ describe("cross-package core invariants", () => {
 				},
 				listAll: {
 					descriptor: templatesListAllDescriptor,
-					effect: vi.fn(() => Effect.succeed([])),
+					effect: vi.fn(() => Effect.succeed({ items: [], pageCount: 0 })),
 					execute: vi.fn(),
 				},
 			},

--- a/packages/core/src/tools/operation-helpers.ts
+++ b/packages/core/src/tools/operation-helpers.ts
@@ -8,6 +8,7 @@ import {
 	OperationUnavailableError,
 	PaginationMismatchError,
 	RateLimitError,
+	TemplatesSearchValidationError,
 	ToolInputValidationError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,
@@ -51,6 +52,7 @@ function isCoreToolError(error: RuntimeValue): error is CoreToolError {
 		error instanceof ValidationError ||
 		error instanceof EmptyMeasurementUpdateError ||
 		error instanceof PaginationMismatchError ||
+		error instanceof TemplatesSearchValidationError ||
 		error instanceof TrainingSummaryDataError ||
 		error instanceof TrainingSummaryValidationError ||
 		error instanceof WorkoutPayloadError ||

--- a/packages/core/src/tools/routines.test.ts
+++ b/packages/core/src/tools/routines.test.ts
@@ -269,11 +269,11 @@ describe("routine tools", () => {
 			routines: {
 				get: {
 					...layerOperations.routines.get,
-					effect: vi.fn(() => Effect.fail(new Error("wrong source"))),
+					effect: vi.fn(() => Effect.die(new Error("wrong source"))),
 				},
 				list: {
 					...layerOperations.routines.list,
-					effect: vi.fn(() => Effect.fail(new Error("wrong source"))),
+					effect: vi.fn(() => Effect.die(new Error("wrong source"))),
 				},
 			},
 		};

--- a/packages/core/src/tools/workouts.test.ts
+++ b/packages/core/src/tools/workouts.test.ts
@@ -232,11 +232,11 @@ describe("workout tools", () => {
 			workouts: {
 				get: {
 					...layerOperations.workouts.get,
-					effect: vi.fn(() => Effect.fail(new Error("wrong source"))),
+					effect: vi.fn(() => Effect.die(new Error("wrong source"))),
 				},
 				list: {
 					...layerOperations.workouts.list,
-					effect: vi.fn(() => Effect.fail(new Error("wrong source"))),
+					effect: vi.fn(() => Effect.die(new Error("wrong source"))),
 				},
 			},
 		};

--- a/packages/core/src/utils/error-policy.test.ts
+++ b/packages/core/src/utils/error-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { Cause } from "effect";
 import { HevyHttpError } from "@hevy-mcp/hevy-client";
 
 import {
@@ -196,6 +197,18 @@ describe("createSafeErrorDiagnostic", () => {
 			commit_state: "unknown",
 			safe_to_retry: false,
 		});
+	});
+
+	it("resolves bounded timeouts to a network error with a timeout message", () => {
+		for (const error of [
+			new Cause.TimeoutError(),
+			new DOMException("deadline", "TimeoutError"),
+		]) {
+			const policy = resolveErrorPolicy(error, "fallback");
+			expect(policy.type).toBe(ErrorType.NETWORK_ERROR);
+			expect(policy.message).toMatch(/time limit/i);
+			expect(policy.diagnostic.code).toBe("HEVY_DEADLINE_EXCEEDED");
+		}
 	});
 
 	it("classifies and resolves operation domain errors with their messages", () => {

--- a/packages/core/src/utils/error-policy.ts
+++ b/packages/core/src/utils/error-policy.ts
@@ -123,6 +123,7 @@ type ErrorTag =
 	| "WorkoutPayloadError"
 	| "PaginationMismatchError"
 	| "EmptyMeasurementUpdateError"
+	| "TemplatesSearchValidationError"
 	| "TrainingSummaryValidationError"
 	| "TrainingSummaryDataError";
 type TaggedValue = {
@@ -405,12 +406,19 @@ export function determineErrorType(error: RuntimeValue): ErrorType {
 		tag === "WorkoutPrivacyError" ||
 		tag === "WorkoutPayloadError" ||
 		tag === "EmptyMeasurementUpdateError" ||
+		tag === "TemplatesSearchValidationError" ||
 		tag === "TrainingSummaryValidationError"
 	) {
 		return ErrorType.VALIDATION_ERROR;
 	}
 	if (tag === "PaginationMismatchError" || tag === "TrainingSummaryDataError") {
 		return ErrorType.API_ERROR;
+	}
+	// Bounded-execution and transport timeouts share the client-timeout
+	// taxonomy: the request never got an answer, like other network failures.
+	// Name-based (not _tag) so DOMException timeouts classify identically.
+	if (getAbortTimeoutErrorMetadata(error)?.name === "TimeoutError") {
+		return ErrorType.NETWORK_ERROR;
 	}
 	if (isRetryExhausted(error)) return ErrorType.NETWORK_ERROR;
 	const status = extractErrorStatus(error);
@@ -623,6 +631,7 @@ export function resolveErrorPolicy(
 		tag === "WorkoutPayloadError" ||
 		tag === "PaginationMismatchError" ||
 		tag === "EmptyMeasurementUpdateError" ||
+		tag === "TemplatesSearchValidationError" ||
 		tag === "TrainingSummaryValidationError" ||
 		tag === "TrainingSummaryDataError"
 	) {
@@ -652,6 +661,10 @@ export function resolveErrorPolicy(
 		// This code is emitted only for caller cancellation. Keep its explicit
 		// client-facing message instead of falling back to the generic error text.
 		message = "The request was canceled by the client.";
+	} else if (diagnostic.code === HEVY_DEADLINE_EXCEEDED_ERROR_CODE) {
+		// Same treatment for bounded-execution timeouts: the diagnostic code is
+		// emitted only for deadline expiry, so name the outcome explicitly.
+		message = "The request exceeded its time limit before completing.";
 	} else if (isRetryExhausted(error)) {
 		message = getRetryExhaustedMessage(error);
 	} else if (diagnostic.status === 429) {

--- a/packages/core/src/utils/exercise-template-catalog.test.ts
+++ b/packages/core/src/utils/exercise-template-catalog.test.ts
@@ -28,8 +28,7 @@ function createCatalog(
 			Cache.make({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) =>
-					Effect.map(listAll.effect(), (result) => result.items),
+				lookup: (_key: string) => listAll.effect(),
 			}),
 		);
 	return createExerciseTemplateCatalog({ templates: { listAll } }, serverCache);
@@ -146,6 +145,43 @@ describe("exercise template catalog", () => {
 		await expect(first).rejects.toMatchObject({ name: "AbortError" });
 		await expect(second).resolves.toMatchObject([{ id: "shared" }]);
 		expect(listAll).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves the fetched pageCount through the cache", async () => {
+		const finished: Array<{
+			pageCountBucket?: string;
+			itemCountBucket?: string;
+		}> = [];
+		const listAll = vi
+			.fn<ListAll["effect"]>()
+			.mockReturnValue(
+				Effect.succeed({ items: [{ id: "only" }], pageCount: 2 }),
+			);
+		const serverCache = Effect.runSync(
+			Cache.make({
+				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
+				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
+				lookup: (_key: string) => listAll(),
+			}),
+		);
+		const catalog = createExerciseTemplateCatalog(
+			{ templates: { listAll: operation(listAll) } },
+			serverCache,
+			{
+				start: () => ({
+					finish: (metadata) => {
+						finished.push({ ...metadata });
+					},
+				}),
+			},
+		);
+
+		await expect(catalog.get()).resolves.toMatchObject([{ id: "only" }]);
+		expect(listAll).toHaveBeenCalledOnce();
+		// One item fetched across two pages (empty terminal page) must not be
+		// recomputed from the item count.
+		expect(finished[0]?.pageCountBucket).toBe("2-10");
+		expect(finished[0]?.itemCountBucket).toBe("1");
 	});
 
 	it("uses templates.listAll rather than a Promise client for lookup", async () => {

--- a/packages/core/src/utils/exercise-template-catalog.test.ts
+++ b/packages/core/src/utils/exercise-template-catalog.test.ts
@@ -1,9 +1,12 @@
 import { Cache, Effect } from "effect";
 import { TestClock } from "effect/testing";
 import { describe, expect, it, vi } from "vitest";
-import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
 import type { HevyExecutionOptions } from "@hevy-mcp/hevy-client";
-import type { TemplatesListAllOperation } from "@hevy-mcp/operations";
+import type {
+	TemplatesListAllOperation,
+	TemplatesListAllResult,
+} from "@hevy-mcp/operations";
+import { PaginationMismatchError } from "@hevy-mcp/operations";
 import {
 	createExerciseTemplateCatalog,
 	type ExerciseTemplateCatalog,
@@ -25,7 +28,8 @@ function createCatalog(
 			Cache.make({
 				capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 				timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-				lookup: (_key: string) => listAll.effect(),
+				lookup: (_key: string) =>
+					Effect.map(listAll.effect(), (result) => result.items),
 			}),
 		);
 	return createExerciseTemplateCatalog({ templates: { listAll } }, serverCache);
@@ -39,8 +43,12 @@ describe("exercise template catalog", () => {
 	it("reset clears the server cache and forces a fresh catalog request", async () => {
 		const listAll = vi
 			.fn<ListAll["effect"]>()
-			.mockReturnValueOnce(Effect.succeed([{ id: "first" }]))
-			.mockReturnValueOnce(Effect.succeed([{ id: "second" }]));
+			.mockReturnValueOnce(
+				Effect.succeed({ items: [{ id: "first" }], pageCount: 1 }),
+			)
+			.mockReturnValueOnce(
+				Effect.succeed({ items: [{ id: "second" }], pageCount: 1 }),
+			);
 		const catalog = createCatalog(operation(listAll));
 
 		await expect(catalog.get()).resolves.toMatchObject([{ id: "first" }]);
@@ -51,10 +59,10 @@ describe("exercise template catalog", () => {
 	});
 
 	it("deduplicates concurrent cache misses", async () => {
-		let resolveLookup: ((templates: ExerciseTemplate[]) => void) | undefined;
+		let resolveLookup: ((result: TemplatesListAllResult) => void) | undefined;
 		const listAll = vi.fn<ListAll["effect"]>().mockImplementation(() =>
-			Effect.callback<ExerciseTemplate[], ListAllError>((resume) => {
-				resolveLookup = (templates) => resume(Effect.succeed(templates));
+			Effect.callback<TemplatesListAllResult, ListAllError>((resume) => {
+				resolveLookup = (result) => resume(Effect.succeed(result));
 			}),
 		);
 		const catalog = createCatalog(operation(listAll));
@@ -64,7 +72,10 @@ describe("exercise template catalog", () => {
 		await vi.waitFor(() => expect(listAll).toHaveBeenCalledOnce());
 		expect(listAll).toHaveBeenCalledOnce();
 
-		resolveLookup?.([{ id: "shared", title: "Shared" }]);
+		resolveLookup?.({
+			items: [{ id: "shared", title: "Shared" }],
+			pageCount: 1,
+		});
 		await expect(Promise.all([first, second])).resolves.toEqual([
 			[{ id: "shared", title: "Shared" }],
 			[{ id: "shared", title: "Shared" }],
@@ -75,7 +86,7 @@ describe("exercise template catalog", () => {
 		const controller = new AbortController();
 		let cancelled = false;
 		const listAll = vi.fn<ListAll["effect"]>().mockImplementation(() =>
-			Effect.callback<ExerciseTemplate[], ListAllError>(() => {
+			Effect.callback<TemplatesListAllResult, ListAllError>(() => {
 				return Effect.sync(() => {
 					cancelled = true;
 				});
@@ -96,7 +107,7 @@ describe("exercise template catalog", () => {
 		const listAll = vi
 			.fn<ListAll["effect"]>()
 			.mockImplementation((options?: HevyExecutionOptions) =>
-				Effect.callback<ExerciseTemplate[], ListAllError>((resume) => {
+				Effect.callback<TemplatesListAllResult, ListAllError>((resume) => {
 					const signal = options?.signal;
 					if (signal?.aborted) {
 						resume(Effect.fail(signal.reason));
@@ -107,7 +118,13 @@ describe("exercise template catalog", () => {
 					signal?.addEventListener("abort", onAbort, { once: true });
 					const template = "shared";
 					const timer = setTimeout(
-						() => resume(Effect.succeed([{ id: template }])),
+						() =>
+							resume(
+								Effect.succeed({
+									items: [{ id: template }],
+									pageCount: 1,
+								}),
+							),
 						20,
 					);
 					return Effect.sync(() => {
@@ -132,11 +149,12 @@ describe("exercise template catalog", () => {
 	});
 
 	it("uses templates.listAll rather than a Promise client for lookup", async () => {
-		const listAll = vi
-			.fn<ListAll["effect"]>()
-			.mockReturnValue(
-				Effect.succeed([{ id: "template-1", title: "Template 1" }]),
-			);
+		const listAll = vi.fn<ListAll["effect"]>().mockReturnValue(
+			Effect.succeed({
+				items: [{ id: "template-1", title: "Template 1" }],
+				pageCount: 1,
+			}),
+		);
 		const catalog = createCatalog(operation(listAll));
 
 		await expect(catalog.get()).resolves.toEqual([
@@ -147,11 +165,12 @@ describe("exercise template catalog", () => {
 
 	it("reloads after the five-minute TTL", async () => {
 		let calls = 0;
-		const listAll = vi
-			.fn<ListAll["effect"]>()
-			.mockImplementation(() =>
-				Effect.succeed([{ id: `template-${++calls}` }]),
-			);
+		const listAll = vi.fn<ListAll["effect"]>().mockImplementation(() =>
+			Effect.succeed({
+				items: [{ id: `template-${++calls}` }],
+				pageCount: 1,
+			}),
+		);
 		const catalog = createCatalog(operation(listAll));
 		const program = Effect.gen(function* () {
 			const first = yield* catalog.effect();
@@ -171,8 +190,19 @@ describe("exercise template catalog", () => {
 	it("invalidates a failed lookup before the next call", async () => {
 		const listAll = vi
 			.fn<ListAll["effect"]>()
-			.mockReturnValueOnce(Effect.fail(new Error("temporary failure")))
-			.mockReturnValueOnce(Effect.succeed([{ id: "recovered" }]));
+			.mockReturnValueOnce(
+				Effect.fail(
+					new PaginationMismatchError({
+						requested: 1,
+						received: -1,
+						collection: "exerciseTemplates",
+						message: "temporary failure",
+					}),
+				),
+			)
+			.mockReturnValueOnce(
+				Effect.succeed({ items: [{ id: "recovered" }], pageCount: 1 }),
+			);
 		const catalog = createCatalog(operation(listAll));
 
 		await expect(catalog.get()).rejects.toThrow("temporary failure");
@@ -183,12 +213,12 @@ describe("exercise template catalog", () => {
 	it("shares one load between controlled callers", async () => {
 		const pending: Array<{
 			signal: AbortSignal | undefined;
-			resume: (effect: Effect.Effect<ExerciseTemplate[]>) => void;
+			resume: (effect: Effect.Effect<TemplatesListAllResult>) => void;
 		}> = [];
 		const listAll = vi
 			.fn<ListAll["effect"]>()
 			.mockImplementation((options?: HevyExecutionOptions) =>
-				Effect.callback<ExerciseTemplate[], ListAllError>((resume) => {
+				Effect.callback<TemplatesListAllResult, ListAllError>((resume) => {
 					pending.push({ resume, signal: options?.signal });
 				}),
 			);
@@ -198,7 +228,9 @@ describe("exercise template catalog", () => {
 		const second = catalog.get({ execution: {} });
 		await vi.waitFor(() => expect(pending).toHaveLength(1));
 
-		pending[0]?.resume(Effect.succeed([{ id: "shared" }]));
+		pending[0]?.resume(
+			Effect.succeed({ items: [{ id: "shared" }], pageCount: 1 }),
+		);
 		await expect(first).resolves.toMatchObject([{ id: "shared" }]);
 		await expect(second).resolves.toMatchObject([{ id: "shared" }]);
 		expect(pending[0]?.signal).toBeUndefined();
@@ -208,7 +240,9 @@ describe("exercise template catalog", () => {
 	it("fails a past execution deadline as a typed timeout", async () => {
 		const listAll = vi
 			.fn<ListAll["effect"]>()
-			.mockReturnValue(Effect.succeed([{ id: "unused" }]));
+			.mockReturnValue(
+				Effect.succeed({ items: [{ id: "unused" }], pageCount: 0 }),
+			);
 		const catalog = createCatalog(operation(listAll));
 
 		await expect(
@@ -224,7 +258,9 @@ describe("exercise template catalog", () => {
 		controller.abort(new DOMException("cancelled", "AbortError"));
 		const listAll = vi
 			.fn<ListAll["effect"]>()
-			.mockReturnValue(Effect.succeed([{ id: "unused" }]));
+			.mockReturnValue(
+				Effect.succeed({ items: [{ id: "unused" }], pageCount: 0 }),
+			);
 		const catalog = createCatalog(operation(listAll));
 
 		await expect(

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -16,7 +16,6 @@ import { bucketCount } from "./result-telemetry.js";
 export const EXERCISE_TEMPLATE_CATALOG_CACHE_KEY = "exercise-template-catalog";
 export const EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
 export const EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE = 1;
-const EXERCISE_TEMPLATE_CATALOG_PAGE_SIZE = 100;
 
 export type ExerciseTemplateCatalogRefreshReason =
 	| "explicit-refresh"
@@ -37,7 +36,7 @@ type TemplateListAllError = Effect.Error<
 >;
 export type ExerciseTemplateCatalogCache = Cache.Cache<
 	string,
-	ExerciseTemplate[],
+	TemplatesListAllResult,
 	TemplateListAllError
 >;
 export interface ExerciseTemplateCatalog {
@@ -92,13 +91,6 @@ function notifyRefreshed(
 		// Callbacks are best effort.
 	}
 }
-function catalogPageCount(catalog: readonly ExerciseTemplate[]): number {
-	return Math.max(
-		1,
-		Math.ceil(catalog.length / EXERCISE_TEMPLATE_CATALOG_PAGE_SIZE),
-	);
-}
-
 export function createExerciseTemplateCatalog(
 	operations: CatalogOperations,
 	cache: ExerciseTemplateCatalogCache,
@@ -172,20 +164,16 @@ export function createExerciseTemplateCatalog(
 		const load = Effect.gen(function* () {
 			if (refresh) {
 				const result = yield* listAll.effect();
-				yield* Cache.set(
-					cache,
-					EXERCISE_TEMPLATE_CATALOG_CACHE_KEY,
-					result.items,
-				);
+				yield* Cache.set(cache, EXERCISE_TEMPLATE_CATALOG_CACHE_KEY, result);
 				hasLoadedValue = true;
 				return result;
 			}
-			const catalog = yield* Cache.get(
+			const result = yield* Cache.get(
 				cache,
 				EXERCISE_TEMPLATE_CATALOG_CACHE_KEY,
 			);
 			hasLoadedValue = true;
-			return { items: catalog, pageCount: catalogPageCount(catalog) };
+			return result;
 		});
 		let shared =
 			inFlight && (!refresh || inFlight.refresh) ? inFlight : undefined;

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -1,7 +1,10 @@
 import { Cache, Clock, Deferred, Effect, Fiber, Option } from "effect";
 import type { HevyRequestOptions } from "@hevy-mcp/hevy-client";
 import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
-import type { TemplatesListAllOperation } from "@hevy-mcp/operations";
+import type {
+	TemplatesListAllOperation,
+	TemplatesListAllResult,
+} from "@hevy-mcp/operations";
 import type {
 	CacheObservationMetadata,
 	CacheObservationScope,
@@ -90,12 +93,9 @@ function notifyRefreshed(
 	}
 }
 function catalogPageCount(catalog: readonly ExerciseTemplate[]): number {
-	const pages = (
-		catalog as ExerciseTemplate[] & { readonly pageCount?: number }
-	).pageCount;
-	return (
-		pages ??
-		Math.max(1, Math.ceil(catalog.length / EXERCISE_TEMPLATE_CATALOG_PAGE_SIZE))
+	return Math.max(
+		1,
+		Math.ceil(catalog.length / EXERCISE_TEMPLATE_CATALOG_PAGE_SIZE),
 	);
 }
 
@@ -112,7 +112,10 @@ export function createExerciseTemplateCatalog(
 	let generation = 0;
 	let inFlight:
 		| {
-				deferred: Deferred.Deferred<ExerciseTemplate[], TemplateListAllError>;
+				deferred: Deferred.Deferred<
+					TemplatesListAllResult,
+					TemplateListAllError
+				>;
 				fiber: Fiber.Fiber<boolean, never>;
 				waiters: number;
 				refresh: boolean;
@@ -167,19 +170,28 @@ export function createExerciseTemplateCatalog(
 		let metadata: CacheObservationMetadata | undefined;
 		const currentGeneration = ++generation;
 		const load = Effect.gen(function* () {
-			const catalog = yield* refresh
-				? listAll.effect()
-				: Cache.get(cache, EXERCISE_TEMPLATE_CATALOG_CACHE_KEY);
-			if (refresh)
-				yield* Cache.set(cache, EXERCISE_TEMPLATE_CATALOG_CACHE_KEY, catalog);
+			if (refresh) {
+				const result = yield* listAll.effect();
+				yield* Cache.set(
+					cache,
+					EXERCISE_TEMPLATE_CATALOG_CACHE_KEY,
+					result.items,
+				);
+				hasLoadedValue = true;
+				return result;
+			}
+			const catalog = yield* Cache.get(
+				cache,
+				EXERCISE_TEMPLATE_CATALOG_CACHE_KEY,
+			);
 			hasLoadedValue = true;
-			return catalog;
+			return { items: catalog, pageCount: catalogPageCount(catalog) };
 		});
 		let shared =
 			inFlight && (!refresh || inFlight.refresh) ? inFlight : undefined;
 		if (!shared) {
 			const deferred = yield* Deferred.make<
-				ExerciseTemplate[],
+				TemplatesListAllResult,
 				TemplateListAllError
 			>();
 			const fiber = yield* Effect.forkDetach(
@@ -219,12 +231,12 @@ export function createExerciseTemplateCatalog(
 			: loaded;
 		return yield* Effect.ensuring(
 			controlled.pipe(
-				Effect.tap((catalog) =>
+				Effect.tap(({ items: catalog, pageCount }) =>
 					Effect.sync(() => {
 						if (currentGeneration === generation && state !== "hit") {
 							metadata = {
 								refreshReason: reason,
-								pageCountBucket: bucketCount(catalogPageCount(catalog)),
+								pageCountBucket: bucketCount(pageCount),
 								itemCountBucket: bucketCount(catalog.length),
 							};
 							if (state !== "inflight_wait")
@@ -238,6 +250,7 @@ export function createExerciseTemplateCatalog(
 						() => Effect.fail(error),
 					),
 				),
+				Effect.map((result) => result.items),
 			),
 			Effect.sync(() => finishObservation(observationScope, metadata)),
 		);

--- a/packages/hevy-client/src/internal-request-effect.ts
+++ b/packages/hevy-client/src/internal-request-effect.ts
@@ -1,5 +1,4 @@
 import { Effect, Predicate } from "effect";
-import { z } from "zod";
 import type {
 	BodyMeasurement,
 	CreateCustomExerciseRequestBody,
@@ -72,8 +71,7 @@ export type HevyRequestEffectError =
 	| ValidationError
 	| RateLimitError
 	| ApiError
-	| NetworkError
-	| Error;
+	| NetworkError;
 
 export interface HevyRequestEffectClient {
 	getWorkouts(
@@ -199,12 +197,10 @@ type RequestEffectOwner =
 	| RequestEffectAttachment
 	| CuratedClientWithNativeRequestEffect;
 
-const functionSchema = z.function();
-
 function isNativeRequestEffect(
 	value: NativeRequestEffect | undefined,
 ): value is NativeRequestEffect {
-	return functionSchema.safeParse(value).success;
+	return Predicate.isFunction(value);
 }
 
 /**

--- a/packages/operations/src/body-measurements.test.ts
+++ b/packages/operations/src/body-measurements.test.ts
@@ -1,4 +1,5 @@
 import { NotFoundError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
 import type {
 	BodyMeasurement,
 	GetV1BodyMeasurements200,
@@ -25,7 +26,7 @@ function notFound(endpoint = "/v1/body_measurements") {
 }
 
 function createAdapter(
-	responses: readonly (GetV1BodyMeasurements200 | Error)[],
+	responses: readonly (GetV1BodyMeasurements200 | HevyRequestEffectError)[],
 ) {
 	let responseIndex = 0;
 	const requests: Array<{
@@ -44,7 +45,7 @@ function createAdapter(
 			const response = responses[responseIndex++] ?? {
 				body_measurements: [],
 			};
-			return response instanceof Error
+			return "_tag" in response
 				? Effect.fail(response)
 				: Effect.succeed(response);
 		},

--- a/packages/operations/src/folders.test.ts
+++ b/packages/operations/src/folders.test.ts
@@ -1,4 +1,4 @@
-import { HevyHttpError, NotFoundError } from "@hevy-mcp/hevy-client";
+import { NotFoundError } from "@hevy-mcp/hevy-client";
 import type {
 	GetV1RoutineFolders200,
 	PostRoutineFolderRequestBody,
@@ -189,10 +189,11 @@ describe("folders.listAll operation", () => {
 	});
 
 	it("does not recover a member-path 404 while listing", async () => {
-		const error = new HevyHttpError("not found", {
+		const error = new NotFoundError({
 			status: 404,
 			method: "GET",
 			endpoint: "/v1/routine_folders/42",
+			expected: false,
 		});
 		const operation = createFoldersListAllOperation({
 			getRoutineFolders: vi

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -274,6 +274,7 @@ export type {
 export { PaginationMismatchError } from "./operation-errors.js";
 export {
 	EmptyMeasurementUpdateError,
+	TemplatesSearchValidationError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,
 	WorkoutPayloadError,
@@ -284,7 +285,6 @@ export type {
 	ReadCollectionEndpoint,
 	ReadEndpoint,
 	ReadMemberEndpoint,
-	ReadOperationError,
 } from "./operation-errors.js";
 export { WORKOUT_PUT_REQUIRES_IS_PRIVATE } from "./hevy-quirks.js";
 export {

--- a/packages/operations/src/operation-errors.ts
+++ b/packages/operations/src/operation-errors.ts
@@ -25,7 +25,6 @@ export type ReadMemberEndpoint = Extract<
 	| "/v1/workouts/:workoutId"
 >;
 export type ReadEndpoint = HevyEndpointTemplate;
-export type ReadOperationError = Error;
 
 export class PaginationMismatchError extends Schema.TaggedError<PaginationMismatchError>()(
 	"PaginationMismatchError",
@@ -74,6 +73,14 @@ export class TrainingSummaryDataError extends Schema.TaggedError<TrainingSummary
 	},
 ) {}
 
+export class TemplatesSearchValidationError extends Schema.TaggedError<TemplatesSearchValidationError>()(
+	"TemplatesSearchValidationError",
+	{
+		maxPages: Schema.Number,
+		message: Schema.String,
+	},
+) {}
+
 const collectionMemberEndpoints = {
 	"/v1/body_measurements": "/v1/body_measurements/:date",
 	"/v1/exercise_templates": "/v1/exercise_templates/:exerciseTemplateId",
@@ -86,18 +93,18 @@ const collectionMemberEndpoints = {
 	ReadMemberEndpoint | undefined
 >;
 
-function errorIdentity(error: ReadOperationError):
+function errorIdentity(cause: unknown):
 	| {
 			readonly status?: number;
 			readonly method: string;
 			readonly endpoint: string;
 	  }
 	| undefined {
-	if (isHevyHttpError(error) || error instanceof NotFoundError) {
+	if (isHevyHttpError(cause) || cause instanceof NotFoundError) {
 		return {
-			status: error.status,
-			method: error.method,
-			endpoint: error.endpoint,
+			status: cause.status,
+			method: cause.method,
+			endpoint: cause.endpoint,
 		};
 	}
 	return undefined;
@@ -111,11 +118,11 @@ function errorIdentity(error: ReadOperationError):
  * request state, so unexpected errors remain in the Effect channel.
  */
 export function classifyReadError(
-	error: ReadOperationError,
+	cause: unknown,
 	endpoint: ReadEndpoint,
 	page?: number,
 ): ExpectedReadError | undefined {
-	const identity = errorIdentity(error);
+	const identity = errorIdentity(cause);
 	if (
 		identity === undefined ||
 		identity.status !== 404 ||
@@ -160,16 +167,16 @@ export function classifyReadError(
 }
 
 export function isExpectedReadNotFound(
-	error: ReadOperationError,
+	cause: unknown,
 	endpoint: ReadEndpoint,
 ): boolean {
-	return classifyReadError(error, endpoint) === "not_found";
+	return classifyReadError(cause, endpoint) === "not_found";
 }
 
 export function isExpectedReadEndOfList(
-	error: ReadOperationError,
+	cause: unknown,
 	endpoint: ReadCollectionEndpoint,
 	page: number,
 ): boolean {
-	return page > 1 && classifyReadError(error, endpoint, page) === "end_of_list";
+	return page > 1 && classifyReadError(cause, endpoint, page) === "end_of_list";
 }

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -1,5 +1,11 @@
 import type { HevyClient, HevyExecutionOptions } from "@hevy-mcp/hevy-client";
-import { HevyHttpError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
+import {
+	ApiError,
+	NetworkError,
+	NotFoundError,
+	RateLimitError,
+} from "@hevy-mcp/hevy-client";
 import type {
 	GetV1Routines200,
 	GetV1RoutinesRoutineid200,
@@ -31,7 +37,7 @@ interface InMemoryRoutinesAdapter extends RoutinesListAdapter {
 }
 
 function createInMemoryAdapter(
-	responses: readonly (GetV1Routines200 | Error)[],
+	responses: readonly (GetV1Routines200 | HevyRequestEffectError)[],
 ): InMemoryRoutinesAdapter {
 	let responseIndex = 0;
 	const requests: InMemoryRoutinesAdapter["requests"] = [];
@@ -43,27 +49,24 @@ function createInMemoryAdapter(
 			argumentCounts.push(arguments.length);
 			requests.push({ params, options });
 			const response = responses[responseIndex++] ?? { routines: [] };
-			if (response instanceof Error) return Effect.fail(response);
+			if ("_tag" in response) return Effect.fail(response);
 			return Effect.succeed(response);
 		},
 	};
 }
 
-function httpError(
-	status: number,
-	method: string,
-	endpoint: string,
-	message = "request failed",
-) {
-	return new HevyHttpError(message, {
-		status,
-		method,
-		endpoint,
-	});
+function httpError(status: number, method: string, endpoint: string) {
+	if (status === 404) {
+		return new NotFoundError({ status, method, endpoint, expected: true });
+	}
+	if (status === 429) {
+		return new RateLimitError({ status, method, endpoint });
+	}
+	return new ApiError({ status, method, endpoint });
 }
 
 function notFound(endpoint = "/v1/routines", method = "GET") {
-	return httpError(404, method, endpoint, "not found");
+	return httpError(404, method, endpoint);
 }
 
 interface InMemoryRoutinesGetAdapter extends RoutinesGetAdapter {
@@ -77,14 +80,14 @@ interface InMemoryRoutinesGetAdapter extends RoutinesGetAdapter {
 function abortable<T>(
 	options: HevyExecutionOptions | undefined,
 	error: Error,
-): Effect.Effect<T, Error> {
+): Effect.Effect<T> {
 	const signal = options?.signal;
-	if (signal === undefined) return Effect.fail(error);
+	if (signal === undefined) return Effect.die(error);
 	return Effect.callback((resume) => {
 		const rejectOnAbort = () => {
 			signal.removeEventListener("abort", rejectOnAbort);
 			const reason = signal.reason;
-			resume(Effect.fail(reason instanceof Error ? reason : error));
+			resume(Effect.die(reason instanceof Error ? reason : error));
 		};
 		if (signal.aborted) {
 			rejectOnAbort();
@@ -100,8 +103,12 @@ function abortable<T>(
 function createInMemoryGetAdapter(
 	responses:
 		| GetV1RoutinesRoutineid200
-		| Error
-		| readonly (GetV1RoutinesRoutineid200 | Error | undefined)[],
+		| HevyRequestEffectError
+		| readonly (
+				| GetV1RoutinesRoutineid200
+				| HevyRequestEffectError
+				| undefined
+		  )[],
 ): InMemoryRoutinesGetAdapter {
 	const requests: InMemoryRoutinesGetAdapter["requests"] = [];
 	const argumentCounts: InMemoryRoutinesGetAdapter["argumentCounts"] = [];
@@ -114,7 +121,8 @@ function createInMemoryGetAdapter(
 			argumentCounts.push(arguments.length);
 			requests.push({ routineId, options });
 			const response = responseSequence[responseIndex++];
-			if (response instanceof Error) return Effect.fail(response);
+			if (response !== undefined && "_tag" in response)
+				return Effect.fail(response);
 			return Effect.succeed(response ?? {});
 		},
 	};
@@ -162,7 +170,7 @@ function createRoutineWriteAdapter(
 }
 
 function createSearchAdapter(
-	responses: readonly (GetV1Routines200 | Error)[],
+	responses: readonly (GetV1Routines200 | HevyRequestEffectError)[],
 ): RoutinesSearchAdapter & {
 	readonly requests: Array<{
 		readonly params: Parameters<HevyClient["getRoutines"]>[0];
@@ -179,7 +187,7 @@ function createSearchAdapter(
 		getRoutines(params, options) {
 			requests.push({ params, options });
 			const response = responses[responseIndex++] ?? { routines: [] };
-			if (response instanceof Error) return Effect.fail(response);
+			if ("_tag" in response) return Effect.fail(response);
 			return Effect.succeed(response);
 		},
 	};
@@ -248,7 +256,7 @@ describe("routines.get operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves non-404 error identity for routines.get", async () => {
-		const error = httpError(401, "GET", "/v1/routines/r1", "unauthorized");
+		const error = httpError(401, "GET", "/v1/routines/r1");
 		const operation = createRoutinesGetOperation(
 			createInMemoryGetAdapter(error),
 		);
@@ -372,7 +380,7 @@ describe("routines.update operation", () => {
 		const adapter = {
 			...createRoutineWriteAdapter(),
 			getRoutineById: vi.fn(() =>
-				Effect.fail(new Error("update must not read first")),
+				Effect.die(new Error("update must not read first")),
 			),
 		};
 		const operation = createRoutinesUpdateOperation(adapter);
@@ -805,7 +813,12 @@ describe("routines.list operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves a plain network error for routines.get", async () => {
-		const error = new Error("network failure");
+		const error = new NetworkError({
+			code: "ERR_NETWORK",
+			endpoint: "/v1/routines/r1",
+			method: "GET",
+			retryExhausted: false,
+		});
 		const operation = createRoutinesGetOperation(
 			createInMemoryGetAdapter(error),
 		);
@@ -814,7 +827,7 @@ describe("routines.list operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves a non-404 HTTP error for routines.list", async () => {
-		const error = httpError(503, "GET", "/v1/routines", "upstream failure");
+		const error = httpError(503, "GET", "/v1/routines");
 		const operation = createRoutinesListOperation(
 			createInMemoryAdapter([error]),
 		);
@@ -971,7 +984,7 @@ describe("routines.list operation", () => {
 		const adapter: RoutinesListAdapter = {
 			getRoutines(params) {
 				if (params === undefined) {
-					return Effect.fail(new Error("params are required"));
+					return Effect.die(new Error("params are required"));
 				}
 				return params.page === 2
 					? Effect.fail(error)

--- a/packages/operations/src/templates.test.ts
+++ b/packages/operations/src/templates.test.ts
@@ -1,4 +1,5 @@
-import { HevyHttpError, NotFoundError } from "@hevy-mcp/hevy-client";
+import { NotFoundError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
 import type {
 	CreateCustomExerciseRequestBody,
 	ExerciseHistoryEntry,
@@ -29,15 +30,12 @@ function notFound(endpoint: string): NotFoundError {
 }
 
 function createGetAdapter(
-	response: ExerciseTemplate | Error,
+	response: ExerciseTemplate | HevyRequestEffectError,
 ): TemplatesGetAdapter {
 	const getExerciseTemplate: TemplatesGetAdapter["getExerciseTemplate"] = (
 		_id,
 		_options,
-	) =>
-		response instanceof Error
-			? Effect.fail(response)
-			: Effect.succeed(response);
+	) => ("_tag" in response ? Effect.fail(response) : Effect.succeed(response));
 	return { getExerciseTemplate };
 }
 
@@ -218,12 +216,10 @@ describe("templates.listAll operation", () => {
 		});
 
 		const templates = await Effect.runPromise(operation.effect(options));
-		expect(templates).toEqual([
-			{ id: "template-1" },
-			{ id: "template-2" },
-			{ id: "template-3" },
-		]);
-		expect(templates.pageCount).toBe(3);
+		expect(templates).toEqual({
+			items: [{ id: "template-1" }, { id: "template-2" }, { id: "template-3" }],
+			pageCount: 3,
+		});
 		expect(requests).toEqual([
 			{ params: { page: 1, pageSize: 100 }, options },
 			{ params: { page: 2, pageSize: 100 }, options },
@@ -249,9 +245,10 @@ describe("templates.listAll operation", () => {
 			getExerciseTemplates,
 		});
 
-		await expect(Effect.runPromise(operation.effect())).resolves.toEqual([
-			{ id: "template-1" },
-		]);
+		await expect(Effect.runPromise(operation.effect())).resolves.toEqual({
+			items: [{ id: "template-1" }],
+			pageCount: 2,
+		});
 		expect(getExerciseTemplates).toHaveBeenCalledTimes(2);
 	});
 
@@ -275,7 +272,7 @@ describe("templates.listAll operation", () => {
 
 		await expect(
 			Effect.runPromise(laterPageOperation.effect()),
-		).resolves.toEqual([{ id: "template-1" }]);
+		).resolves.toEqual({ items: [{ id: "template-1" }], pageCount: 1 });
 		expect(laterPageAdapter.getExerciseTemplates).toHaveBeenCalledTimes(2);
 
 		const firstPageError = notFound("/v1/exercise_templates");
@@ -348,10 +345,11 @@ describe("templates.listAll operation", () => {
 	});
 
 	it("does not recover a member-path 404 while listing", async () => {
-		const error = new HevyHttpError("not found", {
+		const error = new NotFoundError({
 			status: 404,
 			method: "GET",
 			endpoint: "/v1/exercise_templates/template-1",
+			expected: false,
 		});
 		const operation = createTemplatesListAllOperation({
 			getExerciseTemplates: vi
@@ -462,5 +460,27 @@ describe("templates.search operation", () => {
 			_tag: "PaginationMismatchError",
 			message: "The API returned invalid pagination metadata",
 		});
+	});
+
+	it("fails typed on out-of-range maxPages instead of silently returning empty", async () => {
+		const getExerciseTemplates = vi.fn(() =>
+			Effect.succeed({
+				page: 1,
+				page_count: 1,
+				exercise_templates: [{ id: "template-1", title: "Bench" }],
+			}),
+		);
+		const operation = createTemplatesSearchOperation({
+			getExerciseTemplates,
+		});
+		for (const maxPages of [0, -1, 101, 1.5, Number.NaN]) {
+			await expect(
+				Effect.runPromise(operation.effect({ query: "bench", maxPages })),
+			).rejects.toMatchObject({
+				_tag: "TemplatesSearchValidationError",
+				maxPages,
+			});
+		}
+		expect(getExerciseTemplates).not.toHaveBeenCalled();
 	});
 });

--- a/packages/operations/src/templates.ts
+++ b/packages/operations/src/templates.ts
@@ -18,6 +18,7 @@ import {
 	isExpectedReadEndOfList,
 	isExpectedReadNotFound,
 	PaginationMismatchError,
+	TemplatesSearchValidationError,
 } from "./operation-errors.js";
 
 export interface TemplatesGetInput {
@@ -170,12 +171,13 @@ export interface TemplatesListAllOperation {
 		TemplatesListAllResult,
 		HevyRequestEffectError | PaginationMismatchError
 	>;
-	execute(options?: HevyExecutionOptions): Promise<ExerciseTemplate[]>;
+	execute(options?: HevyExecutionOptions): Promise<TemplatesListAllResult>;
 }
 
-export type TemplatesListAllResult = ExerciseTemplate[] & {
-	readonly pageCount?: number;
-};
+export interface TemplatesListAllResult {
+	readonly items: ExerciseTemplate[];
+	readonly pageCount: number;
+}
 
 export interface TemplatesSearchInput {
 	readonly query: string;
@@ -206,7 +208,9 @@ export interface TemplatesSearchOperation {
 		options?: HevyExecutionOptions,
 	) => Effect.Effect<
 		TemplatesSearchOutput,
-		HevyRequestEffectError | PaginationMismatchError
+		| HevyRequestEffectError
+		| PaginationMismatchError
+		| TemplatesSearchValidationError
 	>;
 	execute(
 		input: TemplatesSearchInput,
@@ -215,6 +219,8 @@ export interface TemplatesSearchOperation {
 }
 
 const TEMPLATES_PAGE_SIZE = 100;
+const TEMPLATES_SEARCH_MIN_PAGES = 1;
+const TEMPLATES_SEARCH_MAX_PAGES = 100;
 
 type TemplatesListCursor = {
 	readonly page: number;
@@ -446,16 +452,10 @@ export function createTemplatesListAllOperation(
 			);
 		});
 		const pages = yield* Stream.runCollect(pageStream);
-		const templates = pages.flatMap(
-			(page) => page.templates,
-		) as TemplatesListAllResult;
-		Object.defineProperty(templates, "pageCount", {
-			configurable: false,
-			enumerable: false,
-			value: pages.length,
-			writable: false,
-		});
-		return templates;
+		return {
+			items: pages.flatMap((page) => page.templates),
+			pageCount: pages.length,
+		};
 	});
 
 	const operation: TemplatesListAllOperation = {
@@ -475,7 +475,17 @@ export function createTemplatesSearchOperation(
 		input: TemplatesSearchInput,
 		options?: HevyExecutionOptions,
 	) {
-		const maxPages = Math.max(0, Math.min(input.maxPages, 100));
+		if (
+			!Number.isInteger(input.maxPages) ||
+			input.maxPages < TEMPLATES_SEARCH_MIN_PAGES ||
+			input.maxPages > TEMPLATES_SEARCH_MAX_PAGES
+		) {
+			return yield* new TemplatesSearchValidationError({
+				maxPages: input.maxPages,
+				message: `Templates search maxPages must be an integer from ${TEMPLATES_SEARCH_MIN_PAGES} through ${TEMPLATES_SEARCH_MAX_PAGES}`,
+			});
+		}
+		const maxPages = input.maxPages;
 		const query = input.query.toLowerCase();
 		const pageStream = Stream.paginate<
 			TemplatesSearchCursor,

--- a/packages/operations/src/workflows.test.ts
+++ b/packages/operations/src/workflows.test.ts
@@ -1,4 +1,5 @@
 import { NotFoundError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
 import type {
 	BodyMeasurement,
 	GetV1BodyMeasurements200,
@@ -56,8 +57,11 @@ type ListOperationsFixture = {
 };
 
 function createListOperations(
-	workoutResponses: readonly (GetV1Workouts200 | Error)[],
-	measurementResponses: readonly (GetV1BodyMeasurements200 | Error)[],
+	workoutResponses: readonly (GetV1Workouts200 | HevyRequestEffectError)[],
+	measurementResponses: readonly (
+		| GetV1BodyMeasurements200
+		| HevyRequestEffectError
+	)[],
 ): ListOperationsFixture {
 	let workoutResponseIndex = 0;
 	let measurementResponseIndex = 0;
@@ -82,7 +86,7 @@ function createListOperations(
 			const response = workoutResponses[workoutResponseIndex++] ?? {
 				workouts: [],
 			};
-			return response instanceof Error
+			return "_tag" in response
 				? Effect.fail(response)
 				: Effect.succeed(response);
 		},
@@ -97,7 +101,7 @@ function createListOperations(
 			const response = measurementResponses[measurementResponseIndex++] ?? {
 				body_measurements: [],
 			};
-			return response instanceof Error
+			return "_tag" in response
 				? Effect.fail(response)
 				: Effect.succeed(response);
 		},
@@ -331,7 +335,7 @@ describe("workflows.trainingSummary operation", () => {
 		).rejects.toBeInstanceOf(NotFoundError);
 	});
 
-	it("returns an empty scan without loading when a window cannot be parsed", async () => {
+	it("fails without loading when a window cannot be parsed", async () => {
 		const loader = vi.fn(() =>
 			Effect.succeed({
 				items: [{ id: "unexpected" }],
@@ -351,10 +355,9 @@ describe("workflows.trainingSummary operation", () => {
 					(item: { id: string }) => item.id,
 				),
 			),
-		).resolves.toEqual({
-			items: [],
-			pages: 0,
-			itemsScanned: 0,
+		).rejects.toMatchObject({
+			_tag: "TrainingSummaryDataError",
+			message: "The training summary window contains an invalid date",
 		});
 		expect(loader).not.toHaveBeenCalled();
 	});

--- a/packages/operations/src/workflows.ts
+++ b/packages/operations/src/workflows.ts
@@ -226,7 +226,10 @@ export const scanPagesInWindow = Effect.fn(
 	const start = parseUtcDate(startDate);
 	const end = parseUtcDate(endDate);
 	if (start === undefined || end === undefined) {
-		return { items: [], pages: 0, itemsScanned: 0 };
+		return yield* new TrainingSummaryDataError({
+			collection: "training-summary",
+			message: "The training summary window contains an invalid date",
+		});
 	}
 
 	const startMillis = DateTime.toEpochMillis(start);

--- a/packages/operations/src/workout-events.test.ts
+++ b/packages/operations/src/workout-events.test.ts
@@ -1,4 +1,5 @@
 import { NotFoundError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
 import type { GetV1WorkoutsEvents200 } from "@hevy-mcp/hevy-client/types";
 import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
@@ -16,7 +17,9 @@ function notFound(endpoint = "/v1/workouts/events") {
 	});
 }
 
-function createAdapter(responses: readonly (GetV1WorkoutsEvents200 | Error)[]) {
+function createAdapter(
+	responses: readonly (GetV1WorkoutsEvents200 | HevyRequestEffectError)[],
+) {
 	let responseIndex = 0;
 	const requests: Array<{
 		readonly params: Parameters<WorkoutsEventsAdapter["getWorkoutEvents"]>[0];
@@ -30,7 +33,7 @@ function createAdapter(responses: readonly (GetV1WorkoutsEvents200 | Error)[]) {
 				page_count: 1,
 				events: [],
 			};
-			return response instanceof Error
+			return "_tag" in response
 				? Effect.fail(response)
 				: Effect.succeed(response);
 		},

--- a/packages/operations/src/workouts.test.ts
+++ b/packages/operations/src/workouts.test.ts
@@ -1,5 +1,6 @@
 import type { HevyClient, HevyExecutionOptions } from "@hevy-mcp/hevy-client";
-import { HevyHttpError } from "@hevy-mcp/hevy-client";
+import type { HevyRequestEffectError } from "@hevy-mcp/hevy-client/internal";
+import { ApiError, NetworkError, RateLimitError } from "@hevy-mcp/hevy-client";
 import type {
 	GetV1Workouts200,
 	GetV1WorkoutsCountStatus200,
@@ -38,7 +39,7 @@ interface InMemoryWorkoutsAdapter extends WorkoutsListAdapter {
 }
 
 function createInMemoryAdapter(
-	responses: readonly (GetV1Workouts200 | Error)[],
+	responses: readonly (GetV1Workouts200 | HevyRequestEffectError)[],
 ): InMemoryWorkoutsAdapter {
 	let responseIndex = 0;
 	const requests: InMemoryWorkoutsAdapter["requests"] = [];
@@ -50,27 +51,24 @@ function createInMemoryAdapter(
 			argumentCounts.push(arguments.length);
 			requests.push({ params, options });
 			const response = responses[responseIndex++] ?? { workouts: [] };
-			if (response instanceof Error) return Effect.fail(response);
+			if ("_tag" in response) return Effect.fail(response);
 			return Effect.succeed(response);
 		},
 	};
 }
 
-function httpError(
-	status: number,
-	method: string,
-	endpoint: string,
-	message = "request failed",
-) {
-	return new HevyHttpError(message, {
-		status,
-		method,
-		endpoint,
-	});
+function httpError(status: number, method: string, endpoint: string) {
+	if (status === 404) {
+		return new NotFoundError({ status, method, endpoint, expected: true });
+	}
+	if (status === 429) {
+		return new RateLimitError({ status, method, endpoint });
+	}
+	return new ApiError({ status, method, endpoint });
 }
 
 function notFound(endpoint = "/v1/workouts", method = "GET") {
-	return httpError(404, method, endpoint, "not found");
+	return httpError(404, method, endpoint);
 }
 
 interface InMemoryWorkoutsGetAdapter extends WorkoutsGetAdapter {
@@ -84,14 +82,14 @@ interface InMemoryWorkoutsGetAdapter extends WorkoutsGetAdapter {
 function abortable<T>(
 	options: HevyExecutionOptions | undefined,
 	error: Error,
-): Effect.Effect<T, Error> {
+): Effect.Effect<T> {
 	const signal = options?.signal;
-	if (signal === undefined) return Effect.fail(error);
+	if (signal === undefined) return Effect.die(error);
 	return Effect.callback((resume) => {
 		const rejectOnAbort = () => {
 			signal.removeEventListener("abort", rejectOnAbort);
 			const reason = signal.reason;
-			resume(Effect.fail(reason instanceof Error ? reason : error));
+			resume(Effect.die(reason instanceof Error ? reason : error));
 		};
 		if (signal.aborted) {
 			rejectOnAbort();
@@ -107,8 +105,12 @@ function abortable<T>(
 function createInMemoryGetAdapter(
 	responses?:
 		| GetV1WorkoutsWorkoutid200
-		| Error
-		| readonly (GetV1WorkoutsWorkoutid200 | Error | undefined)[],
+		| HevyRequestEffectError
+		| readonly (
+				| GetV1WorkoutsWorkoutid200
+				| HevyRequestEffectError
+				| undefined
+		  )[],
 ): InMemoryWorkoutsGetAdapter {
 	const requests: InMemoryWorkoutsGetAdapter["requests"] = [];
 	const argumentCounts: InMemoryWorkoutsGetAdapter["argumentCounts"] = [];
@@ -121,7 +123,8 @@ function createInMemoryGetAdapter(
 			argumentCounts.push(arguments.length);
 			requests.push({ workoutId, options });
 			const response = responseSequence[responseIndex++];
-			if (response instanceof Error) return Effect.fail(response);
+			if (response !== undefined && "_tag" in response)
+				return Effect.fail(response);
 			return Effect.succeed(response as GetV1WorkoutsWorkoutid200);
 		},
 	};
@@ -214,7 +217,7 @@ describe("workouts.get operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves non-404 error identity for workouts.get", async () => {
-		const error = httpError(503, "GET", "/v1/workouts/w1", "upstream failure");
+		const error = httpError(503, "GET", "/v1/workouts/w1");
 		const operation = createWorkoutsGetOperation(
 			createInMemoryGetAdapter(error),
 		);
@@ -320,7 +323,12 @@ describe("workouts.list operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves non-404 error identity for workouts.list", async () => {
-		const error = new Error("network failure");
+		const error = new NetworkError({
+			code: "ERR_NETWORK",
+			endpoint: "/v1/workouts",
+			method: "GET",
+			retryExhausted: false,
+		});
 		const operation = createWorkoutsListOperation(
 			createInMemoryAdapter([error]),
 		);
@@ -471,7 +479,12 @@ describe("workouts.list operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves a plain network error for workouts.get", async () => {
-		const error = new Error("network failure");
+		const error = new NetworkError({
+			code: "ERR_NETWORK",
+			endpoint: "/v1/workouts/w1",
+			method: "GET",
+			retryExhausted: false,
+		});
 		const operation = createWorkoutsGetOperation(
 			createInMemoryGetAdapter(error),
 		);
@@ -480,7 +493,7 @@ describe("workouts.list operation", () => {
 	});
 
 	it("[VAL-OPS-005] preserves a non-404 HTTP error for workouts.list", async () => {
-		const error = httpError(429, "GET", "/v1/workouts", "rate limited");
+		const error = httpError(429, "GET", "/v1/workouts");
 		const operation = createWorkoutsListOperation(
 			createInMemoryAdapter([error]),
 		);
@@ -635,7 +648,7 @@ describe("workouts.list operation", () => {
 		const adapter: WorkoutsListAdapter = {
 			getWorkouts(params) {
 				if (params === undefined) {
-					return Effect.fail(new Error("params are required"));
+					return Effect.die(new Error("params are required"));
 				}
 				return params.page === 2
 					? Effect.fail(error)
@@ -697,7 +710,7 @@ function createInMemoryWorkoutMutationAdapter({
 	readonly created?: PostV1WorkoutsStatus201;
 	readonly updated?: PutV1WorkoutsWorkoutidStatus200;
 	readonly count?: GetV1WorkoutsCountStatus200;
-	readonly getError?: Error;
+	readonly getError?: HevyRequestEffectError;
 }): InMemoryWorkoutMutationAdapter {
 	const calls: string[] = [];
 	const createRequests: InMemoryWorkoutMutationAdapter["createRequests"] = [];

--- a/tests/integration/catalog-fixture.ts
+++ b/tests/integration/catalog-fixture.ts
@@ -3,8 +3,10 @@ import {
 	Effect,
 } from "../../packages/core/node_modules/effect/dist/index.js";
 import type { HevyClient } from "@hevy-mcp/hevy-client";
-import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
-import type { TemplatesListAllOperation } from "@hevy-mcp/operations";
+import type {
+	TemplatesListAllOperation,
+	TemplatesListAllResult,
+} from "@hevy-mcp/operations";
 import { createOperations } from "@hevy-mcp/operations";
 import {
 	createExerciseTemplateCatalog,
@@ -21,13 +23,12 @@ export function createIntegrationCatalog(hevyClient: HevyClient) {
 	const cache = Effect.runSync(
 		Cache.make<
 			string,
-			ExerciseTemplate[],
+			TemplatesListAllResult,
 			Effect.Error<ReturnType<TemplatesListAllOperation["effect"]>>
 		>({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) =>
-				Effect.map(listAll.effect(), (result) => result.items),
+			lookup: (_key: string) => listAll.effect(),
 		}),
 	);
 	return createExerciseTemplateCatalog(operations, cache);

--- a/tests/integration/catalog-fixture.ts
+++ b/tests/integration/catalog-fixture.ts
@@ -26,7 +26,8 @@ export function createIntegrationCatalog(hevyClient: HevyClient) {
 		>({
 			capacity: EXERCISE_TEMPLATE_CATALOG_CACHE_MAX_SIZE,
 			timeToLive: EXERCISE_TEMPLATE_CATALOG_CACHE_TTL_MS,
-			lookup: (_key: string) => listAll.effect(),
+			lookup: (_key: string) =>
+				Effect.map(listAll.effect(), (result) => result.items),
 		}),
 	);
 	return createExerciseTemplateCatalog(operations, cache);


### PR DESCRIPTION
Entire-Checkpoint: 01M1W3X0CSDPPD7R2DH1RK0XD3

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
## Primary changes
- Harden typed Effect error propagation across request, execution, catalog, operation, core, and CLI boundaries.
- Surface bounded-execution timeouts as typed deadline/network failures and validate template-search page limits.
- Return template listings with explicit `items` and `pageCount` metadata, preserving pagination information through catalog caching and telemetry.
- Reject invalid training-summary date windows with typed data errors.

## Reviewer walkthrough
1. Review the request and operation changes for tagged client-error channels and preserved domain-error handling.
2. Review bounded execution and error-policy changes for timeout extraction, classification, and diagnostics.
3. Review template pagination, structured list results, and catalog cache/telemetry propagation.
4. Review training-summary validation and the accompanying regression coverage.

## Correctness and invariants
- Unexpected programmer failures remain defects rather than being converted into typed operational failures.
- Invalid pagination and date-window inputs fail before the corresponding API or loader work.
- Template item results remain compatible with catalog consumers while fetched page counts remain explicit for observability.

## Testing and QA
- Added and updated unit coverage for typed request failures, timeout handling, pagination validation and metadata, catalog behavior, and invalid training-summary windows.
- Added release metadata for the affected packages.

## Summary by Sourcery

Harden typed effect error handling across request, execution, catalog, and operation boundaries.

Bug Fixes:
- Return bounded-execution timeouts as typed deadline failures and classify them consistently as network errors.
- Reject invalid template search page limits with a typed validation error instead of silently clamping or returning incomplete results.
- Treat invalid training-summary date windows as typed data failures rather than empty results.

Enhancements:
- Narrow request effect failures to tagged client errors and preserve typed error handling across operation, core, and CLI boundaries.
- Return template list results as an explicit items/pageCount structure and preserve fetched pagination metadata through catalog caching and telemetry.

Tests:
- Add coverage for typed timeout handling, template pagination validation and metadata preservation, and updated error classifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template listings now provide results with explicit items and page counts.
  * Template searches validate page limits from 1–100 and return clear validation errors for invalid values.
  * Cached template listings preserve the original page-count information.

* **Bug Fixes**
  * Invalid training-summary dates now report an error instead of appearing as an empty result.
  * Deadline timeouts provide clearer timeout messaging and diagnostics.
  * Request and pagination failures now provide more consistent, actionable error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->