### PR TITLE
refactor: simplify effect runtime usage across client, core, and cli

### DIFF
--- a/.changeset/witty-effects-simplify.md
+++ b/.changeset/witty-effects-simplify.md
@@ -1,0 +1,10 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Simplify Effect runtime usage: one abort-signal bridge, compiler-checked error vocabulary, a single cause-normalization boundary, lazy service layers, Effect-native catalog lifecycle, and shared response pagination.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -734,13 +734,7 @@ async function executeSummary({
 		{ weeks },
 		execution,
 	);
-	const totalVolumeKg =
-		z
-			.number()
-			.safeParse(
-				(result.workouts as { readonly total_volume_kg?: unknown })
-					.total_volume_kg,
-			).data ?? 0;
+	const totalVolumeKg = result.workouts.total_volume_kg ?? 0;
 	return {
 		weeks,
 		start_date: from.toISOString(),

--- a/packages/core/src/execution.ts
+++ b/packages/core/src/execution.ts
@@ -70,6 +70,13 @@ export function createExecutionProjection(
 	return projection;
 }
 
+/**
+ * Compose request and lifecycle abort signals for the fetch edge.
+ *
+ * Only the native fetch call needs the composed signal: in-flight Effect
+ * waits (retry delays, cache lookups) are already interrupted by the fiber,
+ * so this helper must not be repurposed as general cancellation plumbing.
+ */
 export function mergeAbortSignals(
 	...signals: Array<AbortSignal | undefined>
 ): AbortSignal | undefined {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -139,8 +139,7 @@ export const createHevyMcpServerEffect = Effect.fn("core.createHevyMcpServer")(
 		const services = yield* Layer.build(serviceLayer);
 		yield* Effect.addFinalizer(() => {
 			shutdown.abort(new DOMException("Server closed", "AbortError"));
-			catalog.close?.();
-			return Cache.invalidateAll(cache);
+			return catalog.close().pipe(Effect.andThen(Cache.invalidateAll(cache)));
 		});
 		const runtime = createToolRuntime({
 			client,

--- a/packages/core/src/tools/cross-package.test.ts
+++ b/packages/core/src/tools/cross-package.test.ts
@@ -28,7 +28,8 @@ import { workoutToolDefinitions } from "./workouts.js";
 const catalog: ExerciseTemplateCatalog = {
 	effect: () => Effect.succeed([]),
 	get: () => Promise.resolve([]),
-	reset: () => undefined,
+	reset: () => Effect.void,
+	close: () => Effect.void,
 };
 
 function createSoft404Operations() {

--- a/packages/core/src/tools/define-tool.ts
+++ b/packages/core/src/tools/define-tool.ts
@@ -13,7 +13,6 @@ import {
 	ToolInputValidationError,
 	type CoreToolError,
 } from "../effect-errors.js";
-import { normalizeCoreCause } from "./operation-helpers.js";
 
 type ToolDefinitionBase<
 	TSchema extends Record<string, z.ZodTypeAny>,
@@ -145,15 +144,16 @@ export function registerToolDefinition(
 					return Effect.fail(new ClientNotInitializedError());
 				}
 			}
-			return Effect.catchCause(
-				Effect.suspend(() =>
-					definition
-						.execute(scopedRuntime, args)
-						.pipe(
-							Effect.map((data) => respond(definition.responseContract, data)),
-						),
-				),
-				(cause) => Effect.failCause(normalizeCoreCause(cause)),
+			// The operation seam (operationEffect/normalizeCoreEffect) is the
+			// single normalization boundary: every tool execute() already runs
+			// typed CoreToolError effects, so a second collapse here would only
+			// re-traverse identical causes. Defects pass through either way.
+			return Effect.suspend(() =>
+				definition
+					.execute(scopedRuntime, args)
+					.pipe(
+						Effect.map((data) => respond(definition.responseContract, data)),
+					),
 			);
 		});
 	const handler = runtime.createHandler(directHandler, definition.name, {

--- a/packages/core/src/tools/operation-helpers.test.ts
+++ b/packages/core/src/tools/operation-helpers.test.ts
@@ -82,6 +82,23 @@ describe("operation error normalization", () => {
 		}
 	});
 
+	it("treats inherited tag names as defects", async () => {
+		for (const tag of ["constructor", "toString", "hasOwnProperty"]) {
+			const operation = {
+				effect: () => Effect.fail({ _tag: tag }),
+			};
+
+			const exit = await Effect.runPromiseExit(
+				operationEffect(Effect.succeed(operation)),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				expect(Cause.hasDies(exit.cause)).toBe(true);
+			}
+		}
+	});
+
 	it("preserves operation domain errors in failure channel", async () => {
 		const domainErrors = [
 			new WorkoutPrivacyError({

--- a/packages/core/src/tools/operation-helpers.ts
+++ b/packages/core/src/tools/operation-helpers.ts
@@ -61,7 +61,7 @@ function isCoreToolError(error: RuntimeValue): error is CoreToolError {
 		isObject(error) &&
 		"_tag" in error &&
 		isString(error._tag) &&
-		error._tag in CORE_TOOL_ERROR_TAGS
+		Object.hasOwn(CORE_TOOL_ERROR_TAGS, error._tag)
 	);
 }
 

--- a/packages/core/src/tools/operation-helpers.ts
+++ b/packages/core/src/tools/operation-helpers.ts
@@ -1,23 +1,13 @@
 import { Cause, Context, Effect } from "effect";
 import {
-	ApiError,
-	ClientNotInitializedError,
-	EmptyMeasurementUpdateError,
-	NetworkError,
-	NotFoundError,
 	OperationUnavailableError,
-	PaginationMismatchError,
-	RateLimitError,
-	TemplatesSearchValidationError,
-	ToolInputValidationError,
-	TrainingSummaryDataError,
-	TrainingSummaryValidationError,
-	ValidationError,
-	WorkoutPayloadError,
-	WorkoutPrivacyError,
 	type CoreToolError,
 } from "../effect-errors.js";
-import type { RuntimeValue } from "../utils/type-predicates.js";
+import {
+	isObject,
+	isString,
+	type RuntimeValue,
+} from "../utils/type-predicates.js";
 
 type EffectOperation<TArgs extends readonly unknown[], TResult> = {
 	readonly effect: (...args: TArgs) => Effect.Effect<TResult, unknown, never>;
@@ -40,23 +30,38 @@ export function requireOperation<T>(
 		: Effect.succeed(operation);
 }
 
+type CoreToolTag = CoreToolError["_tag"];
+
+/**
+ * The failure tags that survive the core boundary. `satisfies` keeps the
+ * table complete at compile time: adding a member to `CoreToolError` without
+ * listing its tag here is a type error, so the guard cannot drift from the
+ * vocabulary the way the previous `instanceof` chain could.
+ */
+const CORE_TOOL_ERROR_TAGS = {
+	ToolInputValidationError: true,
+	ClientNotInitializedError: true,
+	OperationUnavailableError: true,
+	ApiError: true,
+	NetworkError: true,
+	NotFoundError: true,
+	RateLimitError: true,
+	ValidationError: true,
+	EmptyMeasurementUpdateError: true,
+	PaginationMismatchError: true,
+	TemplatesSearchValidationError: true,
+	TrainingSummaryDataError: true,
+	TrainingSummaryValidationError: true,
+	WorkoutPayloadError: true,
+	WorkoutPrivacyError: true,
+} as const satisfies Record<CoreToolTag, true>;
+
 function isCoreToolError(error: RuntimeValue): error is CoreToolError {
 	return (
-		error instanceof ToolInputValidationError ||
-		error instanceof ClientNotInitializedError ||
-		error instanceof OperationUnavailableError ||
-		error instanceof ApiError ||
-		error instanceof NetworkError ||
-		error instanceof NotFoundError ||
-		error instanceof RateLimitError ||
-		error instanceof ValidationError ||
-		error instanceof EmptyMeasurementUpdateError ||
-		error instanceof PaginationMismatchError ||
-		error instanceof TemplatesSearchValidationError ||
-		error instanceof TrainingSummaryDataError ||
-		error instanceof TrainingSummaryValidationError ||
-		error instanceof WorkoutPayloadError ||
-		error instanceof WorkoutPrivacyError
+		isObject(error) &&
+		"_tag" in error &&
+		isString(error._tag) &&
+		error._tag in CORE_TOOL_ERROR_TAGS
 	);
 }
 

--- a/packages/core/src/tools/preload.test.ts
+++ b/packages/core/src/tools/preload.test.ts
@@ -14,7 +14,8 @@ import {
 const catalog: ExerciseTemplateCatalog = {
 	effect: () => Effect.succeed([]),
 	get: () => Promise.resolve([]),
-	reset: () => {},
+	reset: () => Effect.void,
+	close: () => Effect.void,
 };
 
 /**

--- a/packages/core/src/tools/register.test.ts
+++ b/packages/core/src/tools/register.test.ts
@@ -359,7 +359,8 @@ describe("registerHevyTools", () => {
 		const catalog: ExerciseTemplateCatalog = {
 			effect: () => Effect.succeed([]),
 			get: () => Promise.resolve([]),
-			reset: () => {},
+			reset: () => Effect.void,
+			close: () => Effect.void,
 		};
 		registerHevyTools(
 			server,
@@ -412,7 +413,8 @@ describe("registerHevyTools", () => {
 		const catalog: ExerciseTemplateCatalog = {
 			effect: () => Effect.succeed([]),
 			get: () => Promise.resolve([]),
-			reset: () => {},
+			reset: () => Effect.void,
+			close: () => Effect.void,
 		};
 		registerHevyTools(
 			productionServer,
@@ -451,7 +453,8 @@ describe("registerHevyTools", () => {
 			const catalog: ExerciseTemplateCatalog = {
 				effect: () => Effect.succeed([]),
 				get: () => Promise.resolve([]),
-				reset: () => {},
+				reset: () => Effect.void,
+				close: () => Effect.void,
 			};
 			registerHevyTools(
 				server,
@@ -505,7 +508,8 @@ describe("registerHevyTools", () => {
 		const catalog: ExerciseTemplateCatalog = {
 			effect: () => Effect.succeed([]),
 			get: () => Promise.resolve([]),
-			reset: () => {},
+			reset: () => Effect.void,
+			close: () => Effect.void,
 		};
 		const buildPair = (name: string) => {
 			const rebuilt = new McpServer({
@@ -576,7 +580,8 @@ describe("registerHevyTools", () => {
 		const catalog: ExerciseTemplateCatalog = {
 			effect: () => Effect.succeed([]),
 			get: () => Promise.resolve([]),
-			reset: () => {},
+			reset: () => Effect.void,
+			close: () => Effect.void,
 		};
 		registerHevyTools(
 			productionServer,

--- a/packages/core/src/tools/templates.test.ts
+++ b/packages/core/src/tools/templates.test.ts
@@ -123,12 +123,14 @@ describe("exercise template tools", () => {
 				Effect.succeed([{ id: "layer-template", title: "Layer Template" }]),
 			),
 			get: vi.fn(),
-			reset: vi.fn(),
+			reset: vi.fn(() => Effect.void),
+			close: vi.fn(() => Effect.void),
 		};
 		const getterCatalog: ExerciseTemplateCatalog = {
 			effect: vi.fn(() => Effect.succeed([])),
 			get: vi.fn().mockRejectedValue(new Error("wrong catalog source")),
-			reset: vi.fn(),
+			reset: vi.fn(() => Effect.void),
+			close: vi.fn(() => Effect.void),
 		};
 		const runtime = createToolRuntime({
 			client: layerClient,
@@ -178,7 +180,8 @@ describe("exercise template tools", () => {
 				Effect.succeed([{ id: "template-1", title: "Bench Press" }]),
 			),
 			get: vi.fn(),
-			reset: vi.fn(),
+			reset: vi.fn(() => Effect.void),
+			close: vi.fn(() => Effect.void),
 		};
 		const runtime = createToolRuntime({
 			client: null,

--- a/packages/core/src/tools/tool-runtime.test.ts
+++ b/packages/core/src/tools/tool-runtime.test.ts
@@ -23,7 +23,8 @@ const runImmediately = <T>(operation: () => Promise<T>): Promise<T> =>
 const catalog = {
 	effect: () => Effect.succeed([]),
 	get: () => Promise.resolve([]),
-	reset: () => undefined,
+	reset: () => Effect.void,
+	close: () => Effect.void,
 };
 
 function resolveRuntimeServices(runtime: ReturnType<typeof createToolRuntime>) {

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -269,46 +269,53 @@ export function createToolRuntime({
 					effect: (options = {}) => catalog.effect({ ...options, execution }),
 					get: (options = {}) => catalog.get({ ...options, execution }),
 					reset: () => catalog.reset(),
+					close: () => catalog.close(),
 				}
 		: Option.isSome(providedCatalog)
 			? providedCatalog.value
 			: catalog;
-	const coreLayer =
-		effectiveClient && resolvedOperations
-			? (createCoreServiceLayer({
-					client: effectiveClient,
-					catalog: effectiveCatalog,
-					execution: execution ?? {},
-					operations: resolvedOperations,
-				}) as ToolRuntimeServiceLayer)
-			: resolvedOperations
-				? (Layer.mergeAll(
-						Layer.succeed(HevyOperationsService, resolvedOperations),
-						Layer.succeed(ExerciseTemplateCatalogService, effectiveCatalog),
-					) as ToolRuntimeServiceLayer)
-				: (Layer.succeed(
-						ExerciseTemplateCatalogService,
-						effectiveCatalog,
-					) as ToolRuntimeServiceLayer);
-	const layer = effectiveObserver
-		? coreLayer
+	// The layer is built lazily: production request flow provides the
+	// services Context directly, so only Scope-based consumers (server
+	// construction, layer tests) pay for construction, and nested
+	// forExecution scopes never rebuild it unless read.
+	let cachedLayer: ToolRuntimeServiceLayer | undefined;
+	const getLayer = (): ToolRuntimeServiceLayer =>
+		(cachedLayer ??= buildLayer());
+	const buildLayer = (): ToolRuntimeServiceLayer => {
+		const coreLayer =
+			effectiveClient && resolvedOperations
+				? (createCoreServiceLayer({
+						client: effectiveClient,
+						catalog: effectiveCatalog,
+						execution: execution ?? {},
+						operations: resolvedOperations,
+					}) as ToolRuntimeServiceLayer)
+				: resolvedOperations
+					? (Layer.mergeAll(
+							Layer.succeed(HevyOperationsService, resolvedOperations),
+							Layer.succeed(ExerciseTemplateCatalogService, effectiveCatalog),
+						) as ToolRuntimeServiceLayer)
+					: (Layer.succeed(
+							ExerciseTemplateCatalogService,
+							effectiveCatalog,
+						) as ToolRuntimeServiceLayer);
+		const layer = effectiveObserver
 			? (Layer.merge(
 					coreLayer,
 					createToolObserverLayer(effectiveObserver),
 				) as ToolRuntimeServiceLayer)
-			: (createToolObserverLayer(effectiveObserver) as ToolRuntimeServiceLayer)
-		: coreLayer;
+			: coreLayer;
+		return layer;
+	};
 	const services =
 		providedServices ??
-		(layer
-			? createCoreServiceContext({
-					client: effectiveClient ?? undefined,
-					catalog: effectiveCatalog,
-					execution,
-					operations: resolvedOperations ?? undefined,
-					observer: effectiveObserver,
-				})
-			: undefined);
+		createCoreServiceContext({
+			client: effectiveClient ?? undefined,
+			catalog: effectiveCatalog,
+			execution,
+			operations: resolvedOperations ?? undefined,
+			observer: effectiveObserver,
+		});
 	const effectHandlerFactory: ToolHandlerFactory =
 		createHandler ??
 		(<TParams extends object>(
@@ -442,7 +449,9 @@ export function createToolRuntime({
 	const runtime: ToolRuntime = {
 		client: effectiveClient,
 		catalog: effectiveCatalog,
-		layer,
+		get layer() {
+			return getLayer();
+		},
 		services,
 		logger,
 		execution,
@@ -499,6 +508,7 @@ export function createToolRuntime({
 							execution: nestedExecution,
 						}),
 					reset: () => nestedBaseCatalog.reset(),
+					close: () => nestedBaseCatalog.close(),
 				};
 				return createToolRuntime({
 					client: nestedBaseClient,

--- a/packages/core/src/tools/tool-runtime.ts
+++ b/packages/core/src/tools/tool-runtime.ts
@@ -279,8 +279,6 @@ export function createToolRuntime({
 	// construction, layer tests) pay for construction, and nested
 	// forExecution scopes never rebuild it unless read.
 	let cachedLayer: ToolRuntimeServiceLayer | undefined;
-	const getLayer = (): ToolRuntimeServiceLayer =>
-		(cachedLayer ??= buildLayer());
 	const buildLayer = (): ToolRuntimeServiceLayer => {
 		const coreLayer =
 			effectiveClient && resolvedOperations
@@ -307,6 +305,8 @@ export function createToolRuntime({
 			: coreLayer;
 		return layer;
 	};
+	const getLayer = (): ToolRuntimeServiceLayer =>
+		(cachedLayer ??= buildLayer());
 	const services =
 		providedServices ??
 		createCoreServiceContext({

--- a/packages/core/src/tools/user.test.ts
+++ b/packages/core/src/tools/user.test.ts
@@ -20,7 +20,8 @@ function registerUserDefinition(
 	const catalog: ExerciseTemplateCatalog = {
 		effect: () => Effect.succeed([]),
 		get: vi.fn(),
-		reset: vi.fn(),
+		reset: vi.fn(() => Effect.void),
+		close: vi.fn(() => Effect.void),
 	};
 	registerToolDefinition(
 		server,

--- a/packages/core/src/utils/exercise-template-catalog.test.ts
+++ b/packages/core/src/utils/exercise-template-catalog.test.ts
@@ -52,7 +52,7 @@ describe("exercise template catalog", () => {
 
 		await expect(catalog.get()).resolves.toMatchObject([{ id: "first" }]);
 		await expect(catalog.get()).resolves.toMatchObject([{ id: "first" }]);
-		catalog.reset();
+		await Effect.runPromise(catalog.reset());
 		await expect(catalog.get()).resolves.toMatchObject([{ id: "second" }]);
 		expect(listAll).toHaveBeenCalledTimes(2);
 	});

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -1,5 +1,6 @@
 import { Cache, Clock, Deferred, Effect, Fiber, Option } from "effect";
 import type { HevyRequestOptions } from "@hevy-mcp/hevy-client";
+import { failOnAbortSignal } from "@hevy-mcp/hevy-client/internal";
 import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
 import type {
 	TemplatesListAllOperation,
@@ -44,8 +45,8 @@ export interface ExerciseTemplateCatalog {
 		options?: ExerciseTemplateCatalogOptions,
 	): Effect.Effect<ExerciseTemplate[], TemplateListAllError>;
 	get(options?: ExerciseTemplateCatalogOptions): Promise<ExerciseTemplate[]>;
-	reset(): void;
-	close?(): void;
+	reset(): Effect.Effect<void>;
+	close(): Effect.Effect<void>;
 }
 
 type CatalogOperations = {
@@ -133,19 +134,11 @@ export function createExerciseTemplateCatalog(
 		},
 	);
 
+	// The shared abort bridge owns listener lifecycle; the channel
+	// instantiation documents that aborts escape through the catalog's
+	// Promise edge rather than its typed Effect channel.
 	const awaitAbort = (signal: AbortSignal) =>
-		Effect.callback<never, TemplateListAllError>((resume) => {
-			const abort = () =>
-				resume(
-					Effect.fail(
-						signal.reason ??
-							new DOMException("Operation canceled", "AbortError"),
-					) as Effect.Effect<never, TemplateListAllError>,
-				);
-			if (signal.aborted) abort();
-			else signal.addEventListener("abort", abort, { once: true });
-			return Effect.sync(() => signal.removeEventListener("abort", abort));
-		});
+		failOnAbortSignal<TemplateListAllError>(signal);
 
 	const effect = Effect.fn("core.exerciseTemplateCatalog.get")(function* (
 		options: ExerciseTemplateCatalogOptions = {},
@@ -205,12 +198,13 @@ export function createExerciseTemplateCatalog(
 							: Effect.never,
 					),
 				),
-				Effect.sync(() => {
+				Effect.suspend(() => {
 					shared.waiters -= 1;
 					if (shared.waiters === 0 && inFlight === shared) {
 						inFlight = undefined;
-						void Effect.runPromise(Fiber.interrupt(shared.fiber));
+						return Effect.asVoid(Fiber.interrupt(shared.fiber));
 					}
+					return Effect.void;
 				}),
 			);
 		});
@@ -247,19 +241,27 @@ export function createExerciseTemplateCatalog(
 	return {
 		effect,
 		get: (options) => Effect.runPromise(effect(options)),
-		reset() {
-			hasLoadedValue = false;
-			generation += 1;
-			if (inFlight) void Effect.runPromise(Fiber.interrupt(inFlight.fiber));
-			inFlight = undefined;
-			Effect.runSync(
-				Cache.invalidate(cache, EXERCISE_TEMPLATE_CATALOG_CACHE_KEY),
-			);
-		},
-		close() {
-			if (inFlight) void Effect.runPromise(Fiber.interrupt(inFlight.fiber));
-			inFlight = undefined;
-		},
+		reset: () =>
+			Effect.suspend(() => {
+				hasLoadedValue = false;
+				generation += 1;
+				const fiber = inFlight?.fiber;
+				inFlight = undefined;
+				return (
+					fiber ? Effect.asVoid(Fiber.interrupt(fiber)) : Effect.void
+				).pipe(
+					Effect.andThen(
+						Cache.invalidate(cache, EXERCISE_TEMPLATE_CATALOG_CACHE_KEY),
+					),
+					Effect.asVoid,
+				);
+			}),
+		close: () =>
+			Effect.suspend(() => {
+				const fiber = inFlight?.fiber;
+				inFlight = undefined;
+				return fiber ? Effect.asVoid(Fiber.interrupt(fiber)) : Effect.void;
+			}),
 	};
 }
 

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -136,16 +136,12 @@ export function createExerciseTemplateCatalog(
 	// Local abort bridge: core must not import the client Effect seam
 	// (@hevy-mcp/hevy-client/internal per repository/topology.json), and the
 	// public entry stays Effect-seam-free (see hevy-client-internal-export
-	// test). Kept textually identical to failOnAbortSignal by convention.
+	// test). Mirrors failOnAbortSignal's branch structure by convention.
 	// The channel instantiation documents that aborts escape through the
 	// catalog's Promise edge rather than its typed Effect channel.
 	const awaitAbort = (signal: AbortSignal) =>
 		Effect.callback<never, TemplateListAllError>(
 			(resume, interruptionSignal) => {
-				const cleanup = () => {
-					signal.removeEventListener("abort", fail);
-					interruptionSignal.removeEventListener("abort", cleanup);
-				};
 				const fail = () =>
 					resume(
 						Effect.fail(
@@ -153,11 +149,15 @@ export function createExerciseTemplateCatalog(
 								new DOMException("Operation canceled", "AbortError"),
 						) as Effect.Effect<never, TemplateListAllError>,
 					);
+				const cleanup = () => {
+					signal.removeEventListener("abort", fail);
+					interruptionSignal.removeEventListener("abort", cleanup);
+				};
 				if (signal.aborted) {
 					fail();
-				} else {
-					signal.addEventListener("abort", fail, { once: true });
+					return;
 				}
+				signal.addEventListener("abort", fail, { once: true });
 				interruptionSignal.addEventListener("abort", cleanup, { once: true });
 				return Effect.sync(cleanup);
 			},

--- a/packages/core/src/utils/exercise-template-catalog.ts
+++ b/packages/core/src/utils/exercise-template-catalog.ts
@@ -1,6 +1,5 @@
 import { Cache, Clock, Deferred, Effect, Fiber, Option } from "effect";
 import type { HevyRequestOptions } from "@hevy-mcp/hevy-client";
-import { failOnAbortSignal } from "@hevy-mcp/hevy-client/internal";
 import type { ExerciseTemplate } from "@hevy-mcp/hevy-client/types";
 import type {
 	TemplatesListAllOperation,
@@ -134,11 +133,35 @@ export function createExerciseTemplateCatalog(
 		},
 	);
 
-	// The shared abort bridge owns listener lifecycle; the channel
-	// instantiation documents that aborts escape through the catalog's
-	// Promise edge rather than its typed Effect channel.
+	// Local abort bridge: core must not import the client Effect seam
+	// (@hevy-mcp/hevy-client/internal per repository/topology.json), and the
+	// public entry stays Effect-seam-free (see hevy-client-internal-export
+	// test). Kept textually identical to failOnAbortSignal by convention.
+	// The channel instantiation documents that aborts escape through the
+	// catalog's Promise edge rather than its typed Effect channel.
 	const awaitAbort = (signal: AbortSignal) =>
-		failOnAbortSignal<TemplateListAllError>(signal);
+		Effect.callback<never, TemplateListAllError>(
+			(resume, interruptionSignal) => {
+				const cleanup = () => {
+					signal.removeEventListener("abort", fail);
+					interruptionSignal.removeEventListener("abort", cleanup);
+				};
+				const fail = () =>
+					resume(
+						Effect.fail(
+							signal.reason ??
+								new DOMException("Operation canceled", "AbortError"),
+						) as Effect.Effect<never, TemplateListAllError>,
+					);
+				if (signal.aborted) {
+					fail();
+				} else {
+					signal.addEventListener("abort", fail, { once: true });
+				}
+				interruptionSignal.addEventListener("abort", cleanup, { once: true });
+				return Effect.sync(cleanup);
+			},
+		).pipe(Effect.interruptible);
 
 	const effect = Effect.fn("core.exerciseTemplateCatalog.get")(function* (
 		options: ExerciseTemplateCatalogOptions = {},

--- a/packages/core/src/utils/response-contracts.ts
+++ b/packages/core/src/utils/response-contracts.ts
@@ -178,6 +178,15 @@ export type PaginatedToolResult<T> = {
 	expected404Outcome?: "not_found" | "end_of_list";
 };
 type PaginatedInput<T> = PaginatedToolResult<T> | readonly T[] | undefined;
+/** Shared pagination footer so every paginated contract computes it once. */
+function toPaginationFields(page: number, pageCount: number | undefined) {
+	return {
+		page,
+		page_count: pageCount,
+		has_next_page: pageCount === undefined ? undefined : page < pageCount,
+	};
+}
+
 function normalizePaginatedInput<T>(
 	data: PaginatedInput<T>,
 ): PaginatedToolResult<T> {
@@ -351,10 +360,7 @@ export const workoutsResponse = defineStructuredResponseContract({
 		const data = normalizePaginatedInput(input);
 		return {
 			workouts: data.items.map(summarizeWorkout),
-			page: data.page,
-			page_count: data.pageCount,
-			has_next_page:
-				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+			...toPaginationFields(data.page, data.pageCount),
 		};
 	},
 	legacyJson: ({ workouts }) => workouts,
@@ -403,10 +409,7 @@ export const workoutEventsResponse = defineStructuredResponseContract({
 		expected404Outcome?: "end_of_list";
 	}) => ({
 		events: data.events?.map(projectWorkoutEvent) ?? [],
-		page: data.page,
-		page_count: data.pageCount,
-		has_next_page:
-			data.pageCount === undefined ? undefined : data.page < data.pageCount,
+		...toPaginationFields(data.page, data.pageCount),
 	}),
 	legacyJson: ({ events }) => events,
 	text: ({ since }, { events }) =>
@@ -425,10 +428,7 @@ export const routinesResponse = defineStructuredResponseContract({
 		const data = normalizePaginatedInput(input);
 		return {
 			routines: data.items.map(summarizeRoutine),
-			page: data.page,
-			page_count: data.pageCount,
-			has_next_page:
-				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+			...toPaginationFields(data.page, data.pageCount),
 		};
 	},
 	legacyJson: ({ routines }) => routines,
@@ -466,10 +466,7 @@ export const exerciseTemplatesResponse = defineStructuredResponseContract({
 		const data = normalizePaginatedInput(input);
 		return {
 			exercise_templates: data.items,
-			page: data.page,
-			page_count: data.pageCount,
-			has_next_page:
-				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+			...toPaginationFields(data.page, data.pageCount),
 		};
 	},
 	legacyJson: ({ exercise_templates }) => exercise_templates,
@@ -549,10 +546,7 @@ export const routineFoldersResponse = defineStructuredResponseContract({
 		const data = normalizePaginatedInput(input);
 		return {
 			routine_folders: data.items.map(projectRoutineFolder),
-			page: data.page,
-			page_count: data.pageCount,
-			has_next_page:
-				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+			...toPaginationFields(data.page, data.pageCount),
 		};
 	},
 	legacyJson: ({ routine_folders }) => routine_folders,
@@ -594,10 +588,7 @@ export const bodyMeasurementsResponse = defineStructuredResponseContract({
 		const data = normalizePaginatedInput(input);
 		return {
 			body_measurements: data.items.map(normalizeBodyMeasurement),
-			page: data.page,
-			page_count: data.pageCount,
-			has_next_page:
-				data.pageCount === undefined ? undefined : data.page < data.pageCount,
+			...toPaginationFields(data.page, data.pageCount),
 		};
 	},
 	legacyJson: ({ body_measurements }) => body_measurements,

--- a/packages/hevy-client/src/abort-signal.ts
+++ b/packages/hevy-client/src/abort-signal.ts
@@ -22,3 +22,45 @@ export function interruptOnAbortSignal(
 		return Effect.sync(cleanup);
 	}).pipe(Effect.interruptible);
 }
+
+/**
+ * Bridge an external AbortSignal into a typed failure carrying the abort
+ * reason (falling back to an AbortError DOMException).
+ *
+ * This is the shared implementation behind retry-backoff waits and catalog
+ * loads: both race their work against abortion and must surface the reason
+ * in the failure channel rather than interrupting the fiber. Callers that
+ * need interruption instead use `interruptOnAbortSignal`.
+ *
+ * The error type defaults to `unknown` because abort reasons are untrusted
+ * caller input. Adapters that promise a narrower channel instantiate `E`
+ * explicitly; the cast is sound because the failure always escapes through
+ * the adapter's own Promise edge, never through the typed Effect channel.
+ */
+export function failOnAbortSignal<E = unknown>(
+	signal: AbortSignal,
+): Effect.Effect<never, E> {
+	const bridge = Effect.callback<never, unknown>(
+		(resume, interruptionSignal) => {
+			const cleanup = () => {
+				signal.removeEventListener("abort", fail);
+				interruptionSignal.removeEventListener("abort", cleanup);
+			};
+			const fail = () =>
+				resume(
+					Effect.fail(
+						signal.reason ??
+							new DOMException("Operation canceled", "AbortError"),
+					),
+				);
+			if (signal.aborted) {
+				fail();
+				return;
+			}
+			signal.addEventListener("abort", fail, { once: true });
+			interruptionSignal.addEventListener("abort", cleanup, { once: true });
+			return Effect.sync(cleanup);
+		},
+	).pipe(Effect.interruptible);
+	return bridge as Effect.Effect<never, E>;
+}

--- a/packages/hevy-client/src/abort-signal.ts
+++ b/packages/hevy-client/src/abort-signal.ts
@@ -42,10 +42,6 @@ export function failOnAbortSignal<E = unknown>(
 ): Effect.Effect<never, E> {
 	const bridge = Effect.callback<never, unknown>(
 		(resume, interruptionSignal) => {
-			const cleanup = () => {
-				signal.removeEventListener("abort", fail);
-				interruptionSignal.removeEventListener("abort", cleanup);
-			};
 			const fail = () =>
 				resume(
 					Effect.fail(
@@ -53,6 +49,10 @@ export function failOnAbortSignal<E = unknown>(
 							new DOMException("Operation canceled", "AbortError"),
 					),
 				);
+			const cleanup = () => {
+				signal.removeEventListener("abort", fail);
+				interruptionSignal.removeEventListener("abort", cleanup);
+			};
 			if (signal.aborted) {
 				fail();
 				return;

--- a/packages/hevy-client/src/backoff.test.ts
+++ b/packages/hevy-client/src/backoff.test.ts
@@ -45,6 +45,30 @@ describe("Effect retry backoff primitives", () => {
 		expect(result._tag).toBe("Failure");
 	});
 
+	it("fails a custom sleep whose deadline passed via the Effect Clock", async () => {
+		const controller = new AbortController();
+		await expect(
+			Effect.runPromise(
+				customPromiseSleep(
+					5,
+					controller.signal,
+					() => Promise.resolve(),
+					Date.now() - 1,
+				),
+			),
+		).rejects.toMatchObject({ _tag: "TimeoutError" });
+		await expect(
+			Effect.runPromise(
+				customPromiseSleep(
+					5,
+					controller.signal,
+					() => Promise.resolve(),
+					Date.now() + 60_000,
+				),
+			),
+		).resolves.toBeUndefined();
+	});
+
 	it("keeps a non-cooperative custom sleep interruptible", async () => {
 		const controller = new AbortController();
 		const fiber = await Effect.runPromise(

--- a/packages/hevy-client/src/backoff.ts
+++ b/packages/hevy-client/src/backoff.ts
@@ -1,4 +1,5 @@
-import { Cause, Data, Duration, Effect } from "effect";
+import { Cause, Clock, Data, Duration, Effect } from "effect";
+import { failOnAbortSignal } from "./abort-signal.js";
 
 import type { HevyOperationSafety } from "./execution.js";
 
@@ -21,30 +22,6 @@ export class BackoffFailure extends Data.TaggedError("BackoffFailure")<{
 	readonly deadline?: number;
 }> {}
 
-function interruptionEffect(
-	signal: AbortSignal,
-): Effect.Effect<never, unknown> {
-	return Effect.callback<never, unknown>((resume, interruptionSignal) => {
-		const cleanup = () => {
-			signal.removeEventListener("abort", fail);
-			interruptionSignal.removeEventListener("abort", cleanup);
-		};
-		const fail = () =>
-			resume(
-				Effect.fail(
-					signal.reason ?? new DOMException("Operation canceled", "AbortError"),
-				),
-			);
-		if (signal.aborted) {
-			fail();
-			return;
-		}
-		signal.addEventListener("abort", fail, { once: true });
-		interruptionSignal.addEventListener("abort", cleanup, { once: true });
-		return Effect.sync(cleanup);
-	}).pipe(Effect.interruptible);
-}
-
 /**
  * Wait using the Effect Clock while still observing the operation signal.
  * This is deliberately separate from the Promise adapter so TestClock can
@@ -60,9 +37,7 @@ export function effectClockSleep(
 		);
 	}
 	const sleep = Effect.sleep(Duration.millis(Math.max(0, delayMs)));
-	return Effect.raceFirst(sleep, interruptionEffect(signal)).pipe(
-		Effect.asVoid,
-	);
+	return Effect.raceFirst(sleep, failOnAbortSignal(signal)).pipe(Effect.asVoid);
 }
 
 /**
@@ -112,12 +87,6 @@ export function customPromiseSleep(
 				try {
 					Promise.resolve(sleep(delayMs, signal)).then(() => {
 						if (settled) return;
-						if (deadline !== undefined && Date.now() >= deadline) {
-							settleReject(
-								new Cause.TimeoutError("Retry backoff deadline exceeded"),
-							);
-							return;
-						}
 						settled = true;
 						cleanup();
 						resolve();
@@ -128,7 +97,19 @@ export function customPromiseSleep(
 			});
 		},
 		catch: (cause) => cause,
-	});
+	}).pipe(
+		Effect.flatMap(() =>
+			deadline === undefined
+				? Effect.void
+				: Effect.flatMap(Clock.currentTimeMillis, (now) =>
+						now >= deadline
+							? Effect.fail(
+									new Cause.TimeoutError("Retry backoff deadline exceeded"),
+								)
+							: Effect.void,
+					),
+		),
+	);
 }
 
 export function retryBackoff(

--- a/packages/hevy-client/src/internal.ts
+++ b/packages/hevy-client/src/internal.ts
@@ -7,4 +7,4 @@ export {
 	type HevyRequestEffectError,
 	type NativeRequestEffect,
 } from "./internal-request-effect.js";
-export { interruptOnAbortSignal } from "./abort-signal.js";
+export { failOnAbortSignal, interruptOnAbortSignal } from "./abort-signal.js";

--- a/packages/hevy-client/src/retry-schedule.ts
+++ b/packages/hevy-client/src/retry-schedule.ts
@@ -35,7 +35,9 @@ export interface RetryScheduleOptions<ScheduleError = never> {
  *
  * The schedule owns retry timing, recurrence, and the input predicate. The
  * client supplies the safety predicate and optional delay adapter for
- * observation or deadline bounding.
+ * observation or deadline bounding. Jitter stays behind the injectable
+ * `randomInt` seam (tests pass `() => 0`); it is deliberately sync so the
+ * pure `getRetryDelayMs` policy needs no Effect context.
  */
 export function createRetrySchedule<ScheduleError = never>(
 	maxRetries: number,
@@ -46,21 +48,16 @@ export function createRetrySchedule<ScheduleError = never>(
 ): Schedule.Schedule<number, RetryScheduleInput, ScheduleError> {
 	return Schedule.recurs(Math.max(0, maxRetries)).pipe(
 		Schedule.while(
-			(metadata: Schedule.Metadata<number, RetryScheduleInput>) =>
-				options.whileInput?.(metadata.input, metadata.attempt) ?? true,
+			({ input, attempt }: Schedule.Metadata<number, RetryScheduleInput>) =>
+				options.whileInput?.(input, attempt) ?? true,
 		),
-		Schedule.addDelay((metadata) =>
-			Effect.gen(function* () {
-				const delayMs = getRetryDelayMs(
-					metadata.input,
-					metadata.attempt,
-					policy,
-					randomInt,
-				);
-				return yield* options.delay
-					? options.delay(metadata.input, metadata.attempt, delayMs)
+		Schedule.addDelay(
+			({ input, attempt }: Schedule.Metadata<number, RetryScheduleInput>) => {
+				const delayMs = getRetryDelayMs(input, attempt, policy, randomInt);
+				return options.delay
+					? options.delay(input, attempt, delayMs)
 					: Effect.succeed(Duration.millis(delayMs));
-			}),
+			},
 		),
 	);
 }

--- a/packages/operations/src/templates.ts
+++ b/packages/operations/src/templates.ts
@@ -75,10 +75,12 @@ type ExerciseHistoryQuery = {
 function exerciseHistoryQuery(
 	input: TemplatesHistoryInput,
 ): ExerciseHistoryQuery {
-	return {
-		start_date: input.startDate,
-		end_date: input.endDate,
-	};
+	if (input.startDate === undefined) {
+		if (input.endDate === undefined) return {};
+		return { end_date: input.endDate };
+	}
+	if (input.endDate === undefined) return { start_date: input.startDate };
+	return { start_date: input.startDate, end_date: input.endDate };
 }
 
 export interface TemplatesHistoryOutput {

--- a/packages/operations/src/templates.ts
+++ b/packages/operations/src/templates.ts
@@ -75,15 +75,6 @@ type ExerciseHistoryQuery = {
 function exerciseHistoryQuery(
 	input: TemplatesHistoryInput,
 ): ExerciseHistoryQuery {
-	if (input.startDate === undefined && input.endDate === undefined) {
-		return {};
-	}
-	if (input.startDate === undefined) {
-		return { end_date: input.endDate };
-	}
-	if (input.endDate === undefined) {
-		return { start_date: input.startDate };
-	}
 	return {
 		start_date: input.startDate,
 		end_date: input.endDate,

--- a/scripts/measure-token-cost.ts
+++ b/scripts/measure-token-cost.ts
@@ -301,7 +301,8 @@ export async function listRegisteredTools(): Promise<Tool[]> {
 			catalog: {
 				effect: () => Effect.succeed([]),
 				get: () => Promise.resolve([]),
-				reset: () => {},
+				reset: () => Effect.void,
+				close: () => Effect.void,
 			} satisfies ExerciseTemplateCatalog,
 		}),
 	);


### PR DESCRIPTION
Entire-Checkpoint: 01M1X5Z5R4DCVARYNXYQXXT8DS

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Summary by Sourcery

Simplify Effect runtime usage across the client, core, operations, and CLI while standardizing cancellation, lifecycle management, error handling, and response pagination.

Bug Fixes:
- Use Effect-clock time for retry backoff deadline handling and preserve abort reasons across promise-based waits.
- Ensure exercise-template catalog shutdown and reset operations are Effect-native and compose server cleanup with cache invalidation.

Enhancements:
- Centralize abort-signal failure bridging, simplify operation error normalization, and enforce the core error vocabulary at compile time.
- Construct tool service layers lazily while supplying request-scoped services directly through runtime context and preserving catalog lifecycle methods across nested runtimes.
- Share pagination metadata generation across response contracts and simplify typed workout summary and exercise-history handling.

Tests:
- Add coverage for Effect-clock retry deadlines and update catalog lifecycle fixtures for Effect-returning cleanup methods.

Chores:
- Add patch changesets for the client, operations, core, server, Worker, and CLI packages.

## Primary changes

- Centralize the AbortSignal-to-Effect failure bridge and use the Effect clock for retry backoff deadline checks while keeping native fetch signal composition at the fetch boundary.
- Make exercise-template catalog reset and close operations Effect-native, propagate lifecycle methods through runtime wrappers, and compose catalog shutdown with cache invalidation.
- Build tool service layers lazily, provide request services directly through the runtime context, and use a compiler-checked core error-tag vocabulary at the operation boundary.
- Share pagination field generation across response contracts and simplify typed workout summary and exercise-history query handling.
- Update the affected test fixtures and add a patch changeset for the client, operations, core, Node server, Worker, and CLI packages.

## Reviewer walkthrough

1. Start with `packages/hevy-client/src/abort-signal.ts`, `backoff.ts`, and `retry-schedule.ts` for cancellation and retry timing.
2. Follow `packages/core/src/utils/exercise-template-catalog.ts` into `packages/core/src/server.ts` to review Effect-native catalog cleanup and cache invalidation.
3. Review `packages/core/src/tools/tool-runtime.ts`, `operation-helpers.ts`, and `define-tool.ts` for lazy layers, catalog propagation, and error normalization boundaries.
4. Finish with `packages/core/src/utils/response-contracts.ts`, `packages/operations/src/templates.ts`, and `packages/cli/src/commands/index.ts` for response projection and typed data handling.
5. Check the updated catalog fixtures and `packages/hevy-client/src/backoff.test.ts` for lifecycle and deadline coverage.

## Correctness and invariants

- Native fetch calls receive the composed request and lifecycle signal; internal Effect waits remain fiber-interruptible, and abort reasons cross the Promise adapter through the failure edge.
- Catalog lifecycle methods return Effects, and server finalization closes the catalog before invalidating the cache; nested runtime catalog wrappers preserve those methods.
- Service layers are constructed only when the runtime layer is read, while request-scoped services are supplied directly through the runtime context.
- All paginated response contracts use the shared page, page-count, and next-page calculation, and the core error-tag allowlist remains compiler-checked against `CoreToolError`.

## Testing and QA

- Added coverage for custom promise sleep with expired and future Effect-clock deadlines.
- Updated catalog lifecycle fixtures and reset coverage to execute Effect-returning methods.
- Review CI results against head commit `017cfdeda3331d71ec61678b8e81e9ef3c6ec62d`; this body does not claim a test result that has not been verified here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent pagination fields across paginated responses.
  - Improved cancellation handling for interrupted requests and retry waits.
  - Catalog refresh and shutdown operations now complete reliably.

- **Bug Fixes**
  - Retry delays now correctly honor expired deadlines.
  - Workout summary volume totals handle missing values safely.
  - Error classification is more reliable for unexpected failure data.

- **Refactor**
  - Simplified runtime services, catalog lifecycle handling, and date-range query processing without changing expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->