### PR TITLE
refactor: deduplicate operation construction behind one effect factory

### DIFF
--- a/.changeset/olive-operations-dedup.md
+++ b/.changeset/olive-operations-dedup.md
@@ -1,0 +1,9 @@
+---
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Deduplicate operation construction: one operation factory with derived tracing spans, unconditional options passthrough, and shared read-outcome, page-echo, and pagination helpers.

--- a/packages/cli/src/commands/index.test.ts
+++ b/packages/cli/src/commands/index.test.ts
@@ -259,7 +259,10 @@ describe("execute command/operation mappings", () => {
 			page_count: 3,
 			routines: [{ id: "r1", title: "Push", exercises: [] }],
 		});
-		expect(listEffect).toHaveBeenCalledWith({ page: 2, pageSize: 5 });
+		expect(listEffect).toHaveBeenCalledWith(
+			{ page: 2, pageSize: 5 },
+			undefined,
+		);
 		expect(injected.routines.list.execute).not.toHaveBeenCalled();
 		expect(api.getRoutines).not.toHaveBeenCalled();
 
@@ -292,10 +295,10 @@ describe("execute command/operation mappings", () => {
 			undefined,
 			injected,
 		);
-		expect(injected.workouts.list.effect).toHaveBeenCalledWith({
-			page: 1,
-			pageSize: 10,
-		});
+		expect(injected.workouts.list.effect).toHaveBeenCalledWith(
+			{ page: 1, pageSize: 10 },
+			undefined,
+		);
 		expect(injected.workouts.list.execute).not.toHaveBeenCalled();
 		expect(api.getWorkouts).not.toHaveBeenCalled();
 	});
