### PR TITLE
fix(hevy-client): restore fresh-budget deadline retry for timed-out reads

### DIFF
--- a/.changeset/tidy-pandas-retry.md
+++ b/.changeset/tidy-pandas-retry.md
@@ -1,0 +1,13 @@
+---
+"@hevy-mcp/hevy-client": patch
+"@hevy-mcp/operations": patch
+"@hevy-mcp/core": patch
+"hevy-mcp": patch
+"@hevy-mcp/worker": patch
+"@chrisdoc/hevy-cli": patch
+---
+
+Restore the fresh-budget deadline retry for timed-out reads. The Effect runtime
+migration dropped the extended operation deadline, so a read whose first attempt
+overshot its timeout could starve the retry before dispatch and skip the second
+fetch.

--- a/packages/hevy-client/src/hevy-client-kubb.ts
+++ b/packages/hevy-client/src/hevy-client-kubb.ts
@@ -925,9 +925,14 @@ export function createNativeClient(
 		let currentPhase: HevyRequestPhase = "before-dispatch";
 		const requestEffect = Effect.suspend(() => {
 			const operationStartedAt = Date.now();
-			const deadline =
+			let deadline =
 				normalized.hevyDeadline ??
 				operationStartedAt + operationTimeoutMs * (maxGetRetries + 1);
+			// A timed-out read gets one fresh attempt budget on retry, bounded
+			// by the extended operation deadline. An explicit caller deadline
+			// stays authoritative and is never extended.
+			const operationDeadline =
+				normalized.hevyDeadline ?? deadline + operationTimeoutMs;
 			let retryCount = 0;
 			let freeDeadlineRetryUsed = false;
 			let activeRetryWaitScope: HevyRetryWaitScope | undefined;
@@ -1225,8 +1230,17 @@ export function createNativeClient(
 						normalized.hevyDeadline === undefined &&
 						attempt === 1 &&
 						!freeDeadlineRetryUsed;
-					if (freeRetry) freeDeadlineRetryUsed = true;
-					if (freeRetry) retryCount = attempt;
+					if (freeRetry) {
+						freeDeadlineRetryUsed = true;
+						retryCount = attempt;
+						// Grant the retry a fresh attempt budget so timer
+						// overshoot on the timed-out attempt cannot starve it
+						// before dispatch, bounded by the operation deadline.
+						deadline = Math.min(
+							Date.now() + operationTimeoutMs,
+							operationDeadline,
+						);
+					}
 					return freeRetry;
 				}
 				if (freeDeadlineRetryUsed) return false;


### PR DESCRIPTION
## Summary

Restores the extended operation deadline for the free deadline retry that the Effect runtime migration (#1123) dropped.

## Root cause

- Before #1123, a timed-out read got one fresh attempt budget via `operationDeadline = deadline + timeoutMs`; on retry, `deadline` was extended to `min(now + timeoutMs, operationDeadline)`.
- After #1123, `deadline` is fixed at `start + timeoutMs * (maxGetRetries + 1)` and never extended. When the first attempt overshoots its timeout (timer/event-loop latency under load), the retry starts with `remaining <= 0` and returns before dispatch, so `fetch` is called once instead of twice.
- This made `hevy-client.test.ts > returns the deadline error when the bounded read retry also times out` fail (locally 3/3, PR #1144 Node 24 CI run) while passing on fast runners — a flake affecting every branch containing #1123.

## Fix

- `deadline` is now `let` with an `operationDeadline = deadline + operationTimeoutMs` bound (explicit caller deadlines stay authoritative and are never extended).
- When the free deadline retry is granted in `canRetryScheduledFailure`, `deadline` is extended to `min(Date.now() + operationTimeoutMs, operationDeadline)`, mirroring the pre-#1123 behavior.

## Validation

- Targeted test: 5/5 pass (was 0/3 before the fix).
- Full `packages/hevy-client` suite: 154/154 pass.
- `pnpm run test:unit`: 110 files, 1223 passed.
- `pnpm run check:types`: clean. `oxlint --type-aware`: clean. `oxfmt --check`: clean. `pnpm run check:changeset`: pass.

## Summary by Sourcery

Restore deadline extension for timed-out read retries while preserving explicit caller deadlines.

Bug Fixes:
- Restore a fresh deadline budget for timed-out reads so the bounded retry is dispatched instead of being skipped after timeout overshoot.

Tests:
- Validate the retry fix across the targeted test, full hevy-client suite, unit tests, type checks, linting, formatting, and changeset checks.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Restore fresh deadline budget allocation for timed-out read retries to prevent starvation before retry dispatch.

Main changes:
- Introduced `operationDeadline` variable extending beyond standard deadline for retries bounded by explicit caller deadlines
- Modified `freeRetry` logic to reset `deadline` with fresh `operationTimeoutMs` budget when retry conditions met, bounded by `operationDeadline`
- Changed `deadline` from constant to mutable variable to support dynamic deadline adjustment during retry attempts

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored retry behavior for timed-out reads by allocating a fresh attempt budget before retrying.
  * Prevented the extended operation deadline from being lost during request processing, ensuring eligible second fetch attempts can be dispatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->