@@ -575,7 +578,10 @@ describe("execute command/operation mappings", () => {
 
 		for (const command of commands) {
 			await execute(command.args, api, undefined, undefined, injected);
-			expect(command.operation?.effect).toHaveBeenCalledWith(command.input);
+			expect(command.operation?.effect).toHaveBeenCalledWith(
+				command.input,
+				undefined,
+			);
 			expect(command.operation?.execute).not.toHaveBeenCalled();
 			expect(api[command.clientMethod]).not.toHaveBeenCalled();
 		}
@@ -665,14 +671,14 @@ describe("execute command/operation mappings", () => {
 				fat_percent: 20,
 			},
 		});
-		expect(injected.bodyMeasurements?.get.effect).toHaveBeenCalledWith({
-			date: "2024-01-01",
-		});
-		expect(injected.bodyMeasurements?.update.effect).toHaveBeenCalledWith({
-			date: "2024-01-01",
-			weight_kg: 81,
-			fat_percent: 20,
-		});
+		expect(injected.bodyMeasurements?.get.effect).toHaveBeenCalledWith(
+			{ date: "2024-01-01" },
+			undefined,
+		);
+		expect(injected.bodyMeasurements?.update.effect).toHaveBeenCalledWith(
+			{ date: "2024-01-01", weight_kg: 81, fat_percent: 20 },
+			undefined,
+		);
 	});
 
 	it("rejects malformed existing measurements before updating", async () => {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -160,11 +160,7 @@ function runOperation<TInput, TOutput>(
 	execution: HevyExecutionOptions | undefined,
 ): Promise<TOutput> {
 	const resolved = requireOperation(operation, id);
-	return collapse(
-		execution === undefined
-			? resolved.effect(input)
-			: resolved.effect(input, execution),
-	);
+	return collapse(resolved.effect(input, execution));
 }
 
 function runOperationWithoutInput<TOutput>(
@@ -173,9 +169,7 @@ function runOperationWithoutInput<TOutput>(
 	execution: HevyExecutionOptions | undefined,
 ): Promise<TOutput> {
 	const resolved = requireOperation(operation, id);
-	return collapse(
-		execution === undefined ? resolved.effect() : resolved.effect(execution),
-	);
+	return collapse(resolved.effect(execution));
 }
 
 function updateMeasurement(
@@ -193,10 +187,7 @@ function updateMeasurement(
 		"bodyMeasurements.update",
 	);
 	const effect = Effect.fn("cli.measurements.update")(function* () {
-		const existing =
-			execution === undefined
-				? yield* getOperation.effect({ date })
-				: yield* getOperation.effect({ date }, execution);
+		const existing = yield* getOperation.effect({ date }, execution);
 		const parsed = existingBodyMeasurementSchema.safeParse(
 			existing.bodyMeasurement,
 		);
@@ -206,8 +197,7 @@ function updateMeasurement(
 			);
 		}
 		const { measurement } = mergeMeasurementPayload(parsed.data, input);
-		if (execution === undefined) yield* updateOperation.effect(measurement);
-		else yield* updateOperation.effect(measurement, execution);
+		yield* updateOperation.effect(measurement, execution);
 		return measurement;
 	});
 	return collapse(effect());

--- a/packages/operations/src/body-measurements.ts
+++ b/packages/operations/src/body-measurements.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -13,8 +14,10 @@ import type {
 	PutBodyMeasurement,
 } from "@hevy-mcp/hevy-client/types";
 import {
-	isExpectedReadEndOfList,
-	isExpectedReadNotFound,
+	assertPageEcho,
+	isEmptyResponse,
+	withExpectedEndOfList,
+	withExpectedNotFound,
 	EmptyMeasurementUpdateError,
 	PaginationMismatchError,
 } from "./operation-errors.js";
@@ -173,165 +176,105 @@ export interface BodyMeasurementsUpdateOperation {
 export function createBodyMeasurementsListOperation(
 	adapter: BodyMeasurementsListAdapter,
 ): BodyMeasurementsListOperation {
-	const effect = Effect.fn("operations.bodyMeasurements.list")(function* (
-		input: BodyMeasurementsListInput,
-		options?: HevyExecutionOptions,
-	) {
-		const params = { page: input.page, pageSize: input.pageSize };
-		const request =
-			options === undefined
-				? adapter.getBodyMeasurements(params)
-				: adapter.getBodyMeasurements(params, options);
-		return yield* request.pipe(
-			Effect.flatMap((response: GetV1BodyMeasurements200) => {
-				if (response?.page !== undefined && response.page !== input.page) {
-					return Effect.fail(
-						new PaginationMismatchError({
-							requested: input.page,
-							received: response.page,
-							collection: "bodyMeasurements",
-							message: `Body measurements page mismatch: requested page ${input.page} but received page ${response.page}`,
-						}),
-					);
-				}
-				return Effect.succeed({
+	return defineOperation(
+		bodyMeasurementsListDescriptor,
+		function* (
+			input: BodyMeasurementsListInput,
+			options?: HevyExecutionOptions,
+		) {
+			const params = { page: input.page, pageSize: input.pageSize };
+			const request = adapter.getBodyMeasurements(params, options);
+			return yield* request.pipe(
+				Effect.tap((response) =>
+					assertPageEcho(response, input.page, "bodyMeasurements"),
+				),
+				Effect.map((response: GetV1BodyMeasurements200) => ({
 					items: response?.body_measurements ?? [],
 					page: response?.page ?? input.page,
 					pageCount: response?.page_count,
-				});
-			}),
-			Effect.catchIf(
-				(error) =>
-					isExpectedReadEndOfList(error, "/v1/body_measurements", input.page),
-				() =>
-					Effect.succeed({
-						items: [],
-						page: input.page,
-						pageCount: undefined,
-						expected404Outcome: "end_of_list" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: BodyMeasurementsListOperation = {
-		descriptor: bodyMeasurementsListDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+				})),
+				withExpectedEndOfList("/v1/body_measurements", input.page, {
+					items: [],
+					page: input.page,
+					pageCount: undefined,
+					expected404Outcome: "end_of_list" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }
 
 export function createBodyMeasurementsGetOperation(
 	adapter: BodyMeasurementsGetAdapter,
 ): BodyMeasurementsGetOperation {
-	const effect = Effect.fn("operations.bodyMeasurements.get")(function* (
-		input: BodyMeasurementsGetInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getBodyMeasurement(input.date)
-				: adapter.getBodyMeasurement(input.date, options);
-		return yield* request.pipe(
-			Effect.map((bodyMeasurement) => ({
-				bodyMeasurement: isEmptyResponse(bodyMeasurement)
-					? null
-					: (bodyMeasurement ?? null),
-				date: input.date,
-			})),
-			Effect.catchIf(
-				(error) => isExpectedReadNotFound(error, "/v1/body_measurements"),
-				() =>
-					Effect.succeed({
-						bodyMeasurement: null,
-						date: input.date,
-						expected404Outcome: "not_found" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: BodyMeasurementsGetOperation = {
-		descriptor: bodyMeasurementsGetDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		bodyMeasurementsGetDescriptor,
+		function* (
+			input: BodyMeasurementsGetInput,
+			options?: HevyExecutionOptions,
+		) {
+			const request = adapter.getBodyMeasurement(input.date, options);
+			return yield* request.pipe(
+				Effect.map((bodyMeasurement) => ({
+					bodyMeasurement: isEmptyResponse(bodyMeasurement)
+						? null
+						: (bodyMeasurement ?? null),
+					date: input.date,
+				})),
+				withExpectedNotFound("/v1/body_measurements", {
+					bodyMeasurement: null,
+					date: input.date,
+					expected404Outcome: "not_found" as const,
+				}),
+			);
 		},
-	};
-	return operation;
-}
-
-function isEmptyResponse<T extends object>(
-	response: T | null | undefined,
-): response is T & Record<never, Record<string, never>> {
-	return (
-		response !== null &&
-		response !== undefined &&
-		Object.keys(response).length === 0
 	);
 }
 
 export function createBodyMeasurementsCreateOperation(
 	adapter: BodyMeasurementsCreateAdapter,
 ): BodyMeasurementsCreateOperation {
-	const effect = Effect.fn("operations.bodyMeasurements.create")(function* (
-		input: BodyMeasurementsCreateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const payload: MeasurementPayload = buildMeasurementPayload(input);
-		const data: BodyMeasurement = {
-			date: input.date,
-			...payload,
-		};
-		const request =
-			options === undefined
-				? adapter.createBodyMeasurement(data)
-				: adapter.createBodyMeasurement(data, options);
-		yield* request;
-		return input.date;
-	});
-
-	const operation: BodyMeasurementsCreateOperation = {
-		descriptor: bodyMeasurementsCreateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		bodyMeasurementsCreateDescriptor,
+		function* (
+			input: BodyMeasurementsCreateInput,
+			options?: HevyExecutionOptions,
+		) {
+			const payload: MeasurementPayload = buildMeasurementPayload(input);
+			const data: BodyMeasurement = {
+				date: input.date,
+				...payload,
+			};
+			const request = adapter.createBodyMeasurement(data, options);
+			yield* request;
+			return input.date;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createBodyMeasurementsUpdateOperation(
 	adapter: BodyMeasurementsUpdateAdapter,
 ): BodyMeasurementsUpdateOperation {
-	const effect = Effect.fn("operations.bodyMeasurements.update")(function* (
-		input: BodyMeasurementsUpdateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const payload: PutBodyMeasurement = buildMeasurementPayload(input);
-		if (Object.keys(payload).length === 0) {
-			return yield* new EmptyMeasurementUpdateError({
-				message:
-					"No measurement fields provided. Include at least one numeric measurement field (e.g. weight_kg) to update.",
-			});
-		}
-		const request =
-			options === undefined
-				? adapter.updateBodyMeasurement(input.date, payload)
-				: adapter.updateBodyMeasurement(input.date, payload, options);
-		yield* request;
-		return input.date;
-	});
-
-	const operation: BodyMeasurementsUpdateOperation = {
-		descriptor: bodyMeasurementsUpdateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		bodyMeasurementsUpdateDescriptor,
+		function* (
+			input: BodyMeasurementsUpdateInput,
+			options?: HevyExecutionOptions,
+		) {
+			const payload: PutBodyMeasurement = buildMeasurementPayload(input);
+			if (Object.keys(payload).length === 0) {
+				return yield* new EmptyMeasurementUpdateError({
+					message:
+						"No measurement fields provided. Include at least one numeric measurement field (e.g. weight_kg) to update.",
+				});
+			}
+			const request = adapter.updateBodyMeasurement(
+				input.date,
+				payload,
+				options,
+			);
+			yield* request;
+			return input.date;
 		},
-	};
-	return operation;
+	);
 }

--- a/packages/operations/src/define-operation.ts
+++ b/packages/operations/src/define-operation.ts
@@ -1,0 +1,49 @@
+import { Effect } from "effect";
+
+export interface DefinedOperation<
+	Descriptor,
+	Args extends readonly unknown[],
+	Result,
+	Error,
+> {
+	readonly descriptor: Descriptor;
+	readonly effect: (...args: Args) => Effect.Effect<Result, Error>;
+	execute(...args: Args): Promise<Result>;
+}
+
+/**
+ * Build one operation triple from a descriptor and a generator body.
+ *
+ * The tracing span derives from the descriptor (`operations.<id>`), so span
+ * names cannot drift from operation identity. `execute` runs the same effect
+ * value instead of closing over the partially built operation object. The
+ * yielded-effect constraint rejects `R` at compile time: only `R = never`
+ * bodies satisfy it, which is what keeps the `Effect.runPromise` edge total.
+ * `E` resolves as the union of every yielded failure, so bodies that recover
+ * typed errors keep their full channel.
+ */
+export function defineOperation<
+	const Descriptor extends { readonly id: string },
+	const Args extends readonly unknown[],
+	Yielded extends Effect.Effect<unknown, unknown, never>,
+	Result,
+>(
+	descriptor: Descriptor,
+	body: (...args: Args) => Generator<Yielded, Result, never>,
+): DefinedOperation<Descriptor, Args, Result, Effect.Error<Yielded>> {
+	const traced = Effect.fn(`operations.${descriptor.id}`)(body);
+	// Discharge Effect.fn's deferred conditional inference, which cannot
+	// resolve inside a generic boundary. The Yielded constraint already proves
+	// R = never, and Effect.Error<Yielded> is exactly the union Effect.fn
+	// computes — identical at every call site once Yielded is concrete.
+	const effect = traced as (
+		...args: Args
+	) => Effect.Effect<Result, Effect.Error<Yielded>>;
+	return {
+		descriptor,
+		effect,
+		execute(...args: Args) {
+			return Effect.runPromise(effect(...args));
+		},
+	};
+}

--- a/packages/operations/src/folders.test.ts
+++ b/packages/operations/src/folders.test.ts
@@ -88,7 +88,7 @@ describe("folders.create operation", () => {
 		await expect(Effect.runPromise(operation.effect(body))).resolves.toEqual(
 			created,
 		);
-		expect(createRoutineFolder).toHaveBeenCalledWith(body);
+		expect(createRoutineFolder).toHaveBeenCalledWith(body, undefined);
 	});
 });
 

--- a/packages/operations/src/folders.ts
+++ b/packages/operations/src/folders.ts
@@ -1,4 +1,5 @@
-import { Effect, Option, Predicate, Stream } from "effect";
+import { Effect, Option, Stream } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -14,8 +15,11 @@ import type {
 	RoutineFolder,
 } from "@hevy-mcp/hevy-client/types";
 import {
-	isExpectedReadEndOfList,
-	isExpectedReadNotFound,
+	assertPageEcho,
+	hasNextPage,
+	isEmptyResponse,
+	withExpectedEndOfList,
+	withExpectedNotFound,
 	PaginationMismatchError,
 } from "./operation-errors.js";
 
@@ -124,148 +128,77 @@ type FoldersListPage = {
 	readonly folders: RoutineFolder[];
 };
 
-function hasNextFoldersPage(
-	pageCount: number | undefined,
-	page: number,
-	folders: readonly RoutineFolder[],
-): boolean {
-	return (
-		folders.length > 0 &&
-		Predicate.isNumber(pageCount) &&
-		Number.isSafeInteger(pageCount) &&
-		pageCount > page
-	);
-}
-
 export function createFoldersGetOperation(
 	adapter: FoldersGetAdapter,
 ): FoldersGetOperation {
-	const effect = Effect.fn("operations.folders.get")(function* (
-		input: FoldersGetInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getRoutineFolder(input.folderId)
-				: adapter.getRoutineFolder(input.folderId, options);
-		return yield* request.pipe(
-			Effect.map((routineFolder) => ({
-				routineFolder: isEmptyResponse(routineFolder)
-					? null
-					: (routineFolder ?? null),
-				folderId: input.folderId,
-			})),
-			Effect.catchIf(
-				(error) => isExpectedReadNotFound(error, "/v1/routine_folders"),
-				() =>
-					Effect.succeed({
-						routineFolder: null,
-						folderId: input.folderId,
-						expected404Outcome: "not_found" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: FoldersGetOperation = {
-		descriptor: foldersGetDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		foldersGetDescriptor,
+		function* (input: FoldersGetInput, options?: HevyExecutionOptions) {
+			const request = adapter.getRoutineFolder(input.folderId, options);
+			return yield* request.pipe(
+				Effect.map((routineFolder) => ({
+					routineFolder: isEmptyResponse(routineFolder)
+						? null
+						: (routineFolder ?? null),
+					folderId: input.folderId,
+				})),
+				withExpectedNotFound("/v1/routine_folders", {
+					routineFolder: null,
+					folderId: input.folderId,
+					expected404Outcome: "not_found" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }
 
 export function createFoldersCreateOperation(
 	adapter: FoldersCreateAdapter,
 ): FoldersCreateOperation {
-	const effect = Effect.fn("operations.folders.create")(function* (
-		input: FoldersCreateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.createRoutineFolder(input)
-				: adapter.createRoutineFolder(input, options);
-		const response = yield* request;
-		return isEmptyResponse(response) ? undefined : response;
-	});
-
-	const operation: FoldersCreateOperation = {
-		descriptor: foldersCreateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		foldersCreateDescriptor,
+		function* (input: FoldersCreateInput, options?: HevyExecutionOptions) {
+			const request = adapter.createRoutineFolder(input, options);
+			const response = yield* request;
+			return isEmptyResponse(response) ? undefined : response;
 		},
-	};
-	return operation;
-}
-
-function isEmptyResponse<T extends object>(
-	response: T | null | undefined,
-): response is T & Record<never, never> {
-	return (
-		response !== null &&
-		response !== undefined &&
-		Object.keys(response).length === 0
 	);
 }
 
 export function createFoldersListAllOperation(
 	adapter: FoldersListAllAdapter,
 ): FoldersListAllOperation {
-	const effect = Effect.fn("operations.folders.listAll")(function* (
-		options?: HevyExecutionOptions,
-	) {
-		const pageStream = Stream.paginate<
-			FoldersListCursor,
-			FoldersListPage,
-			HevyRequestEffectError | PaginationMismatchError
-		>({ page: 1 }, (cursor) => {
-			const params = { page: cursor.page, pageSize: FOLDERS_PAGE_SIZE };
-			const request =
-				options === undefined
-					? adapter.getRoutineFolders(params)
-					: adapter.getRoutineFolders(params, options);
-			return request.pipe(
-				Effect.flatMap((response: GetV1RoutineFolders200) => {
-					if (response?.page !== undefined && response.page !== cursor.page) {
-						return Effect.fail(
-							new PaginationMismatchError({
-								requested: cursor.page,
-								received: response.page,
-								collection: "routineFolders",
-								message: `Routine folders page mismatch: requested page ${cursor.page} but received page ${response.page}`,
-							}),
-						);
-					}
-
-					const folders = response?.routine_folders ?? [];
-					return Effect.succeed([
-						[{ folders }],
-						hasNextFoldersPage(response?.page_count, cursor.page, folders)
-							? Option.some({ page: cursor.page + 1 })
-							: Option.none(),
-					] as const);
-				}),
-				Effect.catchIf(
-					(error) =>
-						isExpectedReadEndOfList(error, "/v1/routine_folders", cursor.page),
-					() => Effect.succeed([[], Option.none<FoldersListCursor>()] as const),
-				),
-			);
-		});
-		const pages = yield* Stream.runCollect(pageStream);
-		return pages.flatMap((page) => page.folders);
-	});
-
-	const operation: FoldersListAllOperation = {
-		descriptor: foldersListAllDescriptor,
-		effect,
-		execute(options) {
-			return Effect.runPromise(operation.effect(options));
+	return defineOperation(
+		foldersListAllDescriptor,
+		function* (options?: HevyExecutionOptions) {
+			const pageStream = Stream.paginate<
+				FoldersListCursor,
+				FoldersListPage,
+				HevyRequestEffectError | PaginationMismatchError
+			>({ page: 1 }, (cursor) => {
+				const params = { page: cursor.page, pageSize: FOLDERS_PAGE_SIZE };
+				const request = adapter.getRoutineFolders(params, options);
+				return request.pipe(
+					Effect.tap((response) =>
+						assertPageEcho(response, cursor.page, "routineFolders"),
+					),
+					Effect.map((response: GetV1RoutineFolders200) => {
+						const folders = response?.routine_folders ?? [];
+						return [
+							[{ folders }],
+							hasNextPage(response?.page_count, cursor.page, folders.length)
+								? Option.some({ page: cursor.page + 1 })
+								: Option.none(),
+						] as const;
+					}),
+					withExpectedEndOfList("/v1/routine_folders", cursor.page, [
+						[],
+						Option.none<FoldersListCursor>(),
+					] as const),
+				);
+			});
+			const pages = yield* Stream.runCollect(pageStream);
+			return pages.flatMap((page) => page.folders);
 		},
-	};
-	return operation;
+	);
 }

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -1,4 +1,6 @@
 import type { HevyClient, HevyOperationSafety } from "@hevy-mcp/hevy-client";
+export { defineOperation } from "./define-operation.js";
+export type { DefinedOperation } from "./define-operation.js";
 import {
 	getRequestEffectClient,
 	type HevyRequestEffectClient,

--- a/packages/operations/src/operation-errors.ts
+++ b/packages/operations/src/operation-errors.ts
@@ -4,7 +4,7 @@ import {
 	isHevyHttpError,
 	NotFoundError,
 } from "@hevy-mcp/hevy-client";
-import { Schema } from "effect";
+import { Effect, Predicate, Schema } from "effect";
 
 export type ExpectedReadError = "not_found" | "end_of_list";
 export type ReadCollectionEndpoint = Extract<
@@ -179,4 +179,94 @@ export function isExpectedReadEndOfList(
 	page: number,
 ): boolean {
 	return page > 1 && classifyReadError(cause, endpoint, page) === "end_of_list";
+}
+
+/**
+ * Detect the Hevy API's empty-object responses, which signal "no entity"
+ * where a 404 would be expected. Shared so the shape check cannot drift
+ * between operation modules.
+ */
+export function isEmptyResponse<T extends object>(
+	response: T | null | undefined,
+): response is T & Record<never, never> {
+	return (
+		response !== null &&
+		response !== undefined &&
+		Object.keys(response).length === 0
+	);
+}
+
+/**
+ * Recover a documented read-side 404 as a successful absence value.
+ * Pipeable so get-style operations keep one outcome-mapping shape.
+ */
+export function withExpectedNotFound<A, E, Absent>(
+	endpoint: ReadEndpoint,
+	absent: Absent,
+): (effect: Effect.Effect<A, E>) => Effect.Effect<A | Absent, E> {
+	return (effect) =>
+		effect.pipe(
+			Effect.catchIf(
+				(cause) => isExpectedReadNotFound(cause, endpoint),
+				() => Effect.succeed(absent),
+			),
+		);
+}
+
+/**
+ * Recover a documented later-page 404 as a successful end-of-list value.
+ * Pipeable so list-style operations keep one outcome-mapping shape.
+ */
+export function withExpectedEndOfList<A, E, Absent>(
+	endpoint: ReadCollectionEndpoint,
+	page: number,
+	absent: Absent,
+): (effect: Effect.Effect<A, E>) => Effect.Effect<A | Absent, E> {
+	return (effect) =>
+		effect.pipe(
+			Effect.catchIf(
+				(cause) => isExpectedReadEndOfList(cause, endpoint, page),
+				() => Effect.succeed(absent),
+			),
+		);
+}
+
+/**
+ * Fail when the API echoes a different page than requested. Compose with
+ * `Effect.tap` ahead of response projection so list operations share one
+ * page-echo policy.
+ */
+export function assertPageEcho(
+	response: { readonly page?: number | undefined } | null | undefined,
+	requestedPage: number,
+	collection: string,
+): Effect.Effect<void, PaginationMismatchError> {
+	if (response?.page !== undefined && response.page !== requestedPage) {
+		return Effect.fail(
+			new PaginationMismatchError({
+				requested: requestedPage,
+				received: response.page,
+				collection,
+				message: `Page mismatch for ${collection}: requested page ${requestedPage} but received page ${response.page}`,
+			}),
+		);
+	}
+	return Effect.void;
+}
+
+/**
+ * Decide whether pagination continues: the page was non-empty and the API
+ * reports more pages. Shared so every collection applies the same policy.
+ */
+export function hasNextPage(
+	pageCount: number | undefined,
+	page: number,
+	itemCount: number,
+): boolean {
+	return (
+		itemCount > 0 &&
+		Predicate.isNumber(pageCount) &&
+		Number.isSafeInteger(pageCount) &&
+		pageCount > page
+	);
 }

--- a/packages/operations/src/routines.test.ts
+++ b/packages/operations/src/routines.test.ts
@@ -273,14 +273,14 @@ describe("routines.get operation", () => {
 		await expect(operation.execute({ routineId: "r1" })).rejects.toBe(error);
 	});
 
-	it("[VAL-OPS-008] omits the options argument when routines.get options are absent", async () => {
+	it("[VAL-OPS-008] forwards options through to the adapter when routines.get options are absent", async () => {
 		const adapter = createInMemoryGetAdapter({ routine: { id: "r1" } });
 		const operation = createRoutinesGetOperation(adapter);
 
 		await expect(operation.execute({ routineId: "r1" })).resolves.toEqual({
 			routine: { id: "r1" },
 		});
-		expect(adapter.argumentCounts).toEqual([1]);
+		expect(adapter.argumentCounts).toEqual([2]);
 	});
 });
 
@@ -768,7 +768,7 @@ describe("routines.list operation", () => {
 		});
 	});
 
-	it("[VAL-OPS-008] omits the options argument when routines.list options are absent", async () => {
+	it("[VAL-OPS-008] forwards options through to the adapter when routines.list options are absent", async () => {
 		const adapter = createInMemoryAdapter([{ page: 1, routines: [] }]);
 		const operation = createRoutinesListOperation(adapter);
 
@@ -777,7 +777,7 @@ describe("routines.list operation", () => {
 			page: 1,
 			pageCount: undefined,
 		});
-		expect(adapter.argumentCounts).toEqual([1]);
+		expect(adapter.argumentCounts).toEqual([2]);
 	});
 
 	it("[VAL-OPS-002] exposes routines.get as a native Promise, not an Effect", async () => {

--- a/packages/operations/src/routines.ts
+++ b/packages/operations/src/routines.ts
@@ -1,4 +1,5 @@
-import { Effect, Option, Predicate, Stream } from "effect";
+import { Effect, Option, Stream } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -18,8 +19,11 @@ import {
 	type RoutinePayloadInput,
 } from "./mutation-semantics.js";
 import {
-	isExpectedReadEndOfList,
-	isExpectedReadNotFound,
+	assertPageEcho,
+	hasNextPage,
+	isEmptyResponse,
+	withExpectedEndOfList,
+	withExpectedNotFound,
 	PaginationMismatchError,
 } from "./operation-errors.js";
 
@@ -224,7 +228,7 @@ const ROUTINE_SEARCH_PAGE_SIZE = 10;
 function normalizeRoutineResponse(
 	response: PostV1Routines201 | PutV1RoutinesRoutineid200,
 ): Routine | undefined {
-	if (Predicate.isObject(response) && Object.keys(response).length === 0) {
+	if (isEmptyResponse(response)) {
 		return undefined;
 	}
 	return response as Routine;
@@ -233,65 +237,45 @@ function normalizeRoutineResponse(
 export function createRoutinesCreateOperation(
 	adapter: RoutinesCreateAdapter,
 ): RoutinesCreateOperation {
-	const effect = Effect.fn("operations.routines.create")(function* (
-		input: RoutinesCreateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const { payload, usesRepRanges } = buildRoutinePayload(
-			input.routine,
-			"create",
-		);
-		const request =
-			options === undefined
-				? adapter.createRoutine({ routine: payload })
-				: adapter.createRoutine({ routine: payload }, options);
-		const response = yield* request;
-		return {
-			routine: normalizeRoutineResponse(response),
-			usesRepRanges,
-		};
-	});
-
-	const operation: RoutinesCreateOperation = {
-		descriptor: routinesCreateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		routinesCreateDescriptor,
+		function* (input: RoutinesCreateInput, options?: HevyExecutionOptions) {
+			const { payload, usesRepRanges } = buildRoutinePayload(
+				input.routine,
+				"create",
+			);
+			const request = adapter.createRoutine({ routine: payload }, options);
+			const response = yield* request;
+			return {
+				routine: normalizeRoutineResponse(response),
+				usesRepRanges,
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 export function createRoutinesUpdateOperation(
 	adapter: RoutinesUpdateAdapter,
 ): RoutinesUpdateOperation {
-	const effect = Effect.fn("operations.routines.update")(function* (
-		input: RoutinesUpdateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const { payload, usesRepRanges } = buildRoutinePayload(
-			"routine" in input ? input.routine : input.patch,
-			"update",
-		);
-		const request =
-			options === undefined
-				? adapter.updateRoutine(input.routineId, { routine: payload })
-				: adapter.updateRoutine(input.routineId, { routine: payload }, options);
-		const response = yield* request;
-		return {
-			routine: normalizeRoutineResponse(response),
-			usesRepRanges,
-		};
-	});
-
-	const operation: RoutinesUpdateOperation = {
-		descriptor: routinesUpdateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		routinesUpdateDescriptor,
+		function* (input: RoutinesUpdateInput, options?: HevyExecutionOptions) {
+			const { payload, usesRepRanges } = buildRoutinePayload(
+				"routine" in input ? input.routine : input.patch,
+				"update",
+			);
+			const request = adapter.updateRoutine(
+				input.routineId,
+				{ routine: payload },
+				options,
+			);
+			const response = yield* request;
+			return {
+				routine: normalizeRoutineResponse(response),
+				usesRepRanges,
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 type RoutinesSearchCursor = {
@@ -300,196 +284,119 @@ type RoutinesSearchCursor = {
 };
 
 type RoutinesSearchPage = {
-	readonly routines: Routine[];
+	readonly matches: Routine[];
+	readonly scanned: number;
 };
-
-function isSearchPageCount(value: number | undefined): value is number {
-	return Predicate.isNumber(value) && Number.isSafeInteger(value) && value > 0;
-}
 
 export function createRoutinesSearchOperation(
 	adapter: RoutinesSearchAdapter,
 ): RoutinesSearchOperation {
-	const effect = Effect.fn("operations.routines.search")(function* (
-		input: RoutinesSearchInput,
-		options?: HevyExecutionOptions,
-	) {
-		const normalizedQuery = input.query?.toLowerCase();
-		const limit = Math.min(
-			Math.max(input.limit ?? DEFAULT_ROUTINE_SEARCH_LIMIT, 0),
-			MAX_ROUTINE_SEARCH_LIMIT,
-		);
-		const pageStream = Stream.paginate<
-			RoutinesSearchCursor,
-			RoutinesSearchPage,
-			HevyRequestEffectError | PaginationMismatchError
-		>({ page: 1, matches: 0 }, (cursor) => {
-			if (limit === 0) {
-				return Effect.succeed([[], Option.none()]);
-			}
-			const params = {
-				page: cursor.page,
-				pageSize: ROUTINE_SEARCH_PAGE_SIZE,
-			};
-			const request =
-				options === undefined
-					? adapter.getRoutines(params)
-					: adapter.getRoutines(params, options);
-			return request.pipe(
-				Effect.flatMap((response: GetV1Routines200) => {
-					if (response.page !== undefined && response.page !== cursor.page) {
-						return Effect.fail(
-							new PaginationMismatchError({
-								requested: cursor.page,
-								received: response.page,
-								collection: "routines",
-								message: `Routines page mismatch: requested page ${cursor.page} but received page ${response.page}`,
-							}),
+	return defineOperation(
+		routinesSearchDescriptor,
+		function* (input: RoutinesSearchInput, options?: HevyExecutionOptions) {
+			const normalizedQuery = input.query?.toLowerCase();
+			const limit = Math.min(
+				Math.max(input.limit ?? DEFAULT_ROUTINE_SEARCH_LIMIT, 0),
+				MAX_ROUTINE_SEARCH_LIMIT,
+			);
+			const pageStream = Stream.paginate<
+				RoutinesSearchCursor,
+				RoutinesSearchPage,
+				HevyRequestEffectError | PaginationMismatchError
+			>({ page: 1, matches: 0 }, (cursor) => {
+				if (limit === 0) {
+					return Effect.succeed([[], Option.none()]);
+				}
+				const params = {
+					page: cursor.page,
+					pageSize: ROUTINE_SEARCH_PAGE_SIZE,
+				};
+				const request = adapter.getRoutines(params, options);
+				return request.pipe(
+					Effect.tap((response) =>
+						assertPageEcho(response, cursor.page, "routines"),
+					),
+					Effect.map((response: GetV1Routines200) => {
+						const routines = response.routines ?? [];
+						const pageMatches = routines.filter((routine) =>
+							normalizedQuery === undefined
+								? true
+								: (routine.title?.toLowerCase().includes(normalizedQuery) ??
+									false),
 						);
-					}
-
-					const routines = response.routines ?? [];
-					const pageMatches = routines.filter((routine) =>
-						normalizedQuery === undefined
-							? true
-							: (routine.title?.toLowerCase().includes(normalizedQuery) ??
-								false),
-					);
-					const matches = cursor.matches + pageMatches.length;
-					const hasNextPage =
-						matches < limit &&
-						routines.length > 0 &&
-						isSearchPageCount(response.page_count) &&
-						response.page_count > cursor.page;
-					return Effect.succeed([
-						[{ routines }],
-						hasNextPage
-							? Option.some({
-									page: cursor.page + 1,
-									matches,
-								})
-							: Option.none(),
-					] as const);
-				}),
-				Effect.catchIf(
-					(error) =>
-						isExpectedReadEndOfList(error, "/v1/routines", cursor.page),
-					() =>
-						Effect.succeed([[], Option.none<RoutinesSearchCursor>()] as const),
-				),
-			);
-		});
-		const pages = yield* Stream.runCollect(pageStream);
-		const routines = pages
-			.flatMap((page) => page.routines)
-			.filter((routine) =>
-				normalizedQuery === undefined
-					? true
-					: (routine.title?.toLowerCase().includes(normalizedQuery) ?? false),
-			);
-		return {
-			routines: routines.slice(0, limit),
-			pages: pages.length,
-			itemsScanned: pages.reduce(
-				(total, page) => total + page.routines.length,
-				0,
-			),
-		};
-	});
-
-	const operation: RoutinesSearchOperation = {
-		descriptor: routinesSearchDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+						const matches = cursor.matches + pageMatches.length;
+						const continuePaging =
+							matches < limit &&
+							hasNextPage(response.page_count, cursor.page, routines.length);
+						return [
+							[{ matches: pageMatches, scanned: routines.length }],
+							continuePaging
+								? Option.some({
+										page: cursor.page + 1,
+										matches,
+									})
+								: Option.none(),
+						] as const;
+					}),
+					withExpectedEndOfList("/v1/routines", cursor.page, [
+						[],
+						Option.none<RoutinesSearchCursor>(),
+					] as const),
+				);
+			});
+			const pages = yield* Stream.runCollect(pageStream);
+			const matches = pages.flatMap((page) => page.matches);
+			return {
+				routines: matches.slice(0, limit),
+				pages: pages.length,
+				itemsScanned: pages.reduce((total, page) => total + page.scanned, 0),
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 export function createRoutinesGetOperation(
 	adapter: RoutinesGetAdapter,
 ): RoutinesGetOperation {
-	const effect = Effect.fn("operations.routines.get")(function* (
-		input: RoutinesGetInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getRoutineById(input.routineId)
-				: adapter.getRoutineById(input.routineId, options);
-		return yield* request.pipe(
-			Effect.map((response) => ({ routine: response?.routine ?? null })),
-			Effect.catchIf(
-				(error) => isExpectedReadNotFound(error, "/v1/routines"),
-				() =>
-					Effect.succeed({
-						routine: null,
-						expected404Outcome: "not_found" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: RoutinesGetOperation = {
-		descriptor: routinesGetDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		routinesGetDescriptor,
+		function* (input: RoutinesGetInput, options?: HevyExecutionOptions) {
+			const request = adapter.getRoutineById(input.routineId, options);
+			return yield* request.pipe(
+				Effect.map((response) => ({ routine: response?.routine ?? null })),
+				withExpectedNotFound("/v1/routines", {
+					routine: null,
+					expected404Outcome: "not_found" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }
 
 export function createRoutinesListOperation(
 	adapter: RoutinesListAdapter,
 ): RoutinesListOperation {
-	const effect = Effect.fn("operations.routines.list")(function* (
-		input: RoutinesListInput,
-		options?: HevyExecutionOptions,
-	) {
-		const params = { page: input.page, pageSize: input.pageSize };
-		const request =
-			options === undefined
-				? adapter.getRoutines(params)
-				: adapter.getRoutines(params, options);
-		return yield* request.pipe(
-			Effect.flatMap((response: GetV1Routines200) => {
-				if (response.page !== undefined && response.page !== input.page) {
-					return Effect.fail(
-						new PaginationMismatchError({
-							requested: input.page,
-							received: response.page,
-							collection: "routines",
-							message: `Routines page mismatch: requested page ${input.page} but received page ${response.page}`,
-						}),
-					);
-				}
-				return Effect.succeed({
+	return defineOperation(
+		routinesListDescriptor,
+		function* (input: RoutinesListInput, options?: HevyExecutionOptions) {
+			const params = { page: input.page, pageSize: input.pageSize };
+			const request = adapter.getRoutines(params, options);
+			return yield* request.pipe(
+				Effect.tap((response) =>
+					assertPageEcho(response, input.page, "routines"),
+				),
+				Effect.map((response: GetV1Routines200) => ({
 					items: response.routines ?? [],
 					page: response.page ?? input.page,
 					pageCount: response.page_count,
-				});
-			}),
-			Effect.catchIf(
-				(error) => isExpectedReadEndOfList(error, "/v1/routines", input.page),
-				() =>
-					Effect.succeed({
-						items: [],
-						page: input.page,
-						pageCount: undefined,
-						expected404Outcome: "end_of_list" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: RoutinesListOperation = {
-		descriptor: routinesListDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+				})),
+				withExpectedEndOfList("/v1/routines", input.page, {
+					items: [],
+					page: input.page,
+					pageCount: undefined,
+					expected404Outcome: "end_of_list" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }

--- a/packages/operations/src/templates.test.ts
+++ b/packages/operations/src/templates.test.ts
@@ -147,7 +147,11 @@ describe("templates.history operation", () => {
 			exerciseHistory: [],
 			exerciseTemplateId: "template-1",
 		});
-		expect(getExerciseHistory).toHaveBeenCalledWith("template-1", {});
+		expect(getExerciseHistory).toHaveBeenCalledWith(
+			"template-1",
+			{},
+			undefined,
+		);
 	});
 
 	it("does not turn a history 404 into a successful absence", async () => {
@@ -175,7 +179,7 @@ describe("templates.create operation", () => {
 		await expect(Effect.runPromise(operation.effect(body))).resolves.toEqual(
 			created,
 		);
-		expect(createExerciseTemplate).toHaveBeenCalledWith(body);
+		expect(createExerciseTemplate).toHaveBeenCalledWith(body, undefined);
 	});
 });
 

--- a/packages/operations/src/templates.ts
+++ b/packages/operations/src/templates.ts
@@ -1,4 +1,5 @@
 import { Effect, Option, Predicate, Stream } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -15,8 +16,10 @@ import type {
 	PostV1ExerciseTemplates200,
 } from "@hevy-mcp/hevy-client/types";
 import {
-	isExpectedReadEndOfList,
-	isExpectedReadNotFound,
+	hasNextPage,
+	isEmptyResponse,
+	withExpectedEndOfList,
+	withExpectedNotFound,
 	PaginationMismatchError,
 	TemplatesSearchValidationError,
 } from "./operation-errors.js";
@@ -240,19 +243,6 @@ type TemplatesSearchPage = {
 	readonly endOfList?: boolean;
 };
 
-function hasNextTemplatesPage(
-	pageCount: number | undefined,
-	page: number,
-	templates: readonly ExerciseTemplate[],
-): boolean {
-	return (
-		templates.length > 0 &&
-		Predicate.isNumber(pageCount) &&
-		Number.isSafeInteger(pageCount) &&
-		pageCount > page
-	);
-}
-
 type ValidatedTemplatesPage = {
 	readonly pageCount: number;
 	readonly templates: ExerciseTemplate[];
@@ -302,272 +292,192 @@ function readTemplatesPage(
 	return Effect.succeed({
 		pageCount,
 		templates,
-		hasNextPage: hasNextTemplatesPage(pageCount, requestedPage, templates),
+		hasNextPage: hasNextPage(pageCount, requestedPage, templates.length),
 	});
 }
 
 export function createTemplatesGetOperation(
 	adapter: TemplatesGetAdapter,
 ): TemplatesGetOperation {
-	const effect = Effect.fn("operations.templates.get")(function* (
-		input: TemplatesGetInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getExerciseTemplate(input.exerciseTemplateId)
-				: adapter.getExerciseTemplate(input.exerciseTemplateId, options);
-		return yield* request.pipe(
-			Effect.map((exerciseTemplate) => ({
-				exerciseTemplate: isEmptyResponse(exerciseTemplate)
-					? null
-					: (exerciseTemplate ?? null),
-				exerciseTemplateId: input.exerciseTemplateId,
-			})),
-			Effect.catchIf(
-				(error) => isExpectedReadNotFound(error, "/v1/exercise_templates"),
-				() =>
-					Effect.succeed({
-						exerciseTemplate: null,
-						exerciseTemplateId: input.exerciseTemplateId,
-						expected404Outcome: "not_found" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: TemplatesGetOperation = {
-		descriptor: templatesGetDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		templatesGetDescriptor,
+		function* (input: TemplatesGetInput, options?: HevyExecutionOptions) {
+			const request = adapter.getExerciseTemplate(
+				input.exerciseTemplateId,
+				options,
+			);
+			return yield* request.pipe(
+				Effect.map((exerciseTemplate) => ({
+					exerciseTemplate: isEmptyResponse(exerciseTemplate)
+						? null
+						: (exerciseTemplate ?? null),
+					exerciseTemplateId: input.exerciseTemplateId,
+				})),
+				withExpectedNotFound("/v1/exercise_templates", {
+					exerciseTemplate: null,
+					exerciseTemplateId: input.exerciseTemplateId,
+					expected404Outcome: "not_found" as const,
+				}),
+			);
 		},
-	};
-	return operation;
-}
-
-function isEmptyResponse<T extends object>(
-	response: T | null | undefined,
-): response is T & Record<never, never> {
-	return (
-		response !== null &&
-		response !== undefined &&
-		Object.keys(response).length === 0
 	);
 }
 
 export function createTemplatesHistoryOperation(
 	adapter: TemplatesHistoryAdapter,
 ): TemplatesHistoryOperation {
-	const effect = Effect.fn("operations.templates.history")(function* (
-		input: TemplatesHistoryInput,
-		options?: HevyExecutionOptions,
-	) {
-		const params = exerciseHistoryQuery(input);
-		const request =
-			options === undefined
-				? adapter.getExerciseHistory(input.exerciseTemplateId, params)
-				: adapter.getExerciseHistory(input.exerciseTemplateId, params, options);
-		const response = yield* request;
-		return {
-			exerciseHistory: response?.exercise_history ?? [],
-			exerciseTemplateId: input.exerciseTemplateId,
-		};
-	});
-
-	const operation: TemplatesHistoryOperation = {
-		descriptor: templatesHistoryDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		templatesHistoryDescriptor,
+		function* (input: TemplatesHistoryInput, options?: HevyExecutionOptions) {
+			const params = exerciseHistoryQuery(input);
+			const request = adapter.getExerciseHistory(
+				input.exerciseTemplateId,
+				params,
+				options,
+			);
+			const response = yield* request;
+			return {
+				exerciseHistory: response?.exercise_history ?? [],
+				exerciseTemplateId: input.exerciseTemplateId,
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 export function createTemplatesCreateOperation(
 	adapter: TemplatesCreateAdapter,
 ): TemplatesCreateOperation {
-	const effect = Effect.fn("operations.templates.create")(function* (
-		input: TemplatesCreateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.createExerciseTemplate(input)
-				: adapter.createExerciseTemplate(input, options);
-		return yield* request;
-	});
-
-	const operation: TemplatesCreateOperation = {
-		descriptor: templatesCreateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		templatesCreateDescriptor,
+		function* (input: TemplatesCreateInput, options?: HevyExecutionOptions) {
+			const request = adapter.createExerciseTemplate(input, options);
+			return yield* request;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createTemplatesListAllOperation(
 	adapter: TemplatesListAllAdapter,
 ): TemplatesListAllOperation {
-	const effect = Effect.fn("operations.templates.listAll")(function* (
-		options?: HevyExecutionOptions,
-	) {
-		const pageStream = Stream.paginate<
-			TemplatesListCursor,
-			TemplatesListPage,
-			HevyRequestEffectError | PaginationMismatchError
-		>({ page: 1 }, (cursor) => {
-			const params = { page: cursor.page, pageSize: TEMPLATES_PAGE_SIZE };
-			const request =
-				options === undefined
-					? adapter.getExerciseTemplates(params)
-					: adapter.getExerciseTemplates(params, options);
-			return request.pipe(
-				Effect.flatMap((response: GetV1ExerciseTemplates200) =>
-					readTemplatesPage(response, cursor.page).pipe(
-						Effect.map(
-							({ templates, hasNextPage }) =>
-								[
-									[{ templates }],
-									hasNextPage
-										? Option.some({ page: cursor.page + 1 })
-										: Option.none(),
-								] as const,
+	return defineOperation(
+		templatesListAllDescriptor,
+		function* (options?: HevyExecutionOptions) {
+			const pageStream = Stream.paginate<
+				TemplatesListCursor,
+				TemplatesListPage,
+				HevyRequestEffectError | PaginationMismatchError
+			>({ page: 1 }, (cursor) => {
+				const params = { page: cursor.page, pageSize: TEMPLATES_PAGE_SIZE };
+				const request = adapter.getExerciseTemplates(params, options);
+				return request.pipe(
+					Effect.flatMap((response: GetV1ExerciseTemplates200) =>
+						readTemplatesPage(response, cursor.page).pipe(
+							Effect.map(
+								({ templates, hasNextPage }) =>
+									[
+										[{ templates }],
+										hasNextPage
+											? Option.some({ page: cursor.page + 1 })
+											: Option.none(),
+									] as const,
+							),
 						),
 					),
-				),
-				Effect.catchIf(
-					(error) =>
-						isExpectedReadEndOfList(
-							error,
-							"/v1/exercise_templates",
-							cursor.page,
-						),
-					() =>
-						Effect.succeed([[], Option.none<TemplatesListCursor>()] as const),
-				),
-			);
-		});
-		const pages = yield* Stream.runCollect(pageStream);
-		return {
-			items: pages.flatMap((page) => page.templates),
-			pageCount: pages.length,
-		};
-	});
-
-	const operation: TemplatesListAllOperation = {
-		descriptor: templatesListAllDescriptor,
-		effect,
-		execute(options) {
-			return Effect.runPromise(operation.effect(options));
+					withExpectedEndOfList("/v1/exercise_templates", cursor.page, [
+						[],
+						Option.none<TemplatesListCursor>(),
+					] as const),
+				);
+			});
+			const pages = yield* Stream.runCollect(pageStream);
+			return {
+				items: pages.flatMap((page) => page.templates),
+				pageCount: pages.length,
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 export function createTemplatesSearchOperation(
 	adapter: TemplatesListAllAdapter,
 ): TemplatesSearchOperation {
-	const effect = Effect.fn("operations.templates.search")(function* (
-		input: TemplatesSearchInput,
-		options?: HevyExecutionOptions,
-	) {
-		if (
-			!Number.isInteger(input.maxPages) ||
-			input.maxPages < TEMPLATES_SEARCH_MIN_PAGES ||
-			input.maxPages > TEMPLATES_SEARCH_MAX_PAGES
-		) {
-			return yield* new TemplatesSearchValidationError({
-				maxPages: input.maxPages,
-				message: `Templates search maxPages must be an integer from ${TEMPLATES_SEARCH_MIN_PAGES} through ${TEMPLATES_SEARCH_MAX_PAGES}`,
-			});
-		}
-		const maxPages = input.maxPages;
-		const query = input.query.toLowerCase();
-		const pageStream = Stream.paginate<
-			TemplatesSearchCursor,
-			TemplatesSearchPage,
-			HevyRequestEffectError | PaginationMismatchError
-		>({ page: 1 }, (cursor) => {
-			if (cursor.page > maxPages) {
-				return Effect.succeed([
-					[] as ReadonlyArray<TemplatesSearchPage>,
-					Option.none<TemplatesSearchCursor>(),
-				] as const);
+	return defineOperation(
+		templatesSearchDescriptor,
+		function* (input: TemplatesSearchInput, options?: HevyExecutionOptions) {
+			if (
+				!Number.isInteger(input.maxPages) ||
+				input.maxPages < TEMPLATES_SEARCH_MIN_PAGES ||
+				input.maxPages > TEMPLATES_SEARCH_MAX_PAGES
+			) {
+				return yield* new TemplatesSearchValidationError({
+					maxPages: input.maxPages,
+					message: `Templates search maxPages must be an integer from ${TEMPLATES_SEARCH_MIN_PAGES} through ${TEMPLATES_SEARCH_MAX_PAGES}`,
+				});
 			}
-			const params = { page: cursor.page, pageSize: TEMPLATES_PAGE_SIZE };
-			const request =
-				options === undefined
-					? adapter.getExerciseTemplates(params)
-					: adapter.getExerciseTemplates(params, options);
-			return request.pipe(
-				Effect.flatMap((response: GetV1ExerciseTemplates200) =>
-					readTemplatesPage(response, cursor.page).pipe(
-						Effect.map(
-							({ templates, hasNextPage }) =>
-								[
+			const maxPages = input.maxPages;
+			const query = input.query.toLowerCase();
+			const pageStream = Stream.paginate<
+				TemplatesSearchCursor,
+				TemplatesSearchPage,
+				HevyRequestEffectError | PaginationMismatchError
+			>({ page: 1 }, (cursor) => {
+				if (cursor.page > maxPages) {
+					return Effect.succeed([
+						[] as ReadonlyArray<TemplatesSearchPage>,
+						Option.none<TemplatesSearchCursor>(),
+					] as const);
+				}
+				const params = { page: cursor.page, pageSize: TEMPLATES_PAGE_SIZE };
+				const request = adapter.getExerciseTemplates(params, options);
+				return request.pipe(
+					Effect.flatMap((response: GetV1ExerciseTemplates200) =>
+						readTemplatesPage(response, cursor.page).pipe(
+							Effect.map(
+								({ templates, hasNextPage }) =>
 									[
-										{
-											templates,
-											hasNextPage,
-										},
-									],
-									hasNextPage && cursor.page < maxPages
-										? Option.some({ page: cursor.page + 1 })
-										: Option.none(),
-								] as const,
+										[
+											{
+												templates,
+												hasNextPage,
+											},
+										],
+										hasNextPage && cursor.page < maxPages
+											? Option.some({ page: cursor.page + 1 })
+											: Option.none(),
+									] as const,
+							),
 						),
 					),
-				),
-				Effect.catchIf(
-					(error) =>
-						isExpectedReadEndOfList(
-							error,
-							"/v1/exercise_templates",
-							cursor.page,
-						),
-					() =>
-						Effect.succeed([
-							[
-								{
-									templates: [] as ExerciseTemplate[],
-									hasNextPage: false,
-									endOfList: true,
-								},
-							],
-							Option.none<TemplatesSearchCursor>(),
-						] as const),
+					withExpectedEndOfList("/v1/exercise_templates", cursor.page, [
+						[
+							{
+								templates: [] as ExerciseTemplate[],
+								hasNextPage: false,
+								endOfList: true,
+							},
+						],
+						Option.none<TemplatesSearchCursor>(),
+					] as const),
+				);
+			});
+			const pages = yield* Stream.runCollect(pageStream);
+			const scannedPages = pages.filter((page) => !page.endOfList);
+			const matches = scannedPages.flatMap((page) =>
+				page.templates.filter((template) =>
+					template.title?.toLowerCase().includes(query),
 				),
 			);
-		});
-		const pages = yield* Stream.runCollect(pageStream);
-		const scannedPages = pages.filter((page) => !page.endOfList);
-		const matches = scannedPages.flatMap((page) =>
-			page.templates.filter((template) =>
-				template.title?.toLowerCase().includes(query),
-			),
-		);
-		return {
-			matches,
-			pages: scannedPages.length,
-			itemsScanned: scannedPages.reduce(
-				(total, page) => total + page.templates.length,
-				0,
-			),
-			complete:
-				pages.at(-1)?.endOfList === true || pages.at(-1)?.hasNextPage !== true,
-		};
-	});
-
-	const operation: TemplatesSearchOperation = {
-		descriptor: templatesSearchDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+			return {
+				matches,
+				pages: scannedPages.length,
+				itemsScanned: scannedPages.reduce(
+					(total, page) => total + page.templates.length,
+					0,
+				),
+				complete:
+					pages.at(-1)?.endOfList === true ||
+					pages.at(-1)?.hasNextPage !== true,
+			};
 		},
-	};
-	return operation;
+	);
 }

--- a/packages/operations/src/user.test.ts
+++ b/packages/operations/src/user.test.ts
@@ -39,13 +39,15 @@ describe("user.get operation", () => {
 		await expect(Effect.runPromise(operation.effect())).rejects.toBe(error);
 	});
 
-	it("omits options when no execution options are supplied", async () => {
+	it("forwards options through to the request client", async () => {
 		const getUserInfo = vi.fn(() => Effect.succeed({ data: undefined }));
 		const operation = createUserGetOperation({ getUserInfo });
 
 		await expect(
 			Effect.runPromise(operation.effect()),
 		).resolves.toBeUndefined();
-		expect(getUserInfo).toHaveBeenCalledWith();
+		// Explicit undefined is identical to omission for optional request
+		// options, and keeps every operation on one calling convention.
+		expect(getUserInfo).toHaveBeenCalledWith(undefined);
 	});
 });

--- a/packages/operations/src/user.ts
+++ b/packages/operations/src/user.ts
@@ -1,4 +1,5 @@
-import { Effect } from "effect";
+import type { Effect } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -32,23 +33,11 @@ export interface UserGetOperation {
 export function createUserGetOperation(
 	adapter: UserGetAdapter,
 ): UserGetOperation {
-	const effect = Effect.fn("operations.user.get")(function* (
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getUserInfo()
-				: adapter.getUserInfo(options);
-		const response = yield* request;
-		return response?.data;
-	});
-
-	const operation: UserGetOperation = {
-		descriptor: userGetDescriptor,
-		effect,
-		execute(options) {
-			return Effect.runPromise(operation.effect(options));
+	return defineOperation(
+		userGetDescriptor,
+		function* (options?: HevyExecutionOptions) {
+			const response = yield* adapter.getUserInfo(options);
+			return response?.data;
 		},
-	};
-	return operation;
+	);
 }

--- a/packages/operations/src/workflows.ts
+++ b/packages/operations/src/workflows.ts
@@ -1,4 +1,5 @@
 import { DateTime, Effect, Option, Predicate, Stream } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -9,6 +10,7 @@ import {
 	PaginationMismatchError,
 	TrainingSummaryDataError,
 	TrainingSummaryValidationError,
+	hasNextPage,
 	isExpectedReadEndOfList,
 } from "./operation-errors.js";
 import type {
@@ -180,14 +182,6 @@ function parseUtcDate(value: string | undefined): DateTime.Utc | undefined {
 	return Option.isSome(parsed) ? parsed.value : undefined;
 }
 
-function hasNextPage(pageCount: number | undefined, page: number): boolean {
-	return (
-		Predicate.isNumber(pageCount) &&
-		Number.isSafeInteger(pageCount) &&
-		pageCount > page
-	);
-}
-
 function hasInvalidPageCount(
 	pageCount: number | undefined,
 	page: number,
@@ -241,10 +235,7 @@ export const scanPagesInWindow = Effect.fn(
 		TrainingSummaryPage<T>,
 		HevyRequestEffectError | PaginationMismatchError
 	>({ page: 1 }, (cursor) => {
-		const request =
-			options === undefined
-				? loader(cursor.page, pageSize)
-				: loader(cursor.page, pageSize, options);
+		const request = loader(cursor.page, pageSize, options);
 		return request.pipe(
 			Effect.flatMap(
 				(
@@ -282,11 +273,13 @@ export const scanPagesInWindow = Effect.fn(
 							}),
 						);
 					}
-					const nextPage =
-						pageResult.items.length > 0 &&
-						hasNextPage(pageResult.pageCount, cursor.page)
-							? Option.some({ page: cursor.page + 1 })
-							: Option.none<{ readonly page: number }>();
+					const nextPage = hasNextPage(
+						pageResult.pageCount,
+						cursor.page,
+						pageResult.items.length,
+					)
+						? Option.some({ page: cursor.page + 1 })
+						: Option.none<{ readonly page: number }>();
 					return Effect.succeed([
 						[pageResult] as ReadonlyArray<TrainingSummaryPage<T>>,
 						nextPage,
@@ -399,10 +392,7 @@ function loadWorkoutsPage(
 	operation: WorkoutsListOperation,
 ): TrainingSummaryPageLoader<Workout> {
 	return (page, pageSize, options) => {
-		const result =
-			options === undefined
-				? operation.effect({ page, pageSize })
-				: operation.effect({ page, pageSize }, options);
+		const result = operation.effect({ page, pageSize }, options);
 		return result.pipe(
 			Effect.map((response: WorkoutsListOutput) => ({
 				items: response.items,
@@ -421,10 +411,7 @@ function loadMeasurementsPage(
 	operation: BodyMeasurementsListOperation,
 ): TrainingSummaryPageLoader<BodyMeasurement> {
 	return (page, pageSize, options) => {
-		const result =
-			options === undefined
-				? operation.effect({ page, pageSize })
-				: operation.effect({ page, pageSize }, options);
+		const result = operation.effect({ page, pageSize }, options);
 		return result.pipe(
 			Effect.map((response: BodyMeasurementsListOutput) => ({
 				items: response.items,
@@ -446,143 +433,133 @@ export function createWorkflowsTrainingSummaryOperation(
 ): WorkflowsTrainingSummaryOperation {
 	const maxWeeks = options.maxWeeks ?? MAX_TRAINING_SUMMARY_WEEKS;
 	const strictPagination = options.strictPagination ?? false;
-	const effect = Effect.fn("operations.workflows.trainingSummary")(function* (
-		input: TrainingSummaryInput,
-		options?: HevyExecutionOptions,
-	): Effect.fn.Return<
-		TrainingSummaryResult,
-		| HevyRequestEffectError
-		| PaginationMismatchError
-		| TrainingSummaryDataError
-		| TrainingSummaryValidationError
-	> {
-		if (
-			!Number.isInteger(input.weeks) ||
-			input.weeks < MIN_TRAINING_SUMMARY_WEEKS ||
-			input.weeks > maxWeeks
-		) {
-			return yield* new TrainingSummaryValidationError({
+	return defineOperation(
+		workflowsTrainingSummaryDescriptor,
+		function* (
+			input: TrainingSummaryInput,
+			options?: HevyExecutionOptions,
+		): Effect.fn.Return<
+			TrainingSummaryResult,
+			| HevyRequestEffectError
+			| PaginationMismatchError
+			| TrainingSummaryDataError
+			| TrainingSummaryValidationError
+		> {
+			if (
+				!Number.isInteger(input.weeks) ||
+				input.weeks < MIN_TRAINING_SUMMARY_WEEKS ||
+				input.weeks > maxWeeks
+			) {
+				return yield* new TrainingSummaryValidationError({
+					weeks: input.weeks,
+					message: `Training summary weeks must be an integer from ${MIN_TRAINING_SUMMARY_WEEKS} through ${maxWeeks}`,
+				});
+			}
+
+			const now = yield* DateTime.now;
+			const end = DateTime.startOf(now, "day");
+			const start = DateTime.subtract(end, { days: input.weeks * 7 });
+			const period = {
+				start_date: DateTime.formatIsoDateUtc(start),
+				end_date: DateTime.formatIsoDateUtc(end),
 				weeks: input.weeks,
-				message: `Training summary weeks must be an integer from ${MIN_TRAINING_SUMMARY_WEEKS} through ${maxWeeks}`,
-			});
-		}
+			};
+			const workoutLoader = loadWorkoutsPage(workoutListOperation(operations));
+			const measurementLoader = loadMeasurementsPage(
+				measurementListOperation(operations),
+			);
+			const [workoutScan, measurementScan] = yield* Effect.all(
+				[
+					scanPagesInWindow(
+						workoutLoader,
+						TRAINING_SUMMARY_PAGE_SIZE,
+						period.start_date,
+						period.end_date,
+						(workout) => workout.start_time,
+						options,
+						strictPagination,
+					),
+					scanPagesInWindow(
+						measurementLoader,
+						TRAINING_SUMMARY_PAGE_SIZE,
+						period.start_date,
+						period.end_date,
+						(measurement) => measurement.date,
+						options,
+						strictPagination,
+					),
+				],
+				{ concurrency: SCAN_CONCURRENCY },
+			);
 
-		const now = yield* DateTime.now;
-		const end = DateTime.startOf(now, "day");
-		const start = DateTime.subtract(end, { days: input.weeks * 7 });
-		const period = {
-			start_date: DateTime.formatIsoDateUtc(start),
-			end_date: DateTime.formatIsoDateUtc(end),
-			weeks: input.weeks,
-		};
-		const workoutLoader = loadWorkoutsPage(workoutListOperation(operations));
-		const measurementLoader = loadMeasurementsPage(
-			measurementListOperation(operations),
-		);
-		const [workoutScan, measurementScan] = yield* Effect.all(
-			[
-				scanPagesInWindow(
-					workoutLoader,
-					TRAINING_SUMMARY_PAGE_SIZE,
-					period.start_date,
-					period.end_date,
-					(workout) => workout.start_time,
-					options,
-					strictPagination,
-				),
-				scanPagesInWindow(
-					measurementLoader,
-					TRAINING_SUMMARY_PAGE_SIZE,
-					period.start_date,
-					period.end_date,
-					(measurement) => measurement.date,
-					options,
-					strictPagination,
-				),
-			],
-			{ concurrency: SCAN_CONCURRENCY },
-		);
-
-		const workouts = workoutScan.items;
-		const sessions = workouts.map(compactSession);
-		const uniqueExerciseTemplateIds = [
-			...new Set(
-				workouts.flatMap((workout) =>
-					(workout.exercises ?? [])
-						.map((exercise) => exercise.exercise_template_id)
-						.filter((id): id is string => Boolean(id)),
-				),
-			),
-		];
-		const measurements = [...measurementScan.items].sort((left, right) =>
-			left.date.localeCompare(right.date),
-		);
-		const earliestMeasurement = measurements[0];
-		const latestMeasurement = measurements.at(-1);
-		const earliest =
-			earliestMeasurement === undefined
-				? undefined
-				: compactMeasurement(earliestMeasurement);
-		const latest =
-			latestMeasurement === undefined
-				? undefined
-				: compactMeasurement(latestMeasurement);
-		const weightChange =
-			latest?.weight_kg !== undefined && earliest?.weight_kg !== undefined
-				? latest.weight_kg - earliest.weight_kg
-				: undefined;
-		const bodyMeasurements: MutableTrainingSummaryBodyMeasurements = {
-			count: measurements.length,
-		};
-		if (latest !== undefined) bodyMeasurements.latest = latest;
-		if (earliest !== undefined) bodyMeasurements.earliest = earliest;
-		if (weightChange !== undefined) {
-			bodyMeasurements.weight_change_kg = weightChange;
-		}
-		return {
-			period,
-			workouts: {
-				count: workouts.length,
-				total_duration_seconds: sessions.reduce(
-					(total, session) => total + (session.duration_seconds ?? 0),
-					0,
-				),
-				exercise_count: sessions.reduce(
-					(total, session) => total + session.exercise_count,
-					0,
-				),
-				set_count: sessions.reduce(
-					(total, session) => total + session.set_count,
-					0,
-				),
-				total_volume_kg: workouts.reduce(
-					(total, workout) => total + workoutVolume(workout),
-					0,
-				),
-				unique_exercise_template_ids: uniqueExerciseTemplateIds,
-				sessions,
-			},
-			body_measurements: bodyMeasurements,
-			workflow: {
-				name: "training-summary" as const,
-				pagination: {
-					workouts: workoutScan.pages,
-					body_measurements: measurementScan.pages,
+			const sessions: TrainingSummarySession[] = [];
+			const uniqueExerciseTemplateIds = new Set<string>();
+			let totalDurationSeconds = 0;
+			let totalExerciseCount = 0;
+			let totalSetCount = 0;
+			let totalVolumeKg = 0;
+			for (const workout of workoutScan.items) {
+				const session = compactSession(workout);
+				sessions.push(session);
+				totalDurationSeconds += session.duration_seconds ?? 0;
+				totalExerciseCount += session.exercise_count;
+				totalSetCount += session.set_count;
+				totalVolumeKg += workoutVolume(workout);
+				for (const exercise of workout.exercises ?? []) {
+					if (exercise.exercise_template_id) {
+						uniqueExerciseTemplateIds.add(exercise.exercise_template_id);
+					}
+				}
+			}
+			const measurements = [...measurementScan.items].sort((left, right) =>
+				left.date.localeCompare(right.date),
+			);
+			const earliestMeasurement = measurements[0];
+			const latestMeasurement = measurements.at(-1);
+			const earliest =
+				earliestMeasurement === undefined
+					? undefined
+					: compactMeasurement(earliestMeasurement);
+			const latest =
+				latestMeasurement === undefined
+					? undefined
+					: compactMeasurement(latestMeasurement);
+			const weightChange =
+				latest?.weight_kg !== undefined && earliest?.weight_kg !== undefined
+					? latest.weight_kg - earliest.weight_kg
+					: undefined;
+			const bodyMeasurements: MutableTrainingSummaryBodyMeasurements = {
+				count: measurements.length,
+			};
+			if (latest !== undefined) bodyMeasurements.latest = latest;
+			if (earliest !== undefined) bodyMeasurements.earliest = earliest;
+			if (weightChange !== undefined) {
+				bodyMeasurements.weight_change_kg = weightChange;
+			}
+			return {
+				period,
+				workouts: {
+					count: sessions.length,
+					total_duration_seconds: totalDurationSeconds,
+					exercise_count: totalExerciseCount,
+					set_count: totalSetCount,
+					total_volume_kg: totalVolumeKg,
+					unique_exercise_template_ids: [...uniqueExerciseTemplateIds],
+					sessions,
 				},
-				cacheStatus: "not-used",
-				itemsScanned: workoutScan.itemsScanned + measurementScan.itemsScanned,
-			},
-		};
-	});
-
-	const operation: WorkflowsTrainingSummaryOperation = {
-		descriptor: workflowsTrainingSummaryDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+				body_measurements: bodyMeasurements,
+				workflow: {
+					name: "training-summary" as const,
+					pagination: {
+						workouts: workoutScan.pages,
+						body_measurements: measurementScan.pages,
+					},
+					cacheStatus: "not-used",
+					itemsScanned: workoutScan.itemsScanned + measurementScan.itemsScanned,
+				},
+			};
 		},
-	};
-	return operation;
+	);
 }
 
 export const createTrainingSummaryOperation =

--- a/packages/operations/src/workouts.test.ts
+++ b/packages/operations/src/workouts.test.ts
@@ -9,7 +9,7 @@ import type {
 	PutV1WorkoutsWorkoutidStatus200,
 } from "@hevy-mcp/hevy-client/types";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	createWorkoutsCountOperation,
 	createWorkoutsCreateOperation,
@@ -234,14 +234,14 @@ describe("workouts.get operation", () => {
 		await expect(operation.execute({ workoutId: "w1" })).rejects.toBe(error);
 	});
 
-	it("[VAL-OPS-008] omits the options argument when workouts.get options are absent", async () => {
+	it("[VAL-OPS-008] forwards options through to the adapter when workouts.get options are absent", async () => {
 		const adapter = createInMemoryGetAdapter({ id: "w1" });
 		const operation = createWorkoutsGetOperation(adapter);
 
 		await expect(operation.execute({ workoutId: "w1" })).resolves.toEqual({
 			workout: { id: "w1" },
 		});
-		expect(adapter.argumentCounts).toEqual([1]);
+		expect(adapter.argumentCounts).toEqual([2]);
 	});
 });
 
@@ -414,7 +414,7 @@ describe("workouts.list operation", () => {
 		});
 	});
 
-	it("[VAL-OPS-008] omits the options argument when workouts.list options are absent", async () => {
+	it("[VAL-OPS-008] forwards options through to the adapter when workouts.list options are absent", async () => {
 		const adapter = createInMemoryAdapter([{ page: 1, workouts: [] }]);
 		const operation = createWorkoutsListOperation(adapter);
 
@@ -423,7 +423,7 @@ describe("workouts.list operation", () => {
 			page: 1,
 			pageCount: undefined,
 		});
-		expect(adapter.argumentCounts).toEqual([1]);
+		expect(adapter.argumentCounts).toEqual([2]);
 	});
 
 	it("[VAL-OPS-003] rejects when response page differs from requested page", async () => {
@@ -783,6 +783,32 @@ describe("workouts write operations", () => {
 		expect(adapter.createRequests).toEqual([
 			{ data: { workout }, options: undefined },
 		]);
+	});
+
+	it("[VAL-OPS-005] lets unexpected builder defects escape instead of mislabeling them", async () => {
+		const malformed = {
+			...currentWorkoutForMutation,
+			exercises: {} as NonNullable<WorkoutMutationCurrent["exercises"]>,
+		};
+		const updateWorkout = vi.fn(() => Effect.succeed({ id: "w1" }));
+		const operation = createWorkoutsUpdateOperation({
+			getWorkout: () => Effect.succeed(malformed),
+			updateWorkout,
+		});
+
+		const failure = await Effect.runPromise(
+			operation.effect({
+				workoutId: "w1",
+				patch: { title: "Renamed", is_private: false },
+			}),
+		).then(
+			() => {
+				throw new Error("expected the malformed workout to defect");
+			},
+			(error) => error,
+		);
+		expect(failure).toBeInstanceOf(TypeError);
+		expect(updateWorkout).not.toHaveBeenCalled();
 	});
 
 	it("[VAL-OPS-012] updates with GET-then-PUT payload semantics", async () => {

--- a/packages/operations/src/workouts.ts
+++ b/packages/operations/src/workouts.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { defineOperation } from "./define-operation.js";
 import type {
 	HevyExecutionOptions,
 	HevyOperationSafety,
@@ -21,11 +22,13 @@ import {
 	type WorkoutExerciseInput,
 } from "./mutation-semantics.js";
 import {
-	isExpectedReadEndOfList,
-	isExpectedReadNotFound,
+	assertPageEcho,
+	isEmptyResponse,
+	withExpectedEndOfList,
+	withExpectedNotFound,
+	PaginationMismatchError,
 	WorkoutPayloadError,
 	WorkoutPrivacyError,
-	PaginationMismatchError,
 } from "./operation-errors.js";
 
 export interface WorkoutsListInput {
@@ -290,301 +293,190 @@ function workoutPayloadEffect(
 	ReturnType<typeof buildWorkoutUpdatePayload>,
 	WorkoutPrivacyError | WorkoutPayloadError
 > {
-	return Effect.try({
-		try: () => buildWorkoutUpdatePayload(current, patch, replacementExercises),
-		catch: (error) => {
+	// Only the builder's documented validation tags stay in the failure
+	// channel. Anything else (e.g. a TypeError from a programming bug) is a
+	// defect and must stay loud instead of being mislabeled a payload error.
+	return Effect.suspend(() => {
+		try {
+			return Effect.succeed(
+				buildWorkoutUpdatePayload(current, patch, replacementExercises),
+			);
+		} catch (cause) {
 			if (
-				error instanceof WorkoutPrivacyError ||
-				error instanceof WorkoutPayloadError
+				cause instanceof WorkoutPrivacyError ||
+				cause instanceof WorkoutPayloadError
 			) {
-				return error;
+				return Effect.fail(cause);
 			}
-			return new WorkoutPayloadError({
-				message: "The workout metadata is invalid for an update",
-			});
-		},
+			return Effect.die(cause);
+		}
 	});
-}
-
-function isEmptyResponse<T extends object>(
-	response: T | null | undefined,
-): response is T & Record<never, never> {
-	return (
-		response !== null &&
-		response !== undefined &&
-		Object.keys(response).length === 0
-	);
 }
 
 export function createWorkoutsCreateOperation(
 	adapter: WorkoutsCreateAdapter,
 ): WorkoutsCreateOperation {
-	const effect = Effect.fn("operations.workouts.create")(function* (
-		input: WorkoutsCreateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.createWorkout({ workout: input.workout })
-				: adapter.createWorkout({ workout: input.workout }, options);
-		const response = yield* request;
-		return isEmptyResponse(response) ? undefined : response;
-	});
-
-	const operation: WorkoutsCreateOperation = {
-		descriptor: workoutsCreateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		workoutsCreateDescriptor,
+		function* (input: WorkoutsCreateInput, options?: HevyExecutionOptions) {
+			const request = adapter.createWorkout(
+				{ workout: input.workout },
+				options,
+			);
+			const response = yield* request;
+			return isEmptyResponse(response) ? undefined : response;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsEventsOperation(
 	adapter: WorkoutsEventsAdapter,
 ): WorkoutsEventsOperation {
-	const effect = Effect.fn("operations.workouts.events")(function* (
-		input: WorkoutsEventsInput,
-		options?: HevyExecutionOptions,
-	) {
-		const params =
-			input.since === undefined
-				? { page: input.page, pageSize: input.pageSize }
-				: {
-						page: input.page,
-						pageSize: input.pageSize,
-						since: input.since,
-					};
-		const request =
-			options === undefined
-				? adapter.getWorkoutEvents(params)
-				: adapter.getWorkoutEvents(params, options);
-		return yield* request.pipe(
-			Effect.flatMap((response: GetV1WorkoutsEvents200) => {
-				if (response?.page !== undefined && response.page !== input.page) {
-					return Effect.fail(
-						new PaginationMismatchError({
-							requested: input.page,
-							received: response.page,
-							collection: "workoutEvents",
-							message: `Workout events page mismatch: requested page ${input.page} but received page ${response.page}`,
-						}),
-					);
-				}
-				return Effect.succeed({
+	return defineOperation(
+		workoutsEventsDescriptor,
+		function* (input: WorkoutsEventsInput, options?: HevyExecutionOptions) {
+			const params =
+				input.since === undefined
+					? { page: input.page, pageSize: input.pageSize }
+					: {
+							page: input.page,
+							pageSize: input.pageSize,
+							since: input.since,
+						};
+			const request = adapter.getWorkoutEvents(params, options);
+			return yield* request.pipe(
+				Effect.tap((response) =>
+					assertPageEcho(response, input.page, "workoutEvents"),
+				),
+				Effect.map((response: GetV1WorkoutsEvents200) => ({
 					events: response?.events ?? [],
 					page: response?.page ?? input.page,
 					pageCount: response?.page_count,
 					since: input.since,
-				});
-			}),
-			Effect.catchIf(
-				(error) =>
-					isExpectedReadEndOfList(error, "/v1/workouts/events", input.page),
-				() =>
-					Effect.succeed({
-						events: [],
-						page: input.page,
-						pageCount: undefined,
-						since: input.since,
-						expected404Outcome: "end_of_list" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: WorkoutsEventsOperation = {
-		descriptor: workoutsEventsDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+				})),
+				withExpectedEndOfList("/v1/workouts/events", input.page, {
+					events: [],
+					page: input.page,
+					pageCount: undefined,
+					since: input.since,
+					expected404Outcome: "end_of_list" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsUpdateOperation(
 	adapter: WorkoutsUpdateAdapter,
 ): WorkoutsUpdateOperation {
-	const effect = Effect.fn("operations.workouts.update")(function* (
-		input: WorkoutsUpdateInput,
-		options?: HevyExecutionOptions,
-	) {
-		const patch = "patch" in input ? input.patch : input.workout;
-		const replacementExercises = isWorkoutReplacementPatch(patch)
-			? patch.exercises
-			: undefined;
-		const current = yield* options === undefined
-			? adapter.getWorkout(input.workoutId)
-			: adapter.getWorkout(input.workoutId, options);
-		const payload = yield* workoutPayloadEffect(
-			current,
-			patch,
-			replacementExercises,
-		);
-		const updateRequest =
-			options === undefined
-				? adapter.updateWorkout(input.workoutId, { workout: payload })
-				: adapter.updateWorkout(input.workoutId, { workout: payload }, options);
-		const response = yield* updateRequest;
-		return isEmptyResponse(response) ? undefined : response;
-	});
-
-	const operation: WorkoutsUpdateOperation = {
-		descriptor: workoutsUpdateDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		workoutsUpdateDescriptor,
+		function* (input: WorkoutsUpdateInput, options?: HevyExecutionOptions) {
+			const patch = "patch" in input ? input.patch : input.workout;
+			const replacementExercises = isWorkoutReplacementPatch(patch)
+				? patch.exercises
+				: undefined;
+			const current = yield* adapter.getWorkout(input.workoutId, options);
+			const payload = yield* workoutPayloadEffect(
+				current,
+				patch,
+				replacementExercises,
+			);
+			const updateRequest = adapter.updateWorkout(
+				input.workoutId,
+				{ workout: payload },
+				options,
+			);
+			const response = yield* updateRequest;
+			return isEmptyResponse(response) ? undefined : response;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsReplaceExercisesOperation(
 	adapter: WorkoutsReplaceExercisesAdapter,
 ): WorkoutsReplaceExercisesOperation {
-	const effect = Effect.fn("operations.workouts.replaceExercises")(function* (
-		input: WorkoutsReplaceExercisesInput,
-		options?: HevyExecutionOptions,
-	) {
-		const getRequest =
-			options === undefined
-				? adapter.getWorkout(input.workoutId)
-				: adapter.getWorkout(input.workoutId, options);
-		const current = yield* getRequest;
-		const payload = yield* workoutPayloadEffect(
-			current,
-			{ is_private: input.is_private },
-			input.exercises,
-		);
-		const updateRequest =
-			options === undefined
-				? adapter.updateWorkout(input.workoutId, { workout: payload })
-				: adapter.updateWorkout(input.workoutId, { workout: payload }, options);
-		const response = yield* updateRequest;
-		return isEmptyResponse(response) ? undefined : response;
-	});
-
-	const operation: WorkoutsReplaceExercisesOperation = {
-		descriptor: workoutsReplaceExercisesDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		workoutsReplaceExercisesDescriptor,
+		function* (
+			input: WorkoutsReplaceExercisesInput,
+			options?: HevyExecutionOptions,
+		) {
+			const getRequest = adapter.getWorkout(input.workoutId, options);
+			const current = yield* getRequest;
+			const payload = yield* workoutPayloadEffect(
+				current,
+				{ is_private: input.is_private },
+				input.exercises,
+			);
+			const updateRequest = adapter.updateWorkout(
+				input.workoutId,
+				{ workout: payload },
+				options,
+			);
+			const response = yield* updateRequest;
+			return isEmptyResponse(response) ? undefined : response;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsCountOperation(
 	adapter: WorkoutsCountAdapter,
 ): WorkoutsCountOperation {
-	const effect = Effect.fn("operations.workouts.count")(function* (
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getWorkoutCount()
-				: adapter.getWorkoutCount(options);
-		const response = yield* request;
-		return response?.workout_count ?? 0;
-	});
-
-	const operation: WorkoutsCountOperation = {
-		descriptor: workoutsCountDescriptor,
-		effect,
-		execute(options) {
-			return Effect.runPromise(operation.effect(options));
+	return defineOperation(
+		workoutsCountDescriptor,
+		function* (options?: HevyExecutionOptions) {
+			const request = adapter.getWorkoutCount(options);
+			const response = yield* request;
+			return response?.workout_count ?? 0;
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsGetOperation(
 	adapter: WorkoutsGetAdapter,
 ): WorkoutsGetOperation {
-	const effect = Effect.fn("operations.workouts.get")(function* (
-		input: WorkoutsGetInput,
-		options?: HevyExecutionOptions,
-	) {
-		const request =
-			options === undefined
-				? adapter.getWorkout(input.workoutId)
-				: adapter.getWorkout(input.workoutId, options);
-		return yield* request.pipe(
-			Effect.map((response) => ({
-				workout: isEmptyResponse(response) ? null : (response ?? null),
-			})),
-			Effect.catchIf(
-				(error) => isExpectedReadNotFound(error, "/v1/workouts"),
-				() =>
-					Effect.succeed({
-						workout: null,
-						expected404Outcome: "not_found" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: WorkoutsGetOperation = {
-		descriptor: workoutsGetDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+	return defineOperation(
+		workoutsGetDescriptor,
+		function* (input: WorkoutsGetInput, options?: HevyExecutionOptions) {
+			const request = adapter.getWorkout(input.workoutId, options);
+			return yield* request.pipe(
+				Effect.map((response) => ({
+					workout: isEmptyResponse(response) ? null : (response ?? null),
+				})),
+				withExpectedNotFound("/v1/workouts", {
+					workout: null,
+					expected404Outcome: "not_found" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }
 
 export function createWorkoutsListOperation(
 	adapter: WorkoutsListAdapter,
 ): WorkoutsListOperation {
-	const effect = Effect.fn("operations.workouts.list")(function* (
-		input: WorkoutsListInput,
-		options?: HevyExecutionOptions,
-	) {
-		const params = { page: input.page, pageSize: input.pageSize };
-		const request =
-			options === undefined
-				? adapter.getWorkouts(params)
-				: adapter.getWorkouts(params, options);
-		return yield* request.pipe(
-			Effect.flatMap((response: GetV1Workouts200) => {
-				if (response?.page !== undefined && response.page !== input.page) {
-					return Effect.fail(
-						new PaginationMismatchError({
-							requested: input.page,
-							received: response.page,
-							collection: "workouts",
-							message: `Workouts page mismatch: requested page ${input.page} but received page ${response.page}`,
-						}),
-					);
-				}
-				return Effect.succeed({
+	return defineOperation(
+		workoutsListDescriptor,
+		function* (input: WorkoutsListInput, options?: HevyExecutionOptions) {
+			const params = { page: input.page, pageSize: input.pageSize };
+			const request = adapter.getWorkouts(params, options);
+			return yield* request.pipe(
+				Effect.tap((response) =>
+					assertPageEcho(response, input.page, "workouts"),
+				),
+				Effect.map((response: GetV1Workouts200) => ({
 					items: response?.workouts ?? [],
 					page: response?.page ?? input.page,
 					pageCount: response?.page_count,
-				});
-			}),
-			Effect.catchIf(
-				(error) => isExpectedReadEndOfList(error, "/v1/workouts", input.page),
-				() =>
-					Effect.succeed({
-						items: [],
-						page: input.page,
-						pageCount: undefined,
-						expected404Outcome: "end_of_list" as const,
-					}),
-			),
-		);
-	});
-
-	const operation: WorkoutsListOperation = {
-		descriptor: workoutsListDescriptor,
-		effect,
-		execute(input, options) {
-			return Effect.runPromise(operation.effect(input, options));
+				})),
+				withExpectedEndOfList("/v1/workouts", input.page, {
+					items: [],
+					page: input.page,
+					pageCount: undefined,
+					expected404Outcome: "end_of_list" as const,
+				}),
+			);
 		},
-	};
-	return operation;
+	);
 }


### PR DESCRIPTION
## Primary changes
- Centralize traced operation construction, execution, and Effect typing behind `defineOperation`.
- Share response normalization, expected read-outcome, page validation, and pagination helpers across operations.
- Standardize execution-option forwarding across operation and CLI callers, while preserving unexpected workout payload-builder failures as defects.

## Reviewer walkthrough
1. Review `packages/operations/src/define-operation.ts` and the operation migrations for factory typing, tracing, and execution.
2. Review `operation-errors.ts` plus the folders, routines, templates, workflows, and workouts modules for shared read and pagination semantics.
3. Review CLI integration, workout defect handling, regression tests, and the release metadata.

## Correctness and invariants
- Unexpected workout payload-builder exceptions remain defects; documented validation errors retain typed recovery.
- Page-echo validation and pagination continuation remain consistent across migrated list and search operations.
- Optional execution options are forwarded consistently, including `undefined`, without changing operation results.

## Testing and QA
- Updated operation and CLI tests for unconditional options forwarding, shared pagination and read behavior, and unexpected workout builder defect propagation.
- Added patch release metadata in `.changeset/olive-operations-dedup.md`.

Entire-Checkpoint: 01M1X53DYVAA59WWPH7JMMSSQQ

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Consolidate operation construction and shared read/pagination behavior while standardizing execution-option forwarding and preserving workout error semantics.

Bug Fixes:
- Preserve unexpected workout payload-builder exceptions as defects while continuing to recover documented validation errors.
- Keep page validation, pagination continuation, empty-response normalization, and expected read outcomes consistent across migrated operations.

Enhancements:
- Centralize operation tracing, Effect typing, execution, and Promise conversion behind a shared operation factory.
- Standardize forwarding of optional execution options from operations and CLI callers, including explicit undefined values.
- Share read-response and pagination helpers across folders, routines, templates, workouts, body measurements, and workflow operations.
- Optimize training-summary aggregation without changing its returned results.

Tests:
- Update operation and CLI coverage for unconditional execution-option forwarding, shared pagination/read semantics, and workout defect propagation.

Chores:
- Add patch release metadata for the affected packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling across routines, workouts, templates, folders, and measurements.
  * Added consistent validation when the API returns a different page than requested.
  * Improved handling of expected “not found” responses and end-of-list conditions.
  * Unexpected malformed workout data now surfaces as an error instead of triggering an update request.

* **Improvements**
  * Standardized operation execution and error handling across supported CLI commands and API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